### PR TITLE
SAA-71 send pipeline alerts to our own dedicated team alerts channel.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,10 +6,10 @@ orbs:
 parameters:
   alerts-slack-channel:
     type: string
-    default: dps_alerts_security
+    default: farsight-alerts
   releases-slack-channel:
     type: string
-    default: dps-releases
+    default: farsight-alerts
 
 jobs:
   validate:


### PR DESCRIPTION
Small change the Circle CI configuration to send alerts to the teams dedicated alerts channel.