### PR TITLE
Allow jobs to be triggered by HTTP in dev only

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,6 +6,8 @@ generic-service:
 
   ingress:
     host: activities-api-dev.prison.service.justice.gov.uk
+    annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: null
 
   env:
     HMPPS_AUTH_URL: https://sign-in-dev.hmpps.service.justice.gov.uk/auth


### PR DESCRIPTION
Environments currently block all requests to the `/jobs` route from outside of the k8s namespace. It would be convenient to hit these endpoints in dev only.