### PR TITLE
SAA-293 recording the (missing) pricinal name against allocation creations.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -96,8 +96,9 @@ data class ActivitySchedule(
     !date.isBefore(it.startDate) && (it.endDate == null || !date.isAfter(it.endDate))
   }
 
-  fun allocatePrisoner(prisonerNumber: PrisonerNumber, payBand: PayBand, bookingId: Long?) {
+  fun allocatePrisoner(prisonerNumber: PrisonerNumber, payBand: PayBand, bookingId: Long?, allocatedBy: String) {
     failIfAlreadyAllocated(prisonerNumber)
+    failIfAllocatedByIsBlank(allocatedBy)
 
     allocations.add(
       Allocation(
@@ -107,11 +108,14 @@ data class ActivitySchedule(
         payBand = payBand.toString(),
         // TODO not sure if this is supported in the UI
         startDate = LocalDate.now(),
-        // TODO need to resolve allocated by, defaulting as first iteration.
-        allocatedBy = "SYSTEM",
+        allocatedBy = allocatedBy,
         allocatedTime = LocalDateTime.now()
       )
     )
+  }
+
+  private fun failIfAllocatedByIsBlank(allocatedBy: String) {
+    if (allocatedBy.isBlank()) throw IllegalArgumentException("Allocated by cannot be blank.")
   }
 
   private fun failIfAlreadyAllocated(prisonerNumber: PrisonerNumber) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.P
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.CapacityAndAllocated
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ActivityScheduleService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.CapacityService
+import java.security.Principal
 import javax.validation.Valid
 
 // TODO add pre-auth annotations to enforce roles when we have them
@@ -235,10 +236,12 @@ class ActivityScheduleController(
   )
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN')")
   fun allocate(
+    principal: Principal,
     @PathVariable("scheduleId") scheduleId: Long,
     @RequestBody @Parameter(
       description = "The prisoner allocation request details",
       required = true
     ) @Valid prisonerAllocationRequest: PrisonerAllocationRequest
-  ): ResponseEntity<Any> = scheduleService.allocatePrisoner(scheduleId, prisonerAllocationRequest).let { ResponseEntity.noContent().build() }
+  ): ResponseEntity<Any> = scheduleService.allocatePrisoner(scheduleId, prisonerAllocationRequest, principal.name)
+    .let { ResponseEntity.noContent().build() }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -84,7 +84,7 @@ class ActivityScheduleService(
   fun getScheduleById(scheduleId: Long) = repository.findOrThrowNotFound(scheduleId).toModelSchedule()
 
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN')")
-  fun allocatePrisoner(scheduleId: Long, request: PrisonerAllocationRequest) {
+  fun allocatePrisoner(scheduleId: Long, request: PrisonerAllocationRequest, allocatedBy: String) {
     log.info("Allocating prisoner ${request.prisonerNumber}.")
 
     val schedule = repository.findOrThrowNotFound(scheduleId)
@@ -99,7 +99,8 @@ class ActivityScheduleService(
     schedule.allocatePrisoner(
       prisonerNumber = prisonerNumber,
       bookingId = prisonerDetails.bookingId,
-      payBand = payBand
+      payBand = payBand,
+      allocatedBy = allocatedBy
     )
 
     repository.saveAndFlush(schedule)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -150,7 +150,8 @@ class ActivityScheduleTest {
     schedule.allocatePrisoner(
       prisonerNumber = "123456".toPrisonerNumber(),
       payBand = "A".toPayBand(),
-      bookingId = 10001
+      bookingId = 10001,
+      allocatedBy = "FRED"
     )
 
     assertThat(schedule.allocations).hasSize(1)
@@ -160,7 +161,7 @@ class ActivityScheduleTest {
       assertThat(prisonerNumber).isEqualTo("123456")
       assertThat(payBand).isEqualTo("A")
       assertThat(startDate).isEqualTo(LocalDate.now())
-      assertThat(allocatedBy).isEqualTo("SYSTEM")
+      assertThat(allocatedBy).isEqualTo("FRED")
       assertThat(allocatedTime).isEqualToIgnoringSeconds(LocalDateTime.now())
     }
   }
@@ -174,7 +175,8 @@ class ActivityScheduleTest {
     schedule.allocatePrisoner(
       prisonerNumber = "654321".toPrisonerNumber(),
       payBand = "B".toPayBand(),
-      bookingId = 10001
+      bookingId = 10001,
+      allocatedBy = "FREDDIE"
     )
 
     assertThat(schedule.allocations).hasSize(2)
@@ -185,7 +187,7 @@ class ActivityScheduleTest {
       assertThat(bookingId).isEqualTo(10001)
       assertThat(payBand).isEqualTo("B")
       assertThat(startDate).isEqualTo(LocalDate.now())
-      assertThat(allocatedBy).isEqualTo("SYSTEM")
+      assertThat(allocatedBy).isEqualTo("FREDDIE")
       assertThat(allocatedTime).isEqualToIgnoringSeconds(LocalDateTime.now())
     }
   }
@@ -200,14 +202,32 @@ class ActivityScheduleTest {
     schedule.allocatePrisoner(
       prisonerNumber = "654321".toPrisonerNumber(),
       payBand = "B".toPayBand(),
-      bookingId = 10001
+      bookingId = 10001,
+      allocatedBy = "FREDDIE"
     )
 
     assertThatThrownBy {
       schedule.allocatePrisoner(
         prisonerNumber = "654321".toPrisonerNumber(),
         payBand = "B".toPayBand(),
-        bookingId = 10001
+        bookingId = 10001,
+        allocatedBy = "NOT FREDDIE"
+      )
+    }.isInstanceOf(IllegalArgumentException::class.java)
+  }
+
+  @Test
+  fun `allocated by cannot be blank when allocating a prisoner`() {
+    val schedule = activityEntity().schedules
+      .first()
+      .apply { allocations.clear() }
+
+    assertThatThrownBy {
+      schedule.allocatePrisoner(
+        prisonerNumber = "654321".toPrisonerNumber(),
+        payBand = "B".toPayBand(),
+        bookingId = 10001,
+        allocatedBy = " "
       )
     }.isInstanceOf(IllegalArgumentException::class.java)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -39,6 +39,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
       assertThat(tier!!.id).isEqualTo(1)
       assertThat(eligibilityRules.size).isEqualTo(1)
       assertThat(pay.size).isEqualTo(2)
+      assertThat(createdBy).isEqualTo("test-client")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -99,6 +99,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
 
     with(repository.findById(1).orElseThrow()) {
       assertThat(allocations.first().prisonerNumber).isEqualTo("G4793VF")
+      assertThat(allocations.first().allocatedBy).isEqualTo("test-client")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleControllerTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.Activit
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.CapacityService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelAllocations
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelSchedule
+import java.security.Principal
 import javax.persistence.EntityNotFoundException
 
 @WebMvcTest(controllers = [ActivityScheduleController::class])
@@ -137,10 +139,13 @@ class ActivityScheduleControllerTest : ControllerTestBase<ActivityScheduleContro
       payBand = "B",
     )
 
+    val mockPrincipal: Principal = mock()
+    whenever(mockPrincipal.name).thenReturn("THE USER NAME")
+
     mockMvc.post(1, request)
       .andExpect { status { isNoContent() } }
 
-    verify(activityScheduleService).allocatePrisoner(1, request)
+    verify(activityScheduleService).allocatePrisoner(1, request, "USERNAME")
   }
 
   @Test
@@ -165,11 +170,12 @@ class ActivityScheduleControllerTest : ControllerTestBase<ActivityScheduleContro
       assertThat(contentAsString).contains("Pay band cannot be more than 10 characters")
     }
 
-    verify(activityScheduleService, never()).allocatePrisoner(any(), any())
+    verify(activityScheduleService, never()).allocatePrisoner(any(), any(), any())
   }
 
   private fun MockMvc.post(scheduleId: Long, request: PrisonerAllocationRequest) =
     post("/schedules/$scheduleId/allocations") {
+      principal = Principal { "USERNAME" }
       content = mapper.writeValueAsString(request)
       contentType = MediaType.APPLICATION_JSON
     }


### PR DESCRIPTION
I missed this when I did the create allocations work and it was on my TODO/tidy up list, so here it is.