### PR TITLE
SAA-211 new endpoint to retrieve an activity schedule by its idenitfier and moving one out to the prison controller due to a clash.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocatio
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelAllocations
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelSchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transform
 import java.time.LocalDate
 import javax.persistence.EntityNotFoundException
@@ -67,4 +68,9 @@ class ActivityScheduleService(private val repository: ActivityScheduleRepository
       .filter { !activeOnly || it.isActive(today) }
       .toModelAllocations()
   }
+
+  fun getScheduleById(scheduleId: Long) =
+    repository.findById(scheduleId).orElseThrow {
+      EntityNotFoundException("$scheduleId")
+    }.toModelSchedule()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -71,7 +71,8 @@ fun transformActivityScheduledInstancesToScheduledEvents(
   defaultPriority: Int?,
   priorities: List<Priority>?,
   activityScheduledInstances: List<ModelActivityScheduleInstance>,
-): List<ModelScheduledEvent> = activityScheduledInstances.toModelScheduledEvents(bookingId, prisonerNumber, defaultPriority, priorities)
+): List<ModelScheduledEvent> =
+  activityScheduledInstances.toModelScheduledEvents(bookingId, prisonerNumber, defaultPriority, priorities)
 
 fun transformToPrisonerScheduledEvents(
   bookingId: Long,
@@ -89,10 +90,28 @@ fun transformToPrisonerScheduledEvents(
     prisonerNumber,
     dateRange.start,
     dateRange.endInclusive,
-    appointments?.prisonApiScheduledEventToScheduledEvents(prisonerNumber, EventType.APPOINTMENT.defaultPriority, eventPriorities[EventType.APPOINTMENT]),
-    courtHearings?.prisonApiCourtHearingsToScheduledEvents(bookingId, prisonCode, prisonerNumber, EventType.COURT_HEARING.defaultPriority, eventPriorities[EventType.COURT_HEARING]),
-    visits?.prisonApiScheduledEventToScheduledEvents(prisonerNumber, EventType.VISIT.defaultPriority, eventPriorities[EventType.VISIT]),
-    activities?.prisonApiScheduledEventToScheduledEvents(prisonerNumber, EventType.ACTIVITY.defaultPriority, eventPriorities[EventType.ACTIVITY]),
+    appointments?.prisonApiScheduledEventToScheduledEvents(
+      prisonerNumber,
+      EventType.APPOINTMENT.defaultPriority,
+      eventPriorities[EventType.APPOINTMENT]
+    ),
+    courtHearings?.prisonApiCourtHearingsToScheduledEvents(
+      bookingId,
+      prisonCode,
+      prisonerNumber,
+      EventType.COURT_HEARING.defaultPriority,
+      eventPriorities[EventType.COURT_HEARING]
+    ),
+    visits?.prisonApiScheduledEventToScheduledEvents(
+      prisonerNumber,
+      EventType.VISIT.defaultPriority,
+      eventPriorities[EventType.VISIT]
+    ),
+    activities?.prisonApiScheduledEventToScheduledEvents(
+      prisonerNumber,
+      EventType.ACTIVITY.defaultPriority,
+      eventPriorities[EventType.ACTIVITY]
+    ),
   )
 
 private fun EntityActivityCategory.toModelActivityCategory() =
@@ -118,20 +137,21 @@ private fun List<EntityActivityEligibility>.toModelEligibilityRules() = map {
 
 fun transform(scheduleEntities: List<EntityActivitySchedule>) = scheduleEntities.toModelSchedules()
 
-fun List<EntityActivitySchedule>.toModelSchedules() = map {
+fun List<EntityActivitySchedule>.toModelSchedules() = map { it.toModelSchedule() }
+
+fun EntityActivitySchedule.toModelSchedule() =
   ModelActivitySchedule(
-    id = it.activityScheduleId!!,
-    instances = it.instances.toModelScheduledInstances(),
-    allocations = it.allocations.toModelAllocations(),
-    description = it.description,
-    suspensions = it.suspensions.toModelSuspensions(),
-    startTime = it.startTime,
-    endTime = it.endTime,
-    internalLocation = it.toInternalLocation(),
-    capacity = it.capacity,
-    daysOfWeek = it.getDaysOfWeek().map { day -> day.getDisplayName(TextStyle.SHORT, Locale.ENGLISH) }
+    id = this.activityScheduleId!!,
+    instances = this.instances.toModelScheduledInstances(),
+    allocations = this.allocations.toModelAllocations(),
+    description = this.description,
+    suspensions = this.suspensions.toModelSuspensions(),
+    startTime = this.startTime,
+    endTime = this.endTime,
+    internalLocation = this.toInternalLocation(),
+    capacity = this.capacity,
+    daysOfWeek = this.getDaysOfWeek().map { day -> day.getDisplayName(TextStyle.SHORT, Locale.ENGLISH) }
   )
-}
 
 private fun List<EntityPrisonerWaiting>.toModelWaitingList() = map {
   ModelPrisonerWaiting(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -5,130 +5,10 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
-import java.time.LocalDate
-import java.time.LocalTime
 
 class ActivityScheduleIntegrationTest : IntegrationTestBase() {
-
-  @Sql(
-    "classpath:test_data/seed-activity-id-1.sql"
-  )
-  @Test
-  fun `get all schedules for Pentonville prison on Monday 10th October 2022`() {
-    val schedules =
-      webTestClient.getSchedulesByPrison("PVI", LocalDate.of(2022, 10, 10))!!
-        .also { assertThat(it).hasSize(2) }
-
-    val morningSchedule = with(schedules.first()) {
-      assertThat(allocations).hasSize(3)
-      assertThat(instances).hasSize(1)
-      this
-    }
-
-    morningSchedule.allocatedPrisoner("A11111A")
-    morningSchedule.allocatedPrisoner("A22222A")
-
-    with(morningSchedule.instances.first()) {
-      assertThat(date).isEqualTo(LocalDate.of(2022, 10, 10))
-      assertThat(cancelled).isFalse
-      assertThat(startTime).isEqualTo(LocalTime.of(10, 0))
-      assertThat(endTime).isEqualTo(LocalTime.of(11, 0))
-    }
-
-    val afternoonSchedule = with(schedules.second()) {
-      assertThat(allocations).hasSize(2)
-      assertThat(instances).hasSize(1)
-      this
-    }
-
-    afternoonSchedule.allocatedPrisoner("A11111A")
-    afternoonSchedule.allocatedPrisoner("A22222A")
-
-    with(afternoonSchedule.instances.first()) {
-      assertThat(date).isEqualTo(LocalDate.of(2022, 10, 10))
-      assertThat(cancelled).isFalse
-      assertThat(startTime).isEqualTo(LocalTime.of(14, 0))
-      assertThat(endTime).isEqualTo(LocalTime.of(15, 0))
-    }
-  }
-
-  @Sql(
-    "classpath:test_data/seed-activity-id-1.sql"
-  )
-  @Test
-  fun `get morning schedules for Pentonville prison on Monday 10th October 2022`() {
-    val schedules =
-      webTestClient.getSchedulesByPrison("PVI", LocalDate.of(2022, 10, 10), TimeSlot.AM)!!
-        .also { assertThat(it).hasSize(1) }
-
-    val schedule = with(schedules.first()) {
-      assertThat(allocations).hasSize(3)
-      assertThat(instances).hasSize(1)
-      assertThat(internalLocation).isEqualTo(InternalLocation(1, "L1", "Location 1"))
-      this
-    }
-
-    schedule.allocatedPrisoner("A11111A")
-    schedule.allocatedPrisoner("A22222A")
-
-    with(schedule.instances.first()) {
-      assertThat(date).isEqualTo(LocalDate.of(2022, 10, 10))
-      assertThat(cancelled).isFalse
-      assertThat(startTime).isEqualTo(LocalTime.of(10, 0))
-      assertThat(endTime).isEqualTo(LocalTime.of(11, 0))
-    }
-  }
-
-  @Sql(
-    "classpath:test_data/seed-activity-id-1.sql"
-  )
-  @Test
-  fun `get afternoon schedules for Pentonville prison on Monday 10th October 2022`() {
-    val schedules =
-      webTestClient.getSchedulesByPrison("PVI", LocalDate.of(2022, 10, 10), TimeSlot.PM)!!
-        .also { assertThat(it).hasSize(1) }
-
-    val schedule = with(schedules.first()) {
-      assertThat(allocations).hasSize(2)
-      assertThat(instances).hasSize(1)
-      this
-    }
-
-    schedule.allocatedPrisoner("A11111A")
-    schedule.allocatedPrisoner("A22222A")
-
-    with(schedule.instances.first()) {
-      assertThat(date).isEqualTo(LocalDate.of(2022, 10, 10))
-      assertThat(cancelled).isFalse
-      assertThat(startTime).isEqualTo(LocalTime.of(14, 0))
-      assertThat(endTime).isEqualTo(LocalTime.of(15, 0))
-    }
-  }
-
-  private fun WebTestClient.getSchedulesByPrison(
-    prisonCode: String,
-    date: LocalDate? = LocalDate.now(),
-    timeSlot: TimeSlot? = null
-  ) =
-    get()
-      .uri { builder ->
-        builder
-          .path("/schedules/$prisonCode")
-          .maybeQueryParam("date", date)
-          .maybeQueryParam("timeSlot", timeSlot)
-          .build(prisonCode)
-      }
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf()))
-      .exchange()
-      .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBodyList(ActivitySchedule::class.java)
-      .returnResult().responseBody
 
   @Sql(
     "classpath:test_data/seed-activity-id-1.sql"
@@ -164,5 +44,32 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
       .expectBodyList(Allocation::class.java)
       .returnResult().responseBody
 
-  private fun List<ActivitySchedule>.second() = this[1]
+  @Sql(
+    "classpath:test_data/seed-activity-id-1.sql"
+  )
+  @Test
+  fun `get schedules by their ids`() {
+    with(webTestClient.getScheduleBy(1)!!) {
+      assertThat(id).isEqualTo(1)
+    }
+
+    with(webTestClient.getScheduleBy(2)!!) {
+      assertThat(id).isEqualTo(2)
+    }
+  }
+
+  private fun WebTestClient.getScheduleBy(scheduleId: Long) =
+    get()
+      .uri { builder ->
+        builder
+          .path("/schedules/$scheduleId")
+          .build(scheduleId)
+      }
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf()))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(ActivitySchedule::class.java)
+      .returnResult().responseBody
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
@@ -7,9 +7,11 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 import java.time.LocalDate
+import java.time.LocalTime
 
 class PrisonIntegrationTest : IntegrationTestBase() {
 
@@ -96,4 +98,122 @@ class PrisonIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectBodyList(InternalLocation::class.java)
       .returnResult().responseBody
+
+  @Sql(
+    "classpath:test_data/seed-activity-id-1.sql"
+  )
+  @Test
+  fun `get all schedules for Pentonville prison on Monday 10th October 2022`() {
+    val schedules =
+      webTestClient.getSchedulesByPrison("PVI", LocalDate.of(2022, 10, 10))!!
+        .also { assertThat(it).hasSize(2) }
+
+    val morningSchedule = with(schedules.first()) {
+      assertThat(allocations).hasSize(3)
+      assertThat(instances).hasSize(1)
+      this
+    }
+
+    morningSchedule.allocatedPrisoner("A11111A")
+    morningSchedule.allocatedPrisoner("A22222A")
+
+    with(morningSchedule.instances.first()) {
+      assertThat(date).isEqualTo(LocalDate.of(2022, 10, 10))
+      assertThat(cancelled).isFalse
+      assertThat(startTime).isEqualTo(LocalTime.of(10, 0))
+      assertThat(endTime).isEqualTo(LocalTime.of(11, 0))
+    }
+
+    val afternoonSchedule = with(schedules.second()) {
+      assertThat(allocations).hasSize(2)
+      assertThat(instances).hasSize(1)
+      this
+    }
+
+    afternoonSchedule.allocatedPrisoner("A11111A")
+    afternoonSchedule.allocatedPrisoner("A22222A")
+
+    with(afternoonSchedule.instances.first()) {
+      assertThat(date).isEqualTo(java.time.LocalDate.of(2022, 10, 10))
+      assertThat(cancelled).isFalse
+      assertThat(startTime).isEqualTo(java.time.LocalTime.of(14, 0))
+      assertThat(endTime).isEqualTo(java.time.LocalTime.of(15, 0))
+    }
+  }
+
+  @Sql(
+    "classpath:test_data/seed-activity-id-1.sql"
+  )
+  @Test
+  fun `get morning schedules for Pentonville prison on Monday 10th October 2022`() {
+    val schedules =
+      webTestClient.getSchedulesByPrison("PVI", LocalDate.of(2022, 10, 10), TimeSlot.AM)!!
+        .also { assertThat(it).hasSize(1) }
+
+    val schedule = with(schedules.first()) {
+      assertThat(allocations).hasSize(3)
+      assertThat(instances).hasSize(1)
+      assertThat(internalLocation).isEqualTo(InternalLocation(1, "L1", "Location 1"))
+      this
+    }
+
+    schedule.allocatedPrisoner("A11111A")
+    schedule.allocatedPrisoner("A22222A")
+
+    with(schedule.instances.first()) {
+      assertThat(date).isEqualTo(LocalDate.of(2022, 10, 10))
+      assertThat(cancelled).isFalse
+      assertThat(startTime).isEqualTo(LocalTime.of(10, 0))
+      assertThat(endTime).isEqualTo(LocalTime.of(11, 0))
+    }
+  }
+
+  @Sql(
+    "classpath:test_data/seed-activity-id-1.sql"
+  )
+  @Test
+  fun `get afternoon schedules for Pentonville prison on Monday 10th October 2022`() {
+    val schedules =
+      webTestClient.getSchedulesByPrison("PVI", LocalDate.of(2022, 10, 10), TimeSlot.PM)!!
+        .also { assertThat(it).hasSize(1) }
+
+    val schedule = with(schedules.first()) {
+      assertThat(allocations).hasSize(2)
+      assertThat(instances).hasSize(1)
+      this
+    }
+
+    schedule.allocatedPrisoner("A11111A")
+    schedule.allocatedPrisoner("A22222A")
+
+    with(schedule.instances.first()) {
+      assertThat(date).isEqualTo(LocalDate.of(2022, 10, 10))
+      assertThat(cancelled).isFalse
+      assertThat(startTime).isEqualTo(LocalTime.of(14, 0))
+      assertThat(endTime).isEqualTo(LocalTime.of(15, 0))
+    }
+  }
+
+  private fun WebTestClient.getSchedulesByPrison(
+    prisonCode: String,
+    date: LocalDate? = LocalDate.now(),
+    timeSlot: TimeSlot? = null
+  ) =
+    get()
+      .uri { builder ->
+        builder
+          .path("/prison/$prisonCode/schedules")
+          .maybeQueryParam("date", date)
+          .maybeQueryParam("timeSlot", timeSlot)
+          .build(prisonCode)
+      }
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf()))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBodyList(ActivitySchedule::class.java)
+      .returnResult().responseBody
+
+  private fun List<ActivitySchedule>.second() = this[1]
 }


### PR DESCRIPTION
Needed an endpoint to be able to retrieve an activity schedule as part of the allocation journey.

This meant moving an endpoint to another controller as this highlighted an ambiguity in the activity schedule controller.

The UI needs to be updated as a result of this change.