### PR TITLE
SAA-198 adding event category to event priority to allow  for a finer level of prioritisation.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventCategory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventCategory.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+// TODO more categories will be added in due course when we are clear on what they should be
+enum class EventCategory {
+  EDUCATION,
+  GYM_SPORTS_FITNESS,
+  INDUCTION,
+  INDUSTRIES,
+  INTERVENTIONS,
+  LEISURE_SOCIAL,
+  SERVICES,
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventPriority.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventPriority.kt
@@ -8,7 +8,6 @@ import javax.persistence.GenerationType
 import javax.persistence.Id
 import javax.persistence.Table
 
-// TODO this will need to contain more information e.g. subtype/subcategories.
 @Entity
 @Table(name = "event_priority")
 data class EventPriority(
@@ -20,6 +19,9 @@ data class EventPriority(
 
   @Enumerated(EnumType.STRING)
   val eventType: EventType,
+
+  @Enumerated(EnumType.STRING)
+  val eventCategory: EventCategory? = null,
 
   val priority: Int
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeService.kt
@@ -1,21 +1,26 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventPriorityRepository
 
 @Service
 class PrisonRegimeService(private val eventPriorityRepository: EventPriorityRepository) {
 
+  /**
+   * Return the event priorities for a given prison.
+   *
+   * If no priorities are found then defaults are provided, see [EventType] for the default order.
+   */
   fun getEventPrioritiesForPrison(code: String) =
     eventPriorityRepository.findByPrisonCode(code)
       .groupBy { it.eventType }
-      .mapValues { it.value.map { ep -> Priority(ep.priority) } }
+      .mapValues { it.value.map { ep -> Priority(ep.priority, ep.eventCategory) } }
       .ifEmpty { defaultPriorities() }
 
   private fun defaultPriorities() =
     EventType.values().associateWith { listOf(Priority(it.defaultPriority)) }
 }
 
-// TODO this will need to contain more information e.g. subtype/subcategories.
-data class Priority(val priority: Int)
+data class Priority(val priority: Int, val eventCategory: EventCategory? = null)

--- a/src/main/resources/migration/common/V1__baseline.sql
+++ b/src/main/resources/migration/common/V1__baseline.sql
@@ -233,7 +233,9 @@ CREATE TABLE event_priority (
   event_priority_id bigserial   NOT NULL CONSTRAINT event_priority_pk PRIMARY KEY,
   prison_code       varchar(3)  NOT NULL,
   event_type        varchar(30) NOT NULL,
+  event_category    varchar(40),
   priority          integer     NOT NULL
 );
 
 CREATE INDEX idx_event_priority_prison_code ON event_priority (prison_code);
+CREATE UNIQUE INDEX idx_event_priority_prison_code_event_type_event_category ON event_priority (prison_code, event_type, event_category);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeServiceTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventPriority
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventPriorityRepository
@@ -32,14 +33,14 @@ class PrisonRegimeServiceTest {
   }
 
   @Test
-  fun `existing prison priorities are returned for prison, overriding defaults`() {
+  fun `non-overlapping prison priorities are returned for prison`() {
     whenever(eventPriorityRepository.findByPrisonCode("MDI")).thenReturn(
       listOf(
-        EventPriority(1, "MDI", EventType.ACTIVITY, 1),
-        EventPriority(2, "MDI", EventType.APPOINTMENT, 2),
-        EventPriority(3, "MDI", EventType.VISIT, 3),
-        EventPriority(4, "MDI", EventType.ADJUDICATION_HEARING, 4),
-        EventPriority(5, "MDI", EventType.COURT_HEARING, 5),
+        priority(EventType.ACTIVITY, 1),
+        priority(EventType.APPOINTMENT, 2),
+        priority(EventType.VISIT, 3),
+        priority(EventType.ADJUDICATION_HEARING, 4),
+        priority(EventType.COURT_HEARING, 5),
       )
     )
 
@@ -55,4 +56,71 @@ class PrisonRegimeServiceTest {
 
     verify(eventPriorityRepository).findByPrisonCode("MDI")
   }
+
+  @Test
+  fun `overlapping prison priorities are returned for prison`() {
+    whenever(eventPriorityRepository.findByPrisonCode("MDI")).thenReturn(
+      listOf(
+        priority(EventType.ACTIVITY, 1),
+        priority(EventType.APPOINTMENT, 2),
+        priority(EventType.VISIT, 2),
+        priority(EventType.ADJUDICATION_HEARING, 3),
+        priority(EventType.COURT_HEARING, 4),
+      )
+    )
+
+    assertThat(service.getEventPrioritiesForPrison("MDI")).containsExactlyInAnyOrderEntriesOf(
+      mapOf(
+        EventType.ACTIVITY to listOf(Priority(1)),
+        EventType.APPOINTMENT to listOf(Priority(2)),
+        EventType.VISIT to listOf(Priority(2)),
+        EventType.ADJUDICATION_HEARING to listOf(Priority(3)),
+        EventType.COURT_HEARING to listOf(Priority(4)),
+      )
+    )
+
+    verify(eventPriorityRepository).findByPrisonCode("MDI")
+  }
+
+  @Test
+  fun `non-overlapping prison priorities and categories are returned for prison`() {
+    whenever(eventPriorityRepository.findByPrisonCode("MDI")).thenReturn(
+      listOf(
+        priority(EventType.ACTIVITY, 1).copy(eventCategory = EventCategory.EDUCATION),
+        priority(EventType.ACTIVITY, 2).copy(eventCategory = EventCategory.SERVICES),
+        priority(EventType.ACTIVITY, 3).copy(eventCategory = EventCategory.GYM_SPORTS_FITNESS),
+        priority(EventType.ACTIVITY, 4).copy(eventCategory = EventCategory.INDUCTION),
+        priority(EventType.ACTIVITY, 5).copy(eventCategory = EventCategory.INDUSTRIES),
+        priority(EventType.ACTIVITY, 6).copy(eventCategory = EventCategory.INTERVENTIONS),
+        priority(EventType.APPOINTMENT, 7),
+        priority(EventType.ACTIVITY, 8).copy(eventCategory = EventCategory.LEISURE_SOCIAL),
+        priority(EventType.VISIT, 9),
+        priority(EventType.ADJUDICATION_HEARING, 10),
+        priority(EventType.COURT_HEARING, 11),
+      )
+    )
+
+    assertThat(service.getEventPrioritiesForPrison("MDI")).containsExactlyInAnyOrderEntriesOf(
+      mapOf(
+        EventType.ACTIVITY to listOf(
+          Priority(1, EventCategory.EDUCATION),
+          Priority(2, EventCategory.SERVICES),
+          Priority(3, EventCategory.GYM_SPORTS_FITNESS),
+          Priority(4, EventCategory.INDUCTION),
+          Priority(5, EventCategory.INDUSTRIES),
+          Priority(6, EventCategory.INTERVENTIONS),
+          Priority(8, EventCategory.LEISURE_SOCIAL),
+        ),
+        EventType.APPOINTMENT to listOf(Priority(7)),
+        EventType.VISIT to listOf(Priority(9)),
+        EventType.ADJUDICATION_HEARING to listOf(Priority(10)),
+        EventType.COURT_HEARING to listOf(Priority(11)),
+      )
+    )
+
+    verify(eventPriorityRepository).findByPrisonCode("MDI")
+  }
+
+  private fun priority(eventType: EventType, priority: Int) =
+    EventPriority(prisonCode = "MDI", eventType = eventType, priority = priority)
 }


### PR DESCRIPTION
**DO NOT MERGE.  CONTAINS BREAKING DB CHANGE.**

Introducing another level for event prioritisation.

An event priority can also have an event category e.g. activities can be broken down further into categories education, gym sports fitness, induction, industries, interventions, leisure social and services. 