### PR TITLE
SAA-70 add code coverage and ci build status badges to the project repo readme.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+[![codecov](https://codecov.io/github/ministryofjustice/hmpps-activities-management-api/branch/main/graph/badge.svg?token=DYVHRRP1B1)](https://codecov.io/github/ministryofjustice/hmpps-activities-management-api)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/ministryofjustice/hmpps-activities-management-api/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/ministryofjustice/hmpps-activities-management-api/tree/main)
+
 # hmpps-activities-management-api
 
 This services provide access to the endpoints for the management of prisoner related activities. The main client is the


### PR DESCRIPTION
Adding badges for code coverage and build status to the repo readme