### PR TITLE
SAA-160 API endpoint to get scheduled events (combined) BUGFIX

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -32,8 +32,8 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path("/api/bookings/{bookingId}/activities")
-          .queryParam("startDate", dateRange.start)
-          .queryParam("endDate", dateRange.endInclusive)
+          .queryParam("fromDate", dateRange.start)
+          .queryParam("toDate", dateRange.endInclusive)
           .build(bookingId)
       }
       .retrieve()
@@ -44,8 +44,8 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path("/api/bookings/{bookingId}/appointments")
-          .queryParam("startDate", dateRange.start)
-          .queryParam("endDate", dateRange.endInclusive)
+          .queryParam("fromDate", dateRange.start)
+          .queryParam("toDate", dateRange.endInclusive)
           .build(bookingId)
       }
       .retrieve()
@@ -57,8 +57,8 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path("/api/bookings/{bookingId}/court-hearings")
-          .queryParam("startDate", dateRange.start)
-          .queryParam("endDate", dateRange.endInclusive)
+          .queryParam("fromDate", dateRange.start)
+          .queryParam("toDate", dateRange.endInclusive)
           .build(bookingId)
       }
       .retrieve()
@@ -70,8 +70,8 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path("/api/bookings/{bookingId}/visits")
-          .queryParam("startDate", dateRange.start)
-          .queryParam("endDate", dateRange.endInclusive)
+          .queryParam("fromDate", dateRange.start)
+          .queryParam("toDate", dateRange.endInclusive)
           .build(bookingId)
       }
       .retrieve()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/Alert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/Alert.kt
@@ -32,7 +32,7 @@ data class Alert(
   @JsonProperty("bookingId") val bookingId: Long,
 
   @Schema(example = "G3878UK", description = "Offender Unique Reference")
-  @JsonProperty("offenderNo") val offenderNo: String,
+  @JsonProperty("offenderNo") val offenderNo: String?,
 
   @Schema(example = "X", description = "Alert Type")
   @JsonProperty("alertType") val alertType: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/Assessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/Assessment.kt
@@ -29,7 +29,7 @@ data class Assessment(
   @JsonProperty("bookingId") val bookingId: Long,
 
   @Schema(example = "GV09876N", description = "Offender number (e.g. NOMS Number).")
-  @JsonProperty("offenderNo") val offenderNo: String,
+  @JsonProperty("offenderNo") val offenderNo: String?,
 
   @Schema(example = "C", description = "Classification code")
   @JsonProperty("classificationCode") val classificationCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
@@ -18,7 +18,6 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonerScheduledEvents
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ScheduledEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ScheduledEventService
 import java.time.LocalDate
 import javax.validation.ValidationException
@@ -41,7 +40,7 @@ class ScheduledEventController(private val scheduledEventService: ScheduledEvent
         content = [
           Content(
             mediaType = "application/json",
-            array = ArraySchema(schema = Schema(implementation = ScheduledEvent::class))
+            array = ArraySchema(schema = Schema(implementation = PrisonerScheduledEvents::class))
           )
         ],
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
@@ -4,10 +4,10 @@ import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonerScheduledEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transformActivityScheduledInstancesToScheduledEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transformToPrisonerScheduledEvents
+import javax.persistence.EntityNotFoundException
 
 @Service
 class ScheduledEventService(
@@ -20,34 +20,33 @@ class ScheduledEventService(
     prisonCode: String,
     prisonerNumber: String,
     dateRange: LocalDateRange
-  ): PrisonerScheduledEvents? =
-    prisonApiClient.getPrisonerDetails(prisonerNumber).block()
-      ?.takeUnless { it.agencyId != prisonCode || it.bookingId == null }
-      ?.let { prisonerDetail ->
-        val prisonRolledOut = rolloutPrisonRepository.findByCode(prisonCode).let { it != null && it.active }
-        getScheduledEventCalls(prisonerDetail.bookingId!!, prisonRolledOut, dateRange)
-          .map { t ->
-            transformToPrisonerScheduledEvents(
+  ) = prisonApiClient.getPrisonerDetails(prisonerNumber).block()
+    ?.also { if (it.agencyId != prisonCode || it.bookingId == null) throw EntityNotFoundException("Prisoner '$prisonerNumber' not found in prison '$prisonCode'") }
+    ?.let { prisonerDetail ->
+      val prisonRolledOut = rolloutPrisonRepository.findByCode(prisonCode).let { it != null && it.active }
+      getScheduledEventCalls(prisonerDetail.bookingId!!, prisonRolledOut, dateRange)
+        .map { t ->
+          transformToPrisonerScheduledEvents(
+            prisonerDetail.bookingId,
+            prisonCode,
+            prisonerNumber,
+            dateRange,
+            t.t1,
+            t.t2,
+            t.t3,
+            t.t4
+          )
+        }.block()
+        ?.apply {
+          if (prisonRolledOut) {
+            activities = transformActivityScheduledInstancesToScheduledEvents(
               prisonerDetail.bookingId,
-              prisonCode,
               prisonerNumber,
-              dateRange,
-              t.t1,
-              t.t2,
-              t.t3,
-              t.t4
+              scheduledInstanceService.getActivityScheduleInstancesByDateRange(prisonCode, prisonerNumber, dateRange)
             )
-          }.block()
-          ?.apply {
-            if (prisonRolledOut) {
-              activities = transformActivityScheduledInstancesToScheduledEvents(
-                prisonerDetail.bookingId,
-                prisonerNumber,
-                scheduledInstanceService.getActivityScheduleInstancesByDateRange(prisonCode, prisonerNumber, dateRange)
-              )
-            }
           }
-      }
+        }
+    }
 
   private fun getScheduledEventCalls(bookingId: Long, prisonRolledOut: Boolean, dateRange: LocalDateRange) =
     Mono.zip(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
@@ -77,7 +77,7 @@ class PrisonApiClientTest {
     prisonApiMockServer.stubGetScheduledAppointmentsNotFound(bookingId, dateRange.start, dateRange.endInclusive)
     assertThatThrownBy { prisonApiClient.getScheduledAppointments(bookingId, dateRange).block() }
       .isInstanceOf(WebClientResponseException::class.java)
-      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/appointments?startDate=2022-10-01&endDate=2022-11-05")
+      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/appointments?fromDate=2022-10-01&toDate=2022-11-05")
   }
 
   @Test
@@ -98,7 +98,7 @@ class PrisonApiClientTest {
     prisonApiMockServer.stubGetScheduledActivitiesNotFound(bookingId, dateRange.start, dateRange.endInclusive)
     assertThatThrownBy { prisonApiClient.getScheduledActivities(bookingId, dateRange).block() }
       .isInstanceOf(WebClientResponseException::class.java)
-      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/activities?startDate=2022-10-01&endDate=2022-11-05")
+      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/activities?fromDate=2022-10-01&toDate=2022-11-05")
   }
 
   @Test
@@ -121,7 +121,7 @@ class PrisonApiClientTest {
     prisonApiMockServer.stubGetCourtHearingsNotFound(bookingId, dateRange.start, dateRange.endInclusive)
     assertThatThrownBy { prisonApiClient.getScheduledCourtHearings(bookingId, dateRange).block() }
       .isInstanceOf(WebClientResponseException::class.java)
-      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/court-hearings?startDate=2022-10-01&endDate=2022-11-05")
+      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/court-hearings?fromDate=2022-10-01&toDate=2022-11-05")
   }
 
   @Test
@@ -142,6 +142,6 @@ class PrisonApiClientTest {
     prisonApiMockServer.stubGetScheduledVisitsNotFound(bookingId, dateRange.start, dateRange.endInclusive)
     assertThatThrownBy { prisonApiClient.getScheduledVisits(bookingId, dateRange).block() }
       .isInstanceOf(WebClientResponseException::class.java)
-      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/visits?startDate=2022-10-01&endDate=2022-11-05")
+      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/visits?fromDate=2022-10-01&toDate=2022-11-05")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -10,7 +10,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetScheduledAppointments(bookingId: Long, startDate: LocalDate, endDate: LocalDate) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/appointments?startDate=$startDate&endDate=$endDate"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/appointments?fromDate=$startDate&toDate=$endDate"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -22,7 +22,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetScheduledAppointmentsNotFound(bookingId: Long, startDate: LocalDate, endDate: LocalDate) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/appointments?startDate=$startDate&endDate=$endDate"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/appointments?fromDate=$startDate&toDate=$endDate"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -34,7 +34,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetScheduledActivities(bookingId: Long, startDate: LocalDate, endDate: LocalDate) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/activities?startDate=$startDate&endDate=$endDate"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/activities?fromDate=$startDate&toDate=$endDate"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -46,7 +46,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetScheduledActivitiesNotFound(bookingId: Long, startDate: LocalDate, endDate: LocalDate) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/activities?startDate=$startDate&endDate=$endDate"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/activities?fromDate=$startDate&toDate=$endDate"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -58,7 +58,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetCourtHearings(bookingId: Long, startDate: LocalDate, endDate: LocalDate) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/court-hearings?startDate=$startDate&endDate=$endDate"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/court-hearings?fromDate=$startDate&toDate=$endDate"))
         .willReturn(
           WireMock.aResponse()
             .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -70,7 +70,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetCourtHearingsNotFound(bookingId: Long, startDate: LocalDate, endDate: LocalDate) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/court-hearings?startDate=$startDate&endDate=$endDate"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/court-hearings?fromDate=$startDate&toDate=$endDate"))
         .willReturn(
           WireMock.aResponse()
             .withHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
@@ -82,7 +82,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetScheduledVisits(bookingId: Long, startDate: LocalDate, endDate: LocalDate) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/visits?startDate=$startDate&endDate=$endDate"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/visits?fromDate=$startDate&toDate=$endDate"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -94,7 +94,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetScheduledVisitsNotFound(bookingId: Long, startDate: LocalDate, endDate: LocalDate) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/visits?startDate=$startDate&endDate=$endDate"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/$bookingId/visits?fromDate=$startDate&toDate=$endDate"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
Corrected prison api request param names
prison api Alert and Assessment data coming through with null offender numbers from dev - made property nullable. Throw 404 if prison code and prisoner number don't match query params 
Swagger endpoint docs fix