### PR TITLE
SAA-247 have identified two attributes returned by prison api can actually be null/empty. This does not align with the API's docs.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/Alert.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/Alert.kt
@@ -47,7 +47,7 @@ data class Alert(
   @JsonProperty("alertCodeDescription") val alertCodeDescription: String,
 
   @Schema(example = "Profession lock pick.", description = "Alert comments")
-  @JsonProperty("comment") val comment: String,
+  @JsonProperty("comment") val comment: String?,
 
   @Valid
   @Schema(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/Assessment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/Assessment.kt
@@ -35,7 +35,7 @@ data class Assessment(
   @JsonProperty("classificationCode") val classificationCode: String,
 
   @Schema(example = "Cat C", description = "Classification description")
-  @JsonProperty("classification") val classification: String,
+  @JsonProperty("classification") val classification: String?,
 
   @Schema(example = "CATEGORY", description = "Identifies the type of assessment")
   @JsonProperty("assessmentCode") val assessmentCode: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/PrisonApiTypesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/PrisonApiTypesTest.kt
@@ -1,0 +1,27 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import kotlin.reflect.full.declaredMembers
+
+/**
+ * This test has been added to cover the fact some of generated prison API types are incorrect.
+ *
+ * In this case fields generated as non-nullable are in fact nullable.
+ */
+class PrisonApiTypesTest {
+
+  @Test
+  fun `comment field on generated Alert DTO type should be nullable`() {
+    val commentField = Alert::class.declaredMembers.first { it.name == "comment" }
+
+    assertThat(commentField.returnType.isMarkedNullable).isTrue
+  }
+
+  @Test
+  fun `classification field on generated Assessment DTO type should be nullable`() {
+    val classificationField = Assessment::class.declaredMembers.first { it.name == "classification" }
+
+    assertThat(classificationField.returnType.isMarkedNullable).isTrue
+  }
+}


### PR DESCRIPTION
There is a risk here if we were to generate the DTO's for prison API again say due to a new endpoint these changes may be overwritten.

The offending endpoint : `/api/bookings/offenderNo/{prisonerNumber}?fullInfo=true`

**_Note: there may be more, these are the two I am aware of._**