### PR TITLE
SAA-288 pay_per_session

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -5,7 +5,6 @@ import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.between
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession as ModelPayPerSession
 import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.persistence.CascadeType
@@ -21,6 +20,7 @@ import javax.persistence.JoinColumn
 import javax.persistence.OneToMany
 import javax.persistence.OneToOne
 import javax.persistence.Table
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession as ModelPayPerSession
 
 @Entity
 @Table(name = "activity")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -5,11 +5,14 @@ import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.between
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession as ModelPayPerSession
 import java.time.LocalDate
 import java.time.LocalDateTime
 import javax.persistence.CascadeType
 import javax.persistence.Entity
 import javax.persistence.EntityListeners
+import javax.persistence.EnumType
+import javax.persistence.Enumerated
 import javax.persistence.FetchType
 import javax.persistence.GeneratedValue
 import javax.persistence.GenerationType
@@ -61,6 +64,9 @@ data class Activity(
 
   var outsideWork: Boolean = false,
 
+  @Enumerated(EnumType.STRING)
+  var payPerSession: PayPerSession = PayPerSession.H,
+
   val summary: String,
 
   val description: String?,
@@ -102,6 +108,7 @@ data class Activity(
     inCell = inCell,
     pieceWork = pieceWork,
     outsideWork = outsideWork,
+    payPerSession = ModelPayPerSession.valueOf(payPerSession.name),
     summary = summary,
     description = description,
     category = activityCategory.toModel(),
@@ -126,3 +133,5 @@ data class Activity(
 }
 
 fun List<Activity>.toModelLite() = map { it.toModelLite() }
+
+enum class PayPerSession { H, F }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Activity.kt
@@ -27,6 +27,9 @@ data class Activity(
   @Schema(description = "Flag to indicate if the activity carried out outside of the prison", example = "false")
   var outsideWork: Boolean,
 
+  @Schema(description = "Indicates whether the activity session is a (F)ull day or a (H)alf day (for payment purposes). ", example = "false")
+  var payPerSession: PayPerSession = PayPerSession.H,
+
   @Schema(description = "A brief summary description of this activity for use in forms and lists", example = "Maths level 1")
   val summary: String,
 
@@ -72,3 +75,5 @@ data class Activity(
   @Schema(description = "The person who created this activity", example = "Adam Smith")
   val createdBy: String
 )
+
+enum class PayPerSession { H, F }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityLite.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityLite.kt
@@ -24,6 +24,9 @@ data class ActivityLite(
   @Schema(description = "Flag to indicate if the activity carried out outside of the prison", example = "false")
   var outsideWork: Boolean,
 
+  @Schema(description = "Indicates whether the activity session is a (F)ull day or a (H)alf day (for payment purposes). ", example = "false")
+  var payPerSession: PayPerSession = PayPerSession.H,
+
   @Schema(description = "A brief summary description of this activity for use in forms and lists", example = "Maths level 1")
   val summary: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import java.time.LocalDate
 import javax.validation.Valid
 import javax.validation.constraints.NotEmpty
@@ -27,6 +28,9 @@ data class ActivityCreateRequest(
 
   @Schema(description = "Flag to indicate if the activity carried out outside of the prison", example = "false")
   var outsideWork: Boolean,
+
+  @Schema(description = "Indicates whether the activity session is a (F)ull day or a (H)alf day (for payment purposes). ", example = "false")
+  var payPerSession: PayPerSession?,
 
   @field:NotEmpty(message = "Activity summary must be supplied")
   @field:Size(max = 50, message = "Summary should not exceed {max} characters")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDat
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerScheduledActivity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityPayCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
@@ -65,6 +66,7 @@ fun transform(activity: EntityActivity) =
     inCell = activity.inCell,
     pieceWork = activity.pieceWork,
     outsideWork = activity.outsideWork,
+    payPerSession = PayPerSession.valueOf(activity.payPerSession.name),
     summary = activity.summary,
     description = activity.description,
     startDate = activity.startDate,

--- a/src/main/resources/migration/common/V1__baseline.sql
+++ b/src/main/resources/migration/common/V1__baseline.sql
@@ -95,6 +95,7 @@ CREATE TABLE activity (
   in_cell              bool         NOT NULL DEFAULT false,
   piece_work           bool         NOT NULL DEFAULT false,
   outside_work         bool         NOT NULL DEFAULT false,
+  pay_per_session      char(1)      NOT NULL DEFAULT 'H',
   summary              varchar(50)  NOT NULL,
   description          varchar(300),
   start_date           date         NOT NULL,

--- a/src/main/resources/migration/data/R__2_1__activities.sql
+++ b/src/main/resources/migration/data/R__2_1__activities.sql
@@ -1,7 +1,7 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'Maths level 1', 'A basic maths course suitable for introduction to the subject', '2022-10-10', null, null, null, '2022-10-10 09:00:00', 'SEED USER'),
-       (2, 'MDI', 1, 1, true, false, false, false, 'English level 1', 'A basic english course suitable for introduction to the subject', '2022-10-10', null, null, null, '2022-10-10 09:00:00', 'SEED USER'),
-       (3, 'MDI', 3, 1, true, false, false, false, 'Wing cleaning', 'Cleaning and upkeep of the wing', '2022-10-10', null, null, null, '2022-10-10 09:00:00', 'SEED USER'),
-       (4, 'MDI', 4, 1, false, false, false, false, 'Gym', 'Time for exercise', '2022-10-10', null, null, null, '2022-10-10 09:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths level 1', 'A basic maths course suitable for introduction to the subject', '2022-10-10', null, null, null, '2022-10-10 09:00:00', 'SEED USER'),
+       (2, 'MDI', 1, 1, true, false, false, false, 'H', 'English level 1', 'A basic english course suitable for introduction to the subject', '2022-10-10', null, null, null, '2022-10-10 09:00:00', 'SEED USER'),
+       (3, 'MDI', 3, 1, true, false, false, false, 'H', 'Wing cleaning', 'Cleaning and upkeep of the wing', '2022-10-10', null, null, null, '2022-10-10 09:00:00', 'SEED USER'),
+       (4, 'MDI', 4, 1, false, false, false, false, 'H', 'Gym', 'Time for exercise', '2022-10-10', null, null, null, '2022-10-10 09:00:00', 'SEED USER');
 
 alter sequence activity_activity_id_seq restart with 5

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityL
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleLite
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -66,6 +67,7 @@ class ActivityScheduleTest {
         inCell = false,
         pieceWork = false,
         outsideWork = false,
+        payPerSession = PayPerSession.H,
         prisonCode = "123",
         summary = "Maths",
         description = "Maths basic",
@@ -109,6 +111,7 @@ class ActivityScheduleTest {
           inCell = false,
           pieceWork = false,
           outsideWork = false,
+          payPerSession = PayPerSession.H,
           prisonCode = "123",
           summary = "Maths",
           description = "Maths basic",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 import java.time.LocalDate
 
@@ -44,6 +45,7 @@ class ActivityTest {
       inCell = false,
       pieceWork = false,
       outsideWork = false,
+      payPerSession = PayPerSession.H,
       prisonCode = "123",
       summary = "Maths",
       description = "Maths basic",
@@ -68,6 +70,7 @@ class ActivityTest {
         inCell = false,
         pieceWork = false,
         outsideWork = false,
+        payPerSession = PayPerSession.H,
         prisonCode = "123",
         summary = "Maths",
         description = "Maths basic",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -10,13 +10,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivitySchedule
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleLite
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleSlot
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityTier
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.*
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.EventsPublisher
@@ -140,6 +134,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           inCell = false,
           pieceWork = false,
           outsideWork = false,
+          payPerSession = PayPerSession.H,
           prisonCode = "PVI",
           summary = "Maths",
           description = "Maths Level 1",
@@ -173,6 +168,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           inCell = false,
           pieceWork = false,
           outsideWork = false,
+          payPerSession = PayPerSession.H,
           summary = "Maths",
           description = "Maths Level 1",
           riskLevel = "High",
@@ -215,6 +211,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           inCell = true,
           pieceWork = true,
           outsideWork = true,
+          payPerSession = PayPerSession.H,
           prisonCode = "PVI",
           summary = "Maths",
           description = "Maths Level 1",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -10,7 +10,14 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.*
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivitySchedule
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleLite
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityTier
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.EventsPublisher

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
@@ -9,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 import java.time.LocalDate
 import java.time.LocalTime
@@ -30,6 +31,7 @@ class PrisonIntegrationTest : IntegrationTestBase() {
         inCell = false,
         pieceWork = false,
         outsideWork = false,
+        payPerSession = PayPerSession.H,
         summary = "Maths",
         description = "Maths Level 1",
         riskLevel = "High",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
@@ -18,7 +18,12 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityModel
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.*
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleLite
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.CapacityAndAllocated

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
@@ -18,11 +18,7 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityModel
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleLite
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleSlot
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.*
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.CapacityAndAllocated
@@ -322,6 +318,7 @@ class ActivityControllerTest : ControllerTestBase<ActivityController>() {
           inCell = false,
           pieceWork = false,
           outsideWork = false,
+          payPerSession = PayPerSession.H,
           summary = "Maths",
           description = "Beginner maths",
           riskLevel = "High",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/PrisonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/PrisonControllerTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityModel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.CapacityAndAllocated
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ActivityScheduleService
@@ -80,6 +81,7 @@ class PrisonControllerTest : ControllerTestBase<PrisonController>() {
         inCell = false,
         pieceWork = false,
         outsideWork = false,
+        payPerSession = PayPerSession.H,
         summary = "activity summary",
         description = "activity description",
         riskLevel = "High",

--- a/src/test/resources/__files/activity/activity-create-request-2.json
+++ b/src/test/resources/__files/activity/activity-create-request-2.json
@@ -3,6 +3,7 @@
   "attendanceRequired": false,
   "summary": "Maths",
   "categoryId": 1,
+  "payPerSession": "H",
   "pay": [
     {
       "incentiveLevel": "Basic",

--- a/src/test/resources/__files/activity/activity-entity-1.json
+++ b/src/test/resources/__files/activity/activity-entity-1.json
@@ -13,6 +13,7 @@
     "description": "Work, education and maintenance"
   },
   "attendanceRequired": false,
+  "payPerSession": "H",
   "summary": "IT level 1",
   "description": "A basic IT course suitable for introduction to the subject",
   "startDate": "2022-06-25",

--- a/src/test/resources/__files/activity/activity-entity-2.json
+++ b/src/test/resources/__files/activity/activity-entity-2.json
@@ -13,6 +13,7 @@
     "description": "Work, education and maintenance"
   },
   "attendanceRequired": false,
+  "payPerSession": "H",
   "summary": "IT level 1",
   "description": "A basic IT course suitable for introduction to the subject",
   "startDate": "2022-06-25",

--- a/src/test/resources/test_data/seed-activity-id-1.sql
+++ b/src/test/resources/test_data/seed-activity-id-1.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'Maths', 'Maths Level 1', '2022-10-10', null, 'High', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'High', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (1, 1, 'Basic', 'A', 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-2.sql
+++ b/src/test/resources/test_data/seed-activity-id-2.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (2, 'PVI', 2, 2, true, false, false, false, 'English', 'English Level 2', '2022-10-21', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (2, 'PVI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (2, 2, 'Basic', 'A', 75, 0, 0);

--- a/src/test/resources/test_data/seed-activity-id-3.sql
+++ b/src/test/resources/test_data/seed-activity-id-3.sql
@@ -1,14 +1,14 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 2, 2, true, false, false, false, 'Geography', 'Geography Level 1', '2022-10-01', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (1, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (2, 'MDI', 2, 2, true, false, false, false, 'English', 'English Level 2', '2022-11-01', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (2, 'MDI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-11-01', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (3, 'PVI', 1, 1, true, false, false, false, 'Maths', 'Maths Level 1', '2022-10-10', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (3, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (4, 'PVI', 2, 2, true, false, false, false, 'English', 'English Level 2', '2022-10-21', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (4, 'PVI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (1, 1, 'Basic', 'A', 101, 0, 0);

--- a/src/test/resources/test_data/seed-activity-id-4.sql
+++ b/src/test/resources/test_data/seed-activity-id-4.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (4, 'PVI', 1, 1, true, false, false, false, 'Maths', 'Maths Level 1', current_date, null, null, null, current_timestamp, 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (4, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, null, null, current_timestamp, 'SEED USER');
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
 values (1, 4, 'Maths AM', 1, 'L1', 'Location 1', 10);

--- a/src/test/resources/test_data/seed-activity-id-5.sql
+++ b/src/test/resources/test_data/seed-activity-id-5.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (5, 'PVI', 1, 1, false, false, false, false, 'Gym', 'Gym induction', current_date, null, null, null, current_timestamp, 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (5, 'PVI', 1, 1, false, false, false, false, 'H', 'Gym', 'Gym induction', current_date, null, null, null, current_timestamp, 'SEED USER');
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
 values (1, 5, 'Gym induction AM', 1, 'L1', 'Location 1', 10);

--- a/src/test/resources/test_data/seed-activity-id-6.sql
+++ b/src/test/resources/test_data/seed-activity-id-6.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'Maths', 'Maths Level 1', '2022-10-10', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'A', 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-7.sql
+++ b/src/test/resources/test_data/seed-activity-id-7.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'Maths', 'Maths Level 1', '2022-10-10', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'A', 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-8.sql
+++ b/src/test/resources/test_data/seed-activity-id-8.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, true, true, true, 'Maths', 'Maths Level 1', '2022-10-10', null, 'High', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (1, 'PVI', 1, 1, true, true, true, true, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'High', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (1, 1, 'Basic', 'A', 125, 150, 1);


### PR DESCRIPTION
New Activity property payPerSession. An enum 'H' Half day or 'F' Full day - indicating whether activity payment is for a full day or half day. DB / Entity / Model updates with test data.