### PR TITLE
SAA-261 publishing activity creation event and start introduction of localstock for working/testing queues locally.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Tools required:
 * Kotlin (Intellij)
 * docker
 * docker-compose
+* AWS cli
 
 ## Install gradle
 
@@ -48,10 +49,24 @@ Ports
 | activities-management-db  | 5432 |
 | hmpps-auth                | 8090 |
 | prison-api                | 8091 |
+| prison-api                | 8091 |
+| localstack                | 4566 |
 
 To create a Token (local):
 ```
 curl --location --request POST "http://localhost:8081/auth/oauth/token?grant_type=client_credentials" --header "Authorization: Basic $(echo -n {Client}:{ClientSecret} | base64)"
+```
+
+To list the localstack queue attributes:
+
+```
+$ aws --endpoint-url=http://localhost:4566 sqs get-queue-attributes --attribute-names All --queue-url http://localhost:4566/000000000000/domainevents-queue
+```
+
+To read a message off the queue (if there are any):
+
+```
+$ aws --endpoint-url=http://localhost:4566 sqs receive-message --queue-url http://localhost:4566/000000000000/domainevents-queue
 ```
 
 ## Swagger v3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,5 +26,26 @@ services:
       - SERVER_PORT=8080
       - SPRING_PROFILES_ACTIVE=nomis-hsqldb
 
+  local-stack-aws:
+    image: localstack/localstack:0.14.0
+    networks:
+      - hmpps
+    container_name: local-stack-aws
+    ports:
+      - "4566:4566"
+    environment:
+      - SERVICES=sns,sqs
+      - DEBUG=${DEBUG- }
+      - DATA_DIR=${DATA_DIR- }
+      - PORT_WEB_UI=${PORT_WEB_UI- }
+      - LAMBDA_EXECUTOR=${LAMBDA_EXECUTOR- }
+      - KINESIS_ERROR_PROBABILITY=${KINESIS_ERROR_PROBABILITY- }
+      - DOCKER_HOST=unix:///var/run/docker.sock
+      - AWS_EXECUTION_ENV=True
+      - DEFAULT_REGION=eu-west-2
+    volumes:
+      - "${TMPDIR:-/tmp/localstack}:/tmp/localstack"
+      - "/var/run/docker.sock:/var/run/docker.sock"
+
 networks:
   hmpps:

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPay.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPay.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
 import org.hibernate.Hibernate
-import org.springframework.data.jpa.domain.AbstractPersistable_.id
 import javax.persistence.Entity
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
@@ -39,7 +38,7 @@ data class ActivityPay(
     return activityPayId != null && activityPayId == other.activityPayId
   }
 
-  override fun hashCode(): Int = id.hashCode()
+  override fun hashCode(): Int = activityPayId.hashCode()
 
   @Override
   override fun toString(): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -99,7 +99,7 @@ class ActivityScheduleService(
       payBand = payBand
     )
 
-    repository.save(schedule)
+    repository.saveAndFlush(schedule)
 
     log.info("Allocated prisoner $prisonerNumber to activity schedule ${schedule.description}.")
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -75,7 +75,7 @@ class ActivityService(
     val activityPayList = transform(activityCreateRequest.pay, activityEntity)
     activityPayList.forEach { aee -> activityEntity.activityPay.add(aee) }
     try {
-      return transform(activityRepository.save(activityEntity))
+      return transform(activityRepository.saveAndFlush(activityEntity))
     } catch (ex: DataIntegrityViolationException) {
       throw IllegalArgumentException("Duplicate activity name detected for this prison (${activityEntity.prisonCode}): '${activityEntity.summary}'")
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventsPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventsPublisher.kt
@@ -1,18 +1,37 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
+import com.amazonaws.services.sns.model.MessageAttributeValue
+import com.amazonaws.services.sns.model.PublishRequest
+import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
+import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Service
-class EventsPublisher {
+class EventsPublisher(
+  private val hmppsQueueService: HmppsQueueService,
+  private val mapper: ObjectMapper
+) {
 
   companion object {
+    const val TOPIC_ID = "domainevents"
+
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  // TODO wire in the HmppsQueueService and send the message ...
+  private val domainEventsTopic by lazy {
+    hmppsQueueService.findByTopicId(TOPIC_ID) ?: throw RuntimeException("Topic with name $TOPIC_ID doesn't exist")
+  }
+
   internal fun send(event: OutboundHMPPSDomainEvent) {
-    log.info("Ignoring sending event: $event")
+    domainEventsTopic.snsClient.publish(
+      PublishRequest(domainEventsTopic.arn, mapper.writeValueAsString(event))
+        .withMessageAttributes(
+          mapOf(
+            "eventType" to MessageAttributeValue().withDataType("String").withStringValue(event.eventType)
+          )
+        )
+    ).also { log.info("Published $event") }
   }
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -41,3 +41,13 @@ prison:
 jobs:
   create-activity-sessions:
     days-in-advance: ${CREATE_ACTIVITY_SESSIONS_DAYS_IN_ADVANCE:0}
+
+hmpps.sqs:
+  provider: localstack
+  queues:
+    domaineventsqueue:
+      queueName: domainevents-queue
+      subscribeTopicId: domainevents
+  topics:
+    domainevents:
+      arn: arn:aws:sns:eu-west-2:000000000000:domainevents-topic

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
@@ -80,7 +80,7 @@ class ActivityServiceTest {
 
     val eligibilityRule = EligibilityRuleEntity(eligibilityRuleId = 1, code = "ER1", "Eligibility rule 1")
     whenever(eligibilityRuleRepository.findById(1L)).thenReturn(Optional.of(eligibilityRule))
-    whenever(activityRepository.save(activityEntityCaptor.capture())).thenReturn(savedActivityEntity)
+    whenever(activityRepository.saveAndFlush(activityEntityCaptor.capture())).thenReturn(savedActivityEntity)
 
     service.createActivity(createActivityRequest, createdBy)
 
@@ -89,7 +89,7 @@ class ActivityServiceTest {
     verify(activityCategoryRepository).findById(1)
     verify(activityTierRepository).findById(1)
     verify(eligibilityRuleRepository).findById(any())
-    verify(activityRepository).save(activityArg)
+    verify(activityRepository).saveAndFlush(activityArg)
 
     with(activityArg) {
       assertThat(eligibilityRules.size).isEqualTo(1)


### PR DESCRIPTION
We need to save and flush data to ensure timing of data being persisted and event being intercepted are in sync.

**Still to do:**

Integration test (this requires test containers for localstack and updating the CI config to pull in a localstack container).