### PR TITLE
SAA-198 adding the domain model and DB DDL for event priorities.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventPriority.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventPriority.kt
@@ -1,0 +1,25 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import javax.persistence.Entity
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
+import javax.persistence.GeneratedValue
+import javax.persistence.GenerationType
+import javax.persistence.Id
+import javax.persistence.Table
+
+// TODO this will need to contain more information e.g. subtype/subcategories.
+@Entity
+@Table(name = "event_priority")
+data class EventPriority(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val eventPriorityId: Long? = null,
+
+  val prisonCode: String,
+
+  @Enumerated(EnumType.STRING)
+  val eventType: EventType,
+
+  val priority: Int
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/EventPriorityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/EventPriorityRepository.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventPriority
+
+@Repository
+interface EventPriorityRepository : JpaRepository<EventPriority, Long> {
+  fun findByPrisonCode(code: String): List<EventPriority>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeService.kt
@@ -2,13 +2,19 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventPriorityRepository
 
 @Service
-class PrisonRegimeService {
+class PrisonRegimeService(private val eventPriorityRepository: EventPriorityRepository) {
 
-  // TODO this is stubbed for now until we have the DB, Entity and repository in place
   fun getEventPrioritiesForPrison(code: String) =
-    EventType.values().associateWith { setOf(Priority(it.defaultPriority)) }
+    eventPriorityRepository.findByPrisonCode(code)
+      .groupBy { it.eventType }
+      .mapValues { it.value.map { ep -> Priority(ep.priority) } }
+      .ifEmpty { defaultPriorities() }
+
+  private fun defaultPriorities() =
+    EventType.values().associateWith { listOf(Priority(it.defaultPriority)) }
 }
 
 // TODO this will need to contain more information e.g. subtype/subcategories.

--- a/src/main/resources/migration/common/V1__baseline.sql
+++ b/src/main/resources/migration/common/V1__baseline.sql
@@ -229,3 +229,11 @@ CREATE TABLE activity_pay (
 
 CREATE INDEX idx_activity_pay_activity_id ON activity_pay (activity_id);
 
+CREATE TABLE event_priority (
+  event_priority_id bigserial   NOT NULL CONSTRAINT event_priority_pk PRIMARY KEY,
+  prison_code       varchar(3)  NOT NULL,
+  event_type        varchar(30) NOT NULL,
+  priority          integer     NOT NULL
+);
+
+CREATE INDEX idx_event_priority_prison_code ON event_priority (prison_code);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeServiceTest.kt
@@ -2,22 +2,57 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventPriority
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventPriorityRepository
 
 class PrisonRegimeServiceTest {
 
-  private val service = PrisonRegimeService()
+  private val eventPriorityRepository: EventPriorityRepository = mock()
+  private val service = PrisonRegimeService(eventPriorityRepository)
 
   @Test
-  fun `default priorities`() {
+  fun `default priorities are returned when no priorities for prison`() {
+    whenever(eventPriorityRepository.findByPrisonCode("PVI")).thenReturn(emptyList())
+
     assertThat(service.getEventPrioritiesForPrison("PVI")).containsExactlyInAnyOrderEntriesOf(
       mapOf(
-        EventType.COURT_HEARING to setOf(Priority(1)),
-        EventType.VISIT to setOf(Priority(2)),
-        EventType.ADJUDICATION_HEARING to setOf(Priority(3)),
-        EventType.APPOINTMENT to setOf(Priority(4)),
-        EventType.ACTIVITY to setOf(Priority(5)),
+        EventType.COURT_HEARING to listOf(Priority(1)),
+        EventType.VISIT to listOf(Priority(2)),
+        EventType.ADJUDICATION_HEARING to listOf(Priority(3)),
+        EventType.APPOINTMENT to listOf(Priority(4)),
+        EventType.ACTIVITY to listOf(Priority(5)),
       )
     )
+
+    verify(eventPriorityRepository).findByPrisonCode("PVI")
+  }
+
+  @Test
+  fun `existing prison priorities are returned for prison, overriding defaults`() {
+    whenever(eventPriorityRepository.findByPrisonCode("MDI")).thenReturn(
+      listOf(
+        EventPriority(1, "MDI", EventType.ACTIVITY, 1),
+        EventPriority(2, "MDI", EventType.APPOINTMENT, 2),
+        EventPriority(3, "MDI", EventType.VISIT, 3),
+        EventPriority(4, "MDI", EventType.ADJUDICATION_HEARING, 4),
+        EventPriority(5, "MDI", EventType.COURT_HEARING, 5),
+      )
+    )
+
+    assertThat(service.getEventPrioritiesForPrison("MDI")).containsExactlyInAnyOrderEntriesOf(
+      mapOf(
+        EventType.ACTIVITY to listOf(Priority(1)),
+        EventType.APPOINTMENT to listOf(Priority(2)),
+        EventType.VISIT to listOf(Priority(3)),
+        EventType.ADJUDICATION_HEARING to listOf(Priority(4)),
+        EventType.COURT_HEARING to listOf(Priority(5)),
+      )
+    )
+
+    verify(eventPriorityRepository).findByPrisonCode("MDI")
   }
 }


### PR DESCRIPTION
**DO NOT MERGE, CONTAINS DB CHANGE**

This change introduces the concept of event priorities for prisons in the domain i.e. when an event takes priority over another should there be a clash because they are both at the same time.

If no priorities exist for a prison then sensible defaults are provided.