### PR TITLE
SAA-176 adding cronjob for creation of attendance records.

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/templates/create-attedance-records-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/create-attedance-records-cronjob.yaml
@@ -1,9 +1,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: create-activity-sessions
+  name: create-attendance-records
 spec:
-  schedule: "0 3 * * *" # 3am every day
+  schedule: "0 4 * * *" # 4am every day
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 43200
@@ -20,4 +20,4 @@ spec:
             args:
               - /bin/sh
               - -c
-              - curl -X POST http://hmpps-activities-management-api/job/create-activity-sessions
+              - curl -X POST http://hmpps-activities-management-api/job/create-attendance-records


### PR DESCRIPTION
Addition of k8's cronjob for the create daily attendance records.  I have applied this locally to dev and test it.

I have run it several times to ensure it works if is run more than once.

![image](https://user-images.githubusercontent.com/60104344/201071498-bd7a642c-3b44-47ea-a33e-add8f1745980.png)
