### PR TITLE
SAA-237 new endpoint to retrieve all or only active allocations for prisoners at a given prison.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -43,4 +43,8 @@ data class Allocation(
   var deallocatedReason: String? = null,
 ) {
   fun isActive(date: LocalDate) = date.between(startDate, endDate)
+
+  fun activitySummary() = activitySchedule.activity.summary
+
+  fun scheduleDescription() = activitySchedule.description
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
@@ -14,6 +14,10 @@ data class Allocation(
   @Schema(description = "The prisoner number (Nomis ID)", example = "A1234AA")
   val prisonerNumber: String,
 
+  val activitySummary: String,
+
+  val scheduleDescription: String,
+
   @Schema(description = "The incentive/earned privilege (level) for this offender allocation", example = "BAS, STD, ENH")
   val incentiveLevel: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/PrisonerAllocations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/PrisonerAllocations.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
+
+@Schema(description = "Describes a prisoners allocations")
+data class PrisonerAllocations(
+
+  @Schema(description = "The prisoner number", example = "GF10101")
+  val prisonerNumber: String,
+
+  @Schema(description = "The list of allocations for the prisoner")
+  val allocations: List<Allocation>
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AllocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AllocationRepository.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
+
+@Repository
+interface AllocationRepository : JpaRepository<Allocation, Long> {
+  @Query(
+    value =
+    "FROM Allocation a " +
+      "WHERE a.prisonerNumber IN (:prisonerNumbers) " +
+      "  AND a.activitySchedule.activity.prisonCode = :prisonCode"
+  )
+  fun findByPrisonCodeAndPrisonerNumbers(prisonCode: String, prisonerNumbers: List<String>): List<Allocation>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/PrisonerAllocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/PrisonerAllocationController.kt
@@ -1,0 +1,79 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.ResponseStatus
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationsService
+
+@RestController
+@RequestMapping("/prisons", produces = [MediaType.APPLICATION_JSON_VALUE])
+class PrisonerAllocationController(private val allocationsService: AllocationsService) {
+  @PostMapping(value = ["/{prisonCode}/prisoner-allocations"])
+  @ResponseBody
+  @Operation(
+    summary = "Get all allocations for prisoners",
+    description = "Returns zero or more allocations for the supplied list of prisoners.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The allocations for the prisoners",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = PrisonerAllocations::class))
+          )
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class)
+          )
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class)
+          )
+        ],
+      )
+    ]
+  )
+  @ResponseStatus(HttpStatus.OK)
+  fun prisonerAllocations(
+    @PathVariable prisonCode: String,
+    @RequestBody @Parameter(
+      description = "The required prisoner numbers (mandatory)",
+      required = true
+    ) prisonerNumbers: List<String>,
+    @RequestParam(
+      value = "activeOnly",
+      required = false
+    ) @Parameter(description = "If true will only return active allocations. Defaults to true.") activeOnly: Boolean?,
+  ) = allocationsService.findByPrisonCodeAndPrisonerNumbers(prisonCode, prisonerNumbers.toSet(), activeOnly ?: true)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonerAllocations
+import java.time.LocalDate
+
+@Service
+class AllocationsService(private val allocationRepository: AllocationRepository) {
+  fun findByPrisonCodeAndPrisonerNumbers(prisonCode: String, prisonNumbers: Set<String>, activeOnly: Boolean = true) =
+    LocalDate.now().let { today ->
+      allocationRepository
+        .findByPrisonCodeAndPrisonerNumbers(prisonCode, prisonNumbers.toList())
+        .filter { !activeOnly || it.isActive(today) }
+        .toModelPrisonerAllocations()
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.Priority
 import java.time.LocalDateTime
 import java.time.format.TextStyle
@@ -278,9 +279,14 @@ fun List<EntityAllocation>.toModelAllocations() = map {
     startDate = it.startDate,
     endDate = it.endDate,
     allocatedTime = it.allocatedTime,
-    allocatedBy = it.allocatedBy
+    allocatedBy = it.allocatedBy,
+    activitySummary = it.activitySummary(),
+    scheduleDescription = it.scheduleDescription()
   )
 }
+
+fun List<EntityAllocation>.toModelPrisonerAllocations() =
+  toModelAllocations().groupBy { it.prisonerNumber }.map { PrisonerAllocations(it.key, it.value) }
 
 private fun List<EntitySuspension>.toModelSuspensions() = map {
   ModelSuspension(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
@@ -1,0 +1,191 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
+
+  @Sql(
+    "classpath:test_data/seed-activity-id-6.sql"
+  )
+  @Test
+  fun `get only active allocations for a group of prisoners at Pentonville`() {
+    val prisonerAllocations = webTestClient.getAllocations("PVI", listOf("A11111A", "A22222A", "A33333A"), true)
+
+    assertThat(prisonerAllocations).hasSize(2)
+
+    with(prisonerAllocations.prisoner("A11111A")) {
+      assertThat(allocations).containsExactlyInAnyOrder(
+        Allocation(
+          id = 1,
+          prisonerNumber = "A11111A",
+          activitySummary = "Maths",
+          scheduleDescription = "Maths AM",
+          incentiveLevel = "BAS",
+          payBand = "A",
+          startDate = LocalDate.of(2022, 10, 10),
+          endDate = null,
+          allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
+          allocatedBy = "MR BLOGS"
+        ),
+        Allocation(
+          id = 4,
+          prisonerNumber = "A11111A",
+          activitySummary = "Maths",
+          scheduleDescription = "Maths PM",
+          incentiveLevel = "STD",
+          payBand = "C",
+          startDate = LocalDate.of(2022, 10, 10),
+          endDate = null,
+          allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
+          allocatedBy = "MR BLOGS"
+        )
+      )
+    }
+
+    with(prisonerAllocations.prisoner("A22222A")) {
+      assertThat(allocations).containsExactlyInAnyOrder(
+        Allocation(
+          id = 2,
+          prisonerNumber = "A22222A",
+          activitySummary = "Maths",
+          scheduleDescription = "Maths AM",
+          incentiveLevel = "STD",
+          payBand = "B",
+          startDate = LocalDate.of(2022, 10, 10),
+          endDate = null,
+          allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
+          allocatedBy = "MRS BLOGS"
+        ),
+        Allocation(
+          id = 5,
+          prisonerNumber = "A22222A",
+          activitySummary = "Maths",
+          scheduleDescription = "Maths PM",
+          incentiveLevel = "ENH",
+          payBand = "D",
+          startDate = LocalDate.of(2022, 10, 10),
+          endDate = null,
+          allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
+          allocatedBy = "MRS BLOGS"
+        )
+      )
+    }
+
+    assertThat(prisonerAllocations.none { it.prisonerNumber == "A33333A" }).isTrue
+  }
+
+  @Sql(
+    "classpath:test_data/seed-activity-id-6.sql"
+  )
+  @Test
+  fun `get all allocations for a group of prisoners at Pentonville`() {
+    val prisonerAllocations = webTestClient.getAllocations("PVI", listOf("A11111A", "A22222A", "A33333A"), false)
+
+    assertThat(prisonerAllocations).hasSize(3)
+
+    with(prisonerAllocations.prisoner("A11111A")) {
+      assertThat(allocations).containsExactlyInAnyOrder(
+        Allocation(
+          id = 1,
+          prisonerNumber = "A11111A",
+          activitySummary = "Maths",
+          scheduleDescription = "Maths AM",
+          incentiveLevel = "BAS",
+          payBand = "A",
+          startDate = LocalDate.of(2022, 10, 10),
+          endDate = null,
+          allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
+          allocatedBy = "MR BLOGS"
+        ),
+        Allocation(
+          id = 4,
+          prisonerNumber = "A11111A",
+          activitySummary = "Maths",
+          scheduleDescription = "Maths PM",
+          incentiveLevel = "STD",
+          payBand = "C",
+          startDate = LocalDate.of(2022, 10, 10),
+          endDate = null,
+          allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
+          allocatedBy = "MR BLOGS"
+        )
+      )
+    }
+
+    with(prisonerAllocations.prisoner("A22222A")) {
+      assertThat(allocations).containsExactlyInAnyOrder(
+        Allocation(
+          id = 2,
+          prisonerNumber = "A22222A",
+          activitySummary = "Maths",
+          scheduleDescription = "Maths AM",
+          incentiveLevel = "STD",
+          payBand = "B",
+          startDate = LocalDate.of(2022, 10, 10),
+          endDate = null,
+          allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
+          allocatedBy = "MRS BLOGS"
+        ),
+        Allocation(
+          id = 5,
+          prisonerNumber = "A22222A",
+          activitySummary = "Maths",
+          scheduleDescription = "Maths PM",
+          incentiveLevel = "ENH",
+          payBand = "D",
+          startDate = LocalDate.of(2022, 10, 10),
+          endDate = null,
+          allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
+          allocatedBy = "MRS BLOGS"
+        )
+      )
+    }
+
+    with(prisonerAllocations.prisoner("A33333A")) {
+      assertThat(allocations).containsOnly(
+        Allocation(
+          id = 3,
+          prisonerNumber = "A33333A",
+          activitySummary = "Maths",
+          scheduleDescription = "Maths AM",
+          incentiveLevel = "STD",
+          payBand = "B",
+          startDate = LocalDate.of(2022, 10, 10),
+          endDate = LocalDate.of(2022, 10, 11),
+          allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
+          allocatedBy = "MRS BLOGS"
+        )
+      )
+    }
+  }
+
+  private fun List<PrisonerAllocations>.prisoner(prisonerNumber: String) = first { it.prisonerNumber == prisonerNumber }
+
+  @Sql(
+    "classpath:test_data/seed-activity-id-6.sql"
+  )
+  @Test
+  fun `no allocations found for a group of prisoners at Moorland`() {
+    assertThat(webTestClient.getAllocations("MDI", listOf("A11111A", "A22222A"), false)).isEmpty()
+  }
+
+  private fun WebTestClient.getAllocations(prisonCode: String, prisonerNumbers: List<String>, activeOnly: Boolean) =
+    post()
+      .uri("/prisons/$prisonCode/prisoner-allocations?activeOnly=$activeOnly")
+      .bodyValue(prisonerNumbers)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf()))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBodyList(PrisonerAllocations::class.java)
+      .returnResult().responseBody!!
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/PrisonerAllocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/PrisonerAllocationControllerTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.post
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationsService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonerAllocations
+
+@WebMvcTest(controllers = [PrisonerAllocationController::class])
+@ContextConfiguration(classes = [PrisonerAllocationController::class])
+class PrisonerAllocationControllerTest : ControllerTestBase<PrisonerAllocationController>() {
+
+  @MockBean
+  private lateinit var service: AllocationsService
+
+  override fun controller() = PrisonerAllocationController(service)
+
+  @Test
+  fun `200 response when post prison numbers`() {
+    val allocations = activityEntity().schedules.flatMap { it.allocations }.toModelPrisonerAllocations()
+    val prisonNumbers = allocations.map { it.prisonerNumber }.toSet()
+
+    whenever(service.findByPrisonCodeAndPrisonerNumbers("MDI", prisonNumbers)).thenReturn(allocations)
+
+    val response = mockMvc.postPrisonerNumbers("MDI", prisonNumbers)
+      .andDo { print() }
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isOk() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).isEqualTo(mapper.writeValueAsString(allocations))
+
+    verify(service).findByPrisonCodeAndPrisonerNumbers("MDI", prisonNumbers)
+  }
+
+  private fun MockMvc.postPrisonerNumbers(prisonCode: String, prisonerNumbers: Collection<String>) =
+    post("/prisons/$prisonCode/prisoner-allocations") {
+      content = mapper.writeValueAsString(prisonerNumbers)
+      contentType = MediaType.APPLICATION_JSON
+    }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationServiceTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonerAllocations
+
+class AllocationServiceTest {
+  private val repository: AllocationRepository = mock()
+  private val service: AllocationsService = AllocationsService(repository)
+
+  @Test
+  fun `find allocations for collection of prisoners`() {
+    val allocations = activityEntity().schedules.flatMap { it.allocations }.also { assertThat(it).isNotEmpty }
+    val prisonNumbers = allocations.map { it.prisonerNumber }
+
+    whenever(repository.findByPrisonCodeAndPrisonerNumbers("MDI", prisonNumbers)).thenReturn(allocations)
+
+    assertThat(
+      service.findByPrisonCodeAndPrisonerNumbers(
+        "MDI",
+        prisonNumbers.toSet()
+      )
+    ).isEqualTo(allocations.toModelPrisonerAllocations())
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -69,6 +69,8 @@ class TransformFunctionsTest {
               endDate = null,
               allocatedTime = timestamp,
               allocatedBy = "Mr Blogs",
+              activitySummary = "Maths",
+              scheduleDescription = "schedule description"
             )
           ),
           description = "schedule description",

--- a/src/test/resources/test_data/seed-activity-id-6.sql
+++ b/src/test/resources/test_data/seed-activity-id-6.sql
@@ -1,0 +1,26 @@
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, summary, description, start_date, end_date, created_time, created_by)
+values (1, 'PVI', 1, 1, true, 'Maths', 'Maths Level 1', '2022-10-10', null, '2022-9-21 00:00:00', 'SEED USER');
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'A', 125, 150, 1);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, start_time, end_time, internal_location_id, internal_location_code, internal_location_description, capacity, monday_flag)
+values (1, 1, 'Maths AM', '10:00:00', '11:00:00', 1, 'L1', 'Location 1', 10, true);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, start_time, end_time, internal_location_id, internal_location_code, internal_location_description, capacity, monday_flag)
+values (2, 1, 'Maths PM', '14:00:00', '15:00:00', 2, 'L2', 'Location 2', 10, true);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, incentive_level, pay_band, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason)
+values (1, 1, 'A11111A', 'BAS', 'A', '2022-10-10', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, incentive_level, pay_band, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason)
+values (2, 1, 'A22222A', 'STD', 'B', '2022-10-10', null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, incentive_level, pay_band, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason)
+values (3, 1, 'A33333A', 'STD', 'B', '2022-10-10', '2022-10-11', '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, incentive_level, pay_band, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason)
+values (4, 2, 'A11111A', 'STD', 'C', '2022-10-10', null, '2022-10-10 10:00:00', 'MR BLOGS', null, null, null);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, incentive_level, pay_band, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason)
+values (5, 2, 'A22222A', 'ENH', 'D', '2022-10-10', null, '2022-10-10 10:00:00', 'MRS BLOGS', null, null, null);


### PR DESCRIPTION
As part of this change it decorates the Allocation model to include the activity summary and schedule description to reduce API calls and the need to keep passing them around.