### PR TITLE
SAA-129 adding unique constraint to attendances. A prisoner can only have one record per scheduled instance.

### DIFF
--- a/src/main/resources/migration/common/V1__baseline.sql
+++ b/src/main/resources/migration/common/V1__baseline.sql
@@ -168,6 +168,7 @@ CREATE TABLE attendance (
 CREATE INDEX idx_attendance_scheduled_instance_id ON attendance (scheduled_instance_id);
 CREATE INDEX idx_attendance_prisoner_number ON attendance (prisoner_number);
 CREATE INDEX idx_attendance_recorded_time ON attendance (recorded_time);
+CREATE UNIQUE INDEX idx_attendance_scheduled_instance_id_prison_number ON attendance (scheduled_instance_id, prisoner_number);
 
 CREATE TABLE prisoner_waiting (
   prisoner_waiting_id bigserial    NOT NULL CONSTRAINT prisoner_waiting_pk PRIMARY KEY,

--- a/src/main/resources/migration/data/R__2_5__maths_level_1_activity_pay.sql
+++ b/src/main/resources/migration/data/R__2_5__maths_level_1_activity_pay.sql
@@ -1,0 +1,2 @@
+insert into activity_pay(activity_pay_id, activity_id, iep_basic_rate, iep_standard_rate, iep_enhanced_rate, piece_rate, piece_rate_items)
+values (1, 1, 100, 125, 150, 150, 10);


### PR DESCRIPTION
Contains breaking change to the DB in the base line script.  Do no merge!