### PR TITLE
SAA-66 Snake yaml security patch.

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -10,6 +10,7 @@
 # Suppression for snakeyaml 1.30 vulnerability as bundled with application insights so can't be upgraded easily
 #   Can be suppressed as we we don't parse untrusted yaml
 CVE-2022-25857
-# Suppression for snakeyaml 1.31 vulnerability as no current upgrade path available
+CVE-2022-38751
+# Suppression for snakeyaml 1.31 vulnerability as not fixed yet
 #   Can be suppressed as we we don't parse untrusted yaml
 CVE-2022-38752

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.1"
   kotlin("plugin.spring") version "1.7.10"
   kotlin("plugin.jpa") version "1.7.10"
 }
@@ -23,7 +23,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-oauth2-resource-server")
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.1.9")
+  implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:1.1.10")
 
   // Database dependencies
   runtimeOnly("org.flywaydb:flyway-core")


### PR DESCRIPTION
The patch is needed again due to OWASP job picking this up.  Taking the next version of the dps gradle boot plugin should resolve this,