### PR TITLE
SAA-33: Correction to cert secret name

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/values.yaml
+++ b/helm_deploy/hmpps-activities-management-api/values.yaml
@@ -14,7 +14,7 @@ generic-service:
     v1_2_enabled: true
     v0_47_enabled: false
     host: app-hostname.local    # override per environment
-    tlsSecretName: hmpps-activities-management-api-cert
+    tlsSecretName: activities-api-cert
 
   # Environment variables to load into the deployment
   env:


### PR DESCRIPTION
Secret name was wrong from the template rename. This corrects it.