### PR TITLE
SAA-156 Add validation to API Endpoint: (prisoner scheduled instances)

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/ControllerAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/ControllerAdvice.kt
@@ -3,7 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatus.*
+import org.springframework.http.HttpStatus.BAD_REQUEST
+import org.springframework.http.HttpStatus.FORBIDDEN
+import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+import org.springframework.http.HttpStatus.NOT_FOUND
 import org.springframework.http.ResponseEntity
 import org.springframework.lang.Nullable
 import org.springframework.security.access.AccessDeniedException
@@ -17,7 +20,7 @@ import javax.persistence.EntityNotFoundException
 import javax.validation.ValidationException
 
 @RestControllerAdvice
-class ControllerAdvice: ResponseEntityExceptionHandler() {
+class ControllerAdvice : ResponseEntityExceptionHandler() {
   @ExceptionHandler(AccessDeniedException::class)
   fun handleAccessDeniedException(e: Exception): ResponseEntity<ErrorResponse> {
     log.info("Access denied exception: {}", e.message)
@@ -100,11 +103,14 @@ class ControllerAdvice: ResponseEntityExceptionHandler() {
     } else {
       if (body == null) {
         return ResponseEntity(
-        ErrorResponse(
-          status = status,
-          userMessage = ex.message,
-          developerMessage = ex.message
-        ), headers, status)
+          ErrorResponse(
+            status = status,
+            userMessage = ex.message,
+            developerMessage = ex.message
+          ),
+          headers,
+          status
+        )
       }
     }
     return ResponseEntity(body, headers, status)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/ControllerAdvice.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/ControllerAdvice.kt
@@ -1,19 +1,23 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config
 
 import org.slf4j.LoggerFactory
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
-import org.springframework.http.HttpStatus.BAD_REQUEST
-import org.springframework.http.HttpStatus.FORBIDDEN
-import org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR
+import org.springframework.http.HttpStatus.*
 import org.springframework.http.ResponseEntity
+import org.springframework.lang.Nullable
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+import org.springframework.web.util.WebUtils
 import javax.persistence.EntityNotFoundException
 import javax.validation.ValidationException
 
 @RestControllerAdvice
-class ControllerAdvice {
+class ControllerAdvice: ResponseEntityExceptionHandler() {
   @ExceptionHandler(AccessDeniedException::class)
   fun handleAccessDeniedException(e: Exception): ResponseEntity<ErrorResponse> {
     log.info("Access denied exception: {}", e.message)
@@ -60,14 +64,50 @@ class ControllerAdvice {
   fun handleEntityNotFoundException(e: EntityNotFoundException): ResponseEntity<ErrorResponse> {
     log.info("Entity not found exception: {}", e.message)
     return ResponseEntity
-      .status(HttpStatus.NOT_FOUND)
+      .status(NOT_FOUND)
       .body(
         ErrorResponse(
-          status = HttpStatus.NOT_FOUND.value(),
+          status = NOT_FOUND.value(),
           userMessage = "Not found: ${e.message}",
           developerMessage = e.message
         )
       )
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException::class)
+  fun handleMethodArgumentTypeMismatchException(e: MethodArgumentTypeMismatchException): ResponseEntity<ErrorResponse> {
+    log.info("Method argument type mismatch exception: {}", e.message)
+    return ResponseEntity
+      .status(BAD_REQUEST)
+      .body(
+        ErrorResponse(
+          status = BAD_REQUEST.value(),
+          userMessage = "Error converting '${e.name}' (${e.value}): ${e.message.orEmpty().substringBefore("; nested exception is")}",
+          developerMessage = e.message
+        )
+      )
+  }
+
+  override fun handleExceptionInternal(
+    ex: java.lang.Exception,
+    @Nullable body: Any?,
+    headers: HttpHeaders,
+    status: HttpStatus,
+    request: WebRequest
+  ): ResponseEntity<Any> {
+    if (INTERNAL_SERVER_ERROR == status) {
+      request.setAttribute(WebUtils.ERROR_EXCEPTION_ATTRIBUTE, ex, WebRequest.SCOPE_REQUEST)
+    } else {
+      if (body == null) {
+        return ResponseEntity(
+        ErrorResponse(
+          status = status,
+          userMessage = ex.message,
+          developerMessage = ex.message
+        ), headers, status)
+      }
+    }
+    return ResponseEntity(body, headers, status)
   }
 
   companion object {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceControllerTest.kt
@@ -76,6 +76,120 @@ class ActivityScheduleInstanceControllerTest(
     )
   }
 
+  @Test
+  fun `400 response when end date missing`() {
+    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+      param("startDate", "2022-10-01")
+    }
+      .andDo { print() }
+      .andExpect {
+        status {
+          is4xxClientError()
+        }
+        content {
+          contentType(MediaType.APPLICATION_JSON)
+          jsonPath("$.userMessage") {
+            value("Required request parameter 'endDate' for method parameter type LocalDate is not present")
+          }
+        }
+      }
+  }
+
+  @Test
+  fun `400 response when start date missing`() {
+    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+      param("endDate", "2022-10-01")
+    }
+      .andDo { print() }
+      .andExpect {
+        status {
+          is4xxClientError()
+        }
+        content {
+          contentType(MediaType.APPLICATION_JSON)
+          jsonPath("$.userMessage") {
+            value("Required request parameter 'startDate' for method parameter type LocalDate is not present")
+          }
+        }
+      }
+  }
+
+  @Test
+  fun `400 response when start date incorrect format`() {
+    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+      param("startDate", "01/10/2022")
+    }
+      .andDo { print() }
+      .andExpect {
+        status {
+          is4xxClientError()
+        }
+        content {
+          contentType(MediaType.APPLICATION_JSON)
+          jsonPath("$.userMessage") {
+            value("Error converting 'startDate' (01/10/2022): Failed to convert value of type 'java.lang.String' to required type 'java.time.LocalDate'")
+          }
+        }
+      }
+  }
+
+  @Test
+  fun `400 response when end date incorrect format`() {
+    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+      param("startDate", "2022-10-01")
+      param("endDate", "01/10/2022")
+    }
+      .andDo { print() }
+      .andExpect {
+        status {
+          is4xxClientError()
+        }
+        content {
+          contentType(MediaType.APPLICATION_JSON)
+          jsonPath("$.userMessage") {
+            value("Error converting 'endDate' (01/10/2022): Failed to convert value of type 'java.lang.String' to required type 'java.time.LocalDate'")
+          }
+        }
+      }
+  }
+
+  @Test
+  fun `400 response when date range exceeds 3 moths`() {
+    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+      param("startDate", "2022-11-01")
+      param("endDate", "2023-02-02")
+    }
+      .andDo { print() }
+      .andExpect {
+        status {
+          is4xxClientError()
+        }
+        content {
+          contentType(MediaType.APPLICATION_JSON)
+          jsonPath("$.userMessage") {
+            value("Validation failure: Date range cannot exceed 3 months")
+          }
+        }
+      }
+  }
+
+  @Test
+  fun `200 response when date range equals 3 moths`() {
+    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+      param("startDate", "2022-11-01")
+      param("endDate", "2023-02-01")
+    }
+      .andDo { print() }
+      .andExpect {
+        status {
+          isOk()
+        }
+        content {
+          contentType(MediaType.APPLICATION_JSON)
+        }
+      }
+  }
+
   private fun MockMvc.getPrisonerScheduledInstances(
     prisonCode: String,
     prisonerNumber: String,


### PR DESCRIPTION
Validate the following

- Incorrect date formats - example error - Error converting 'endDate' (01/10/2022): Failed to convert value of type 'java.lang.String' to required type 'java.time.LocalDate'
- Exceeding 3 month date range limit - Validation failure: Date range cannot exceed 3 months
- Missing start date param - Required request parameter 'startDate' for method parameter type LocalDate is not present
- Missing end date param - Required request parameter 'endDate' for method parameter type LocalDate is not present

Changes

- Make controller advice extend ResponseEntityExceptionHandler and override handlerExceptionInternal
- New controller advice function - handleMethodArgumentTypeMismatchException
- Validate date range
