### PR TITLE
SAA-157 API Endpoint: activity schedule instances

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
@@ -20,4 +20,17 @@ interface ScheduledInstanceRepository : JpaRepository<ScheduledInstance, Long> {
     startDate: LocalDate,
     endDate: LocalDate
   ): List<ScheduledInstance>
+
+  @Query(
+    "SELECT si FROM ScheduledInstance si WHERE EXISTS(" +
+      "SELECT 1 FROM si.activitySchedule.allocations a " +
+      "WHERE a.activitySchedule.activity.prisonCode = :prisonCode) " +
+      "AND si.sessionDate >= :startDate " +
+      "AND si.sessionDate <= :endDate "
+  )
+  fun getActivityScheduleInstancesByPrisonCodeAndDateRange(
+    prisonCode: String,
+    startDate: LocalDate,
+    endDate: LocalDate
+  ): List<ScheduledInstance>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceController.kt
@@ -23,14 +23,14 @@ import java.time.LocalDate
 import javax.validation.ValidationException
 
 @RestController
-@RequestMapping("/prisons/{prisonCode}/prisoners/{prisonerNumber}/scheduled-instances", produces = [MediaType.APPLICATION_JSON_VALUE])
+@RequestMapping("/prisons/{prisonCode}/scheduled-instances", produces = [MediaType.APPLICATION_JSON_VALUE])
 class ActivityScheduleInstanceController(private val scheduledInstanceService: ScheduledInstanceService) {
 
   @GetMapping()
   @ResponseBody
   @Operation(
-    summary = "Get a list of scheduled instances for a prison/prisoner and date range (max 3 months)",
-    description = "Returns zero or more scheduled instances for a prison/prisoner and date range (max 3 months).",
+    summary = "Get a list of scheduled instances for a prison, prisoner (optional) and date range (max 3 months)",
+    description = "Returns zero or more scheduled instances for a prison, prisoner (optional) and date range (max 3 months).",
   )
   @ApiResponses(
     value = [
@@ -56,9 +56,9 @@ class ActivityScheduleInstanceController(private val scheduledInstanceService: S
       )
     ]
   )
-  fun getActivityScheduleInstancesByPrisonerNumberAndDateRange(
+  fun getActivityScheduleInstancesByDateRange(
     @PathVariable("prisonCode") prisonCode: String,
-    @PathVariable("prisonerNumber") prisonerNumber: String,
+    @RequestParam(value = "prisonerNumber") @Parameter(description = "Prisoner number (optional)") prisonerNumber: String?,
     @RequestParam(value = "startDate", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "Start date of query") startDate: LocalDate,
     @RequestParam(value = "endDate", required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) @Parameter(description = "End date of query (max 3 months from start date)") endDate: LocalDate,
   ): List<ActivityScheduleInstance> {
@@ -66,6 +66,6 @@ class ActivityScheduleInstanceController(private val scheduledInstanceService: S
     if (endDate.isAfter(startDate.plusMonths(3))) {
       throw ValidationException("Date range cannot exceed 3 months")
     }
-    return scheduledInstanceService.getActivityScheduleInstancesByPrisonerNumberAndDateRange(prisonCode, prisonerNumber, dateRange)
+    return scheduledInstanceService.getActivityScheduleInstancesByDateRange(prisonCode, prisonerNumber, dateRange)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
@@ -12,13 +12,15 @@ class ScheduledInstanceService(private val repository: ScheduledInstanceReposito
     prisonerNumber: String?,
     dateRange: LocalDateRange
   ) = transformActivityScheduleInstances(
-    if (prisonerNumber == null) repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(
+    prisonerNumber?.let {
+      repository.getActivityScheduleInstancesByPrisonerNumberAndDateRange(
+        prisonCode,
+        prisonerNumber,
+        dateRange.start,
+        dateRange.endInclusive
+      )
+    } ?: repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(
       prisonCode,
-      dateRange.start,
-      dateRange.endInclusive
-    ) else repository.getActivityScheduleInstancesByPrisonerNumberAndDateRange(
-      prisonCode,
-      prisonerNumber,
       dateRange.start,
       dateRange.endInclusive
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
@@ -7,17 +7,20 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Sche
 @Service
 class ScheduledInstanceService(private val repository: ScheduledInstanceRepository) {
 
-  fun getActivityScheduleInstancesByPrisonerNumberAndDateRange(
+  fun getActivityScheduleInstancesByDateRange(
     prisonCode: String,
-    prisonerNumber: String,
+    prisonerNumber: String?,
     dateRange: LocalDateRange
-  ) =
-    transformActivityScheduleInstances(
-      repository.getActivityScheduleInstancesByPrisonerNumberAndDateRange(
-        prisonCode,
-        prisonerNumber,
-        dateRange.start,
-        dateRange.endInclusive
-      )
+  ) = transformActivityScheduleInstances(
+    if (prisonerNumber == null) repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(
+      prisonCode,
+      dateRange.start,
+      dateRange.endInclusive
+    ) else repository.getActivityScheduleInstancesByPrisonerNumberAndDateRange(
+      prisonCode,
+      prisonerNumber,
+      dateRange.start,
+      dateRange.endInclusive
     )
+  )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceControllerTest.kt
@@ -53,7 +53,7 @@ class ActivityScheduleInstanceControllerTest(
     val results = transformActivityScheduleInstances(listOf(ScheduledInstanceFixture.instance(id = 1, locationId = 22)))
 
     whenever(
-      scheduledInstanceService.getActivityScheduleInstancesByPrisonerNumberAndDateRange(
+      scheduledInstanceService.getActivityScheduleInstancesByDateRange(
         "MDI", "A11111A",
         LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
       )
@@ -70,7 +70,7 @@ class ActivityScheduleInstanceControllerTest(
 
     assertThat(response.contentAsString).isEqualTo(mapper.writeValueAsString(results))
 
-    verify(scheduledInstanceService).getActivityScheduleInstancesByPrisonerNumberAndDateRange(
+    verify(scheduledInstanceService).getActivityScheduleInstancesByDateRange(
       "MDI", "A11111A",
       LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
     )
@@ -78,7 +78,8 @@ class ActivityScheduleInstanceControllerTest(
 
   @Test
   fun `400 response when end date missing`() {
-    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+    mockMvc.get("/prisons/MDI/scheduled-instances") {
+      param("prisonerNumber", "A11111A")
       param("startDate", "2022-10-01")
     }
       .andDo { print() }
@@ -97,7 +98,8 @@ class ActivityScheduleInstanceControllerTest(
 
   @Test
   fun `400 response when start date missing`() {
-    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+    mockMvc.get("/prisons/MDI/scheduled-instances") {
+      param("prisonerNumber", "A11111A")
       param("endDate", "2022-10-01")
     }
       .andDo { print() }
@@ -116,7 +118,8 @@ class ActivityScheduleInstanceControllerTest(
 
   @Test
   fun `400 response when start date incorrect format`() {
-    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+    mockMvc.get("/prisons/MDI/scheduled-instances") {
+      param("prisonerNumber", "A11111A")
       param("startDate", "01/10/2022")
     }
       .andDo { print() }
@@ -135,7 +138,8 @@ class ActivityScheduleInstanceControllerTest(
 
   @Test
   fun `400 response when end date incorrect format`() {
-    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+    mockMvc.get("/prisons/MDI/scheduled-instances") {
+      param("prisonerNumber", "A11111A")
       param("startDate", "2022-10-01")
       param("endDate", "01/10/2022")
     }
@@ -155,7 +159,8 @@ class ActivityScheduleInstanceControllerTest(
 
   @Test
   fun `400 response when date range exceeds 3 moths`() {
-    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+    mockMvc.get("/prisons/MDI/scheduled-instances") {
+      param("prisonerNumber", "A11111A")
       param("startDate", "2022-11-01")
       param("endDate", "2023-02-02")
     }
@@ -175,7 +180,8 @@ class ActivityScheduleInstanceControllerTest(
 
   @Test
   fun `200 response when date range equals 3 moths`() {
-    mockMvc.get("/prisons/MDI/prisoners/A11111A/scheduled-instances") {
+    mockMvc.get("/prisons/MDI/scheduled-instances") {
+      param("prisonerNumber", "A11111A")
       param("startDate", "2022-11-01")
       param("endDate", "2023-02-01")
     }
@@ -196,5 +202,5 @@ class ActivityScheduleInstanceControllerTest(
     startDate: LocalDate,
     endDate: LocalDate
   ) =
-    get("/prisons/$prisonCode/prisoners/$prisonerNumber/scheduled-instances?startDate=$startDate&endDate=$endDate")
+    get("/prisons/$prisonCode/scheduled-instances?prisonerNumber=$prisonerNumber&startDate=$startDate&endDate=$endDate")
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
@@ -22,7 +22,7 @@ class ScheduledInstanceServiceTest {
     ).thenReturn(listOf(ScheduledInstanceFixture.instance(id = 1, locationId = 22)))
 
     assertThat(
-      service.getActivityScheduleInstancesByPrisonerNumberAndDateRange(
+      service.getActivityScheduleInstancesByDateRange(
         "MDI", "A11111A",
         LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
       )


### PR DESCRIPTION
Refinement of api for activity schedule instances - prisoner number becomes optional request param
this allows us to select all the activity scheduled instances for a prison or a prisoner