### PR TITLE
SAA-60 (WIP) initial changes to support transformation of activity entity into the external API equivalents

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Activity.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+// TODO swagger docs
+data class Activity(
+
+  val id: Long,
+
+  val prisonCode: String,
+
+  val summary: String,
+
+  val description: String,
+
+  val category: ActivityCategory,
+
+  val tier: ActivityTier,
+
+  val eligibilityRules: List<ActivityEligibility> = emptyList(),
+
+  val sessions: List<ActivitySession> = emptyList(),
+
+  val pay: ActivityPay? = null,
+
+  val startDate: LocalDate,
+
+  val endDate: LocalDate? = null,
+
+  val active: Boolean,
+
+  val createdAt: LocalDateTime,
+
+  val createdBy: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityCategory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityCategory.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+// TODO swagger docs
+data class ActivityCategory(
+
+  val id: Long,
+
+  val code: String,
+
+  val description: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityEligibility.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityEligibility.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+// TODO swagger docs
+data class ActivityEligibility(
+
+  val id: Long,
+
+  val eligibility: EligibilityRule
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityInstance.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+// TODO swagger docs
+data class ActivityInstance(
+
+  val id: Long,
+
+  val sessionDate: LocalDate,
+
+  val startTime: LocalDateTime,
+
+  val endTime: LocalDateTime,
+
+  val internalLocationId: Int? = null,
+
+  val cancelled: Boolean,
+
+  val cancelledAt: LocalDateTime? = null,
+
+  val cancelledBy: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityPay.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityPay.kt
@@ -1,0 +1,19 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+// TODO swagger docs
+data class ActivityPay(
+
+  val id: Long,
+
+  val bands: List<ActivityPayBand> = emptyList(),
+
+  val iepBasicRate: Int? = null,
+
+  val iepStandardRate: Int? = null,
+
+  val iepEnhancedRate: Int? = null,
+
+  val pieceRate: Int? = null,
+
+  val pieceRateItems: Int? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityPayBand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityPayBand.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+// TODO swagger docs
+data class ActivityPayBand(
+
+  val id: Long,
+
+  val payBand: String? = null,
+
+  val rate: Int? = null,
+
+  val pieceRate: Int? = null,
+
+  val pieceRateItems: Int? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityPrisoner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityPrisoner.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+// TODO swagger docs
+data class ActivityPrisoner(
+
+  val id: Long,
+
+  val prisonerNumber: String,
+
+  val iepLevel: String? = null,
+
+  val payBand: String? = null,
+
+  val startDate: LocalDate? = null,
+
+  val endDate: LocalDate? = null,
+
+  val active: Boolean = false,
+
+  val allocationAt: LocalDateTime? = null,
+
+  val allocatedBy: String? = null,
+
+  val deallocatedAt: LocalDateTime? = null,
+
+  val deallocatedBy: String? = null,
+
+  val deallocationReason: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivitySession.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivitySession.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+// TODO swagger docs
+data class ActivitySession(
+
+  val id: Long,
+
+  val instances: List<ActivityInstance> = emptyList(),
+
+  val prisoners: List<ActivityPrisoner> = emptyList(),
+
+  val description: String,
+
+  val suspendUntil: LocalDate? = null,
+
+  val startTime: LocalDateTime,
+
+  val endTime: LocalDateTime,
+
+  val internalLocationId: Int? = null,
+
+  val internalLocationCode: String? = null,
+
+  val internalLocationDescription: String? = null,
+
+  val capacity: Int,
+
+  val daysOfWeek: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityTier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityTier.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+// TODO swagger docs
+data class ActivityTier(
+
+  val tier: Long,
+
+  val description: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/EligibilityRule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/EligibilityRule.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+// TODO swagger docs
+data class EligibilityRule(
+
+  val id: Long,
+
+  val code: String,
+
+  val description: String
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/TransformFunctions.kt
@@ -1,0 +1,119 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity as EntityActivity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityCategory as EntityActivityCategory
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityEligibility as EntityActivityEligibility
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityInstance as EntityActivityInstance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityPay as EntityActivityPay
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityPayBand as EntityActivityPayBand
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityPrisoner as EntityActivityPrisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySession as EntityActivitySession
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityTier as EntityActivityTier
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity as ModelActivity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityCategory as ModelActivityCategory
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityEligibility as ModelActivityEligibility
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityInstance as ModelActivityInstance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPay as ModelActivityPay
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPayBand as ModelActivityPayBand
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPrisoner as ModelActivityPrisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivitySession as ModelActivitySession
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityTier as ModelActivityTier
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.EligibilityRule as ModelEligibilityRule
+
+/**
+ * Transform functions providing a thin layer to transform entities into their API equivalents and vice-versa.
+ */
+fun transform(activity: EntityActivity) =
+  ModelActivity(
+    id = activity.activityId!!,
+    prisonCode = activity.prisonCode,
+    category = activity.activityCategory.toModelActivityCategory(),
+    tier = activity.activityTier.toModelActivityTier(),
+    eligibilityRules = activity.eligibilityRules.toModelEligibilityRules(),
+    sessions = activity.sessions.toModelSessions(),
+    pay = activity.activityPay?.toModelActivityPay(),
+    summary = activity.summary,
+    description = activity.description,
+    startDate = activity.startDate,
+    endDate = activity.endDate,
+    active = activity.active,
+    createdAt = activity.createdAt,
+    createdBy = activity.createdBy
+  )
+
+private fun EntityActivityCategory.toModelActivityCategory() = let {
+  ModelActivityCategory(
+    it.activityCategoryId!!,
+    it.categoryCode,
+    it.description
+  )
+}
+
+private fun EntityActivityTier.toModelActivityTier() = let { ModelActivityTier(it.activityTier, it.description) }
+
+private fun List<EntityActivityEligibility>.toModelEligibilityRules() = map {
+  ModelActivityEligibility(
+    it.activityEligibilityId!!,
+    it.eligibilityRule.let { er -> ModelEligibilityRule(er.eligibilityRuleId!!, er.code, er.description) }
+  )
+}
+
+private fun List<EntityActivityPayBand>.toModelPayBands() = map {
+  ModelActivityPayBand(
+    id = it.activityPayBandId!!,
+    payBand = it.payBand,
+    rate = it.rate,
+    pieceRate = it.pieceRate,
+    pieceRateItems = it.pieceRateItems
+  )
+}
+
+private fun List<EntityActivitySession>.toModelSessions() = map {
+  ModelActivitySession(
+    id = it.activitySessionId!!,
+    instances = it.instances.toModelActivityInstances(),
+    prisoners = it.prisoners.toModelActivityPrisoners(),
+    description = it.description,
+    suspendUntil = it.suspendUntil,
+    startTime = it.startTime,
+    endTime = it.endTime,
+    internalLocationId = it.internalLocationId,
+    internalLocationCode = it.internalLocationCode,
+    internalLocationDescription = it.internalLocationDescription,
+    capacity = it.capacity,
+    daysOfWeek = it.daysOfWeek
+  )
+}
+
+private fun List<EntityActivityInstance>.toModelActivityInstances() = map {
+  ModelActivityInstance(
+    id = it.activityInstanceId!!,
+    sessionDate = it.sessionDate,
+    startTime = it.startTime,
+    endTime = it.endTime,
+    internalLocationId = it.internalLocationId,
+    cancelled = it.cancelled,
+    cancelledAt = it.cancelledAt,
+    cancelledBy = it.cancelledBy
+  )
+}
+
+private fun List<EntityActivityPrisoner>.toModelActivityPrisoners() = map {
+  ModelActivityPrisoner(
+    id = it.activityPrisonerId!!,
+    prisonerNumber = it.prisonerNumber,
+    iepLevel = it.iepLevel,
+    payBand = it.payBand,
+    startDate = it.startDate,
+    endDate = it.endDate,
+    active = it.active,
+    allocationAt = it.allocationAt,
+    allocatedBy = it.allocatedBy
+  )
+}
+
+private fun EntityActivityPay.toModelActivityPay() =
+  ModelActivityPay(
+    id = this.activityPayId!!,
+    bands = this.payBands.toModelPayBands()
+  )


### PR DESCRIPTION
This is the initial work in progress commit to begin process of transforming a persisted activity into it's external API equivalent.

The model objects as they stand lack Swagger documentation.  This will be added in due course.