### PR TITLE
SAA-126 Security update - API

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -20,3 +20,6 @@ CVE-2022-42003
 # Suppression for jackson databind 2.13.3 as bundled with application insights
 #   Can be suppressed as don't parse untrusted json in application insights
 CVE-2022-42004
+# Suppression for apache common-text 1.9 as bundled with application insights
+#   can be suppressed for the time being as it will be fixed in next version of application insights
+CVE-2022-42889

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.4"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.5.5"
   kotlin("plugin.spring") version "1.7.10"
   kotlin("plugin.jpa") version "1.7.10"
   jacoco


### PR DESCRIPTION
Update dps-gradle-spring-boot version to 4.5.5 which gives us a trivyignore on the commons-text vulnerability as it cant be updated because its bundled with application insights

See - https://github.com/ministryofjustice/dps-gradle-spring-boot/blob/b0a2008a0606a657ca5774fc3b913503fd009056/release-notes/4.5.5.md