### PR TITLE
SAA-303 introduction of start and end dates at the activity schedule level.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -77,7 +77,10 @@ data class ActivitySchedule(
   var internalLocationDescription: String? = null,
 
   val capacity: Int,
+
+  val startDate: LocalDate
 ) {
+  val endDate: LocalDate? = null
 
   fun toModelLite() = ActivityScheduleLite(
     id = this.activityScheduleId!!,
@@ -90,6 +93,8 @@ data class ActivitySchedule(
     capacity = this.capacity,
     activity = this.activity.toModelLite(),
     slots = this.slots.map { it.toModel() },
+    startDate = this.startDate,
+    endDate = this.endDate
   )
 
   fun getAllocationsOnDate(date: LocalDate): List<Allocation> = this.allocations.filter {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivitySchedule.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 
 @Schema(
   description =
@@ -23,7 +24,7 @@ data class ActivitySchedule(
   @Schema(description = "The list of allocated prisoners who are allocated to this schedule, at this time and location")
   val allocations: List<Allocation> = emptyList(),
 
-  @Schema(description = "The description of this activity schedule", example = "Monday AM Houseblock 3")
+  @Schema(description = "The description of this activity schedule", example = "Entry level Maths 1")
   val description: String,
 
   @Schema(description = "Indicates the dates between which the schedule has been suspended")
@@ -41,4 +42,12 @@ data class ActivitySchedule(
 
   @Schema(description = "The slots associated with this activity schedule")
   val slots: List<ActivityScheduleSlot> = emptyList(),
+
+  @Schema(description = "The date on which this schedule will start. From this date, any schedules will be created as real, planned instances", example = "21/09/2022")
+  @JsonFormat(pattern = "dd/MM/yyyy")
+  val startDate: LocalDate,
+
+  @Schema(description = "The date on which this schedule will end. From this date, any schedules will be created as real, planned instances", example = "21/10/2022")
+  @JsonFormat(pattern = "dd/MM/yyyy")
+  val endDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleLite.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleLite.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 
 @Schema(
   description =
@@ -31,4 +33,12 @@ data class ActivityScheduleLite(
 
   @Schema(description = "The slots associated with this activity schedule")
   val slots: List<ActivityScheduleSlot> = emptyList(),
+
+  @Schema(description = "The date on which this schedule will start. From this date, any schedules will be created as real, planned instances", example = "21/09/2022")
+  @JsonFormat(pattern = "dd/MM/yyyy")
+  val startDate: LocalDate,
+
+  @Schema(description = "The date on which this schedule will end. From this date, any schedules will be created as real, planned instances", example = "21/10/2022")
+  @JsonFormat(pattern = "dd/MM/yyyy")
+  val endDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -319,7 +319,9 @@ fun EntityActivitySchedule.toModelSchedule() =
     internalLocation = this.toInternalLocation(),
     capacity = this.capacity,
     activity = this.activity.toModelLite(),
-    slots = this.slots.toModelActivityScheduleSlots()
+    slots = this.slots.toModelActivityScheduleSlots(),
+    startDate = this.startDate,
+    endDate = this.endDate
   )
 
 private fun List<EntityPrisonerWaiting>.toModelWaitingList() = map {

--- a/src/main/resources/migration/common/V1__baseline.sql
+++ b/src/main/resources/migration/common/V1__baseline.sql
@@ -130,7 +130,9 @@ CREATE TABLE activity_schedule (
   internal_location_id          integer,
   internal_location_code        varchar(40),
   internal_location_description varchar(100),
-  capacity                      integer      NOT NULL
+  capacity                      integer      NOT NULL,
+  start_date                    date         NOT NULL,
+  end_date                      date
 );
 
 CREATE INDEX idx_activity_schedule_activity_id ON activity_schedule (activity_id);

--- a/src/main/resources/migration/data/R__2_2__schedules.sql
+++ b/src/main/resources/migration/data/R__2_2__schedules.sql
@@ -1,16 +1,16 @@
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (1, 1, 'Entry level Maths 1', 1, 'EDU-ROOM-1', 'Education - R1', 10),
-       (2, 1, 'Entry level Maths 2', 2, 'EDU-ROOM-2', 'Education - R2', 10),
-       (3, 1, 'Entry level Maths 3', 1, 'EDU-ROOM-1', 'Education - R1', 10),
-       (4, 1, 'Entry level Maths 4', 2, 'EDU-ROOM-2', 'Education - R2', 10),
-       (5, 2, 'Entry level English 1', 1, 'EDU-ROOM-1', 'Education - R1', 10),
-       (6, 2, 'Entry level English 2', 2, 'EDU-ROOM-2', 'Education - R2', 10),
-       (7, 2, 'Entry level English 3', 1, 'EDU-ROOM-1', 'Education - R1', 10),
-       (8, 2, 'Entry level English 4', 2, 'EDU-ROOM-2', 'Education - R2', 10),
-       (9, 3, 'Wing cleaning 1', 3, 'W1', 'Wing 1', 10),
-       (10, 3, 'Wing cleaning 2', 3, 'W1', 'Wing 1', 10),
-       (11, 4, 'Gym session 1', 4, 'GYM-1', 'Gym 1', 10),
-       (12, 4, 'Gym session 2', 4, 'GYM-1', 'Gym 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Entry level Maths 1', 1, 'EDU-ROOM-1', 'Education - R1', 10, '2022-10-10'),
+       (2, 1, 'Entry level Maths 2', 2, 'EDU-ROOM-2', 'Education - R2', 10, '2022-10-10'),
+       (3, 1, 'Entry level Maths 3', 1, 'EDU-ROOM-1', 'Education - R1', 10, '2022-10-10'),
+       (4, 1, 'Entry level Maths 4', 2, 'EDU-ROOM-2', 'Education - R2', 10, '2022-10-10'),
+       (5, 2, 'Entry level English 1', 1, 'EDU-ROOM-1', 'Education - R1', 10, '2022-10-10'),
+       (6, 2, 'Entry level English 2', 2, 'EDU-ROOM-2', 'Education - R2', 10, '2022-10-10'),
+       (7, 2, 'Entry level English 3', 1, 'EDU-ROOM-1', 'Education - R1', 10, '2022-10-10'),
+       (8, 2, 'Entry level English 4', 2, 'EDU-ROOM-2', 'Education - R2', 10, '2022-10-10'),
+       (9, 3, 'Wing cleaning 1', 3, 'W1', 'Wing 1', 10, '2022-10-10'),
+       (10, 3, 'Wing cleaning 2', 3, 'W1', 'Wing 1', 10, '2022-10-10'),
+       (11, 4, 'Gym session 1', 4, 'GYM-1', 'Gym 1', 10, '2022-10-10'),
+       (12, 4, 'Gym session 2', 4, 'GYM-1', 'Gym 1', 10, '2022-10-10');
 
 alter sequence activity_schedule_activity_schedule_id_seq restart with 13;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -87,12 +87,14 @@ class ActivityScheduleTest {
           endTime = LocalTime.of(10, 20),
           daysOfWeek = listOf("Mon"),
         )
-      )
+      ),
+      startDate = LocalDate.now().plusDays(1)
     )
     assertThat(
       activitySchedule(
         activityEntity(),
-        timestamp = LocalDate.now().atTime(10, 20)
+        timestamp = LocalDate.now().atTime(10, 20),
+        startDate = LocalDate.now().plusDays(1)
       ).toModelLite()
     ).isEqualTo(expectedModel)
   }
@@ -131,11 +133,12 @@ class ActivityScheduleTest {
             endTime = LocalTime.of(10, 20),
             daysOfWeek = listOf("Mon"),
           )
-        )
+        ),
+        startDate = LocalDate.now().plusDays(1)
       )
     )
 
-    assertThat(listOf(activitySchedule(activityEntity(), timestamp = LocalDate.now().atTime(10, 20))).toModelLite()).isEqualTo(
+    assertThat(listOf(activitySchedule(activityEntity(), timestamp = LocalDate.now().atTime(10, 20), startDate = LocalDate.now().plusDays(1))).toModelLite()).isEqualTo(
       expectedModel
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -91,6 +91,7 @@ internal fun activitySchedule(
   saturday: Boolean = false,
   sunday: Boolean = false,
   runsOnBankHolidays: Boolean = false,
+  startDate: LocalDate? = null
 ) =
   ActivitySchedule(
     activityScheduleId = activityScheduleId,
@@ -100,6 +101,7 @@ internal fun activitySchedule(
     internalLocationId = 1,
     internalLocationCode = "EDU-ROOM-1",
     internalLocationDescription = "Education - R1",
+    startDate = startDate ?: activity.startDate
   ).apply {
     this.instances.add(
       ScheduledInstance(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -144,7 +144,8 @@ class ActivityIntegrationTest : IntegrationTestBase() {
             endTime = LocalTime.of(11, 0),
             daysOfWeek = listOf("Mon"),
           )
-        )
+        ),
+        startDate = LocalDate.of(2022, 10, 10)
       ),
       ActivityScheduleLite(
         id = 2,
@@ -177,7 +178,8 @@ class ActivityIntegrationTest : IntegrationTestBase() {
             endTime = LocalTime.of(15, 0),
             daysOfWeek = listOf("Mon"),
           )
-        )
+        ),
+        startDate = LocalDate.of(2022, 10, 10)
       ),
     )
   }
@@ -228,6 +230,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
             daysOfWeek = listOf("Mon", "Thu"),
           ),
         ),
+        startDate = LocalDate.of(2022, 10, 10)
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
@@ -30,6 +30,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ActivityService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.CapacityService
 import java.security.Principal
+import java.time.LocalDate
 import java.time.LocalTime
 import javax.persistence.EntityNotFoundException
 
@@ -342,7 +343,8 @@ class ActivityControllerTest : ControllerTestBase<ActivityController>() {
             endTime = LocalTime.of(10, 20),
             daysOfWeek = listOf("Mon"),
           )
-        )
+        ),
+        startDate = LocalDate.now()
       )
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceFixture.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceFixture.kt
@@ -51,6 +51,7 @@ object ScheduledInstanceFixture {
       internalLocationCode = "LOCATION_CODE $locationId",
       internalLocationDescription = "LOCATION_DESCRIPTION $locationId",
       capacity = 10,
+      startDate = date
     ),
     sessionDate = date,
     startTime = startTime,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -85,7 +85,8 @@ class TransformFunctionsTest {
               endTime = timestamp.toLocalTime(),
               daysOfWeek = listOf("Mon"),
             )
-          )
+          ),
+          startDate = activityEntity().startDate
         )
       )
       assertThat(waitingList).containsExactly(

--- a/src/test/resources/test_data/seed-activity-id-1.sql
+++ b/src/test/resources/test_data/seed-activity-id-1.sql
@@ -4,14 +4,14 @@ values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1'
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (1, 1, 'Basic', 'A', 125, 150, 1);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (1, 1, '10:00:00', '11:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (2, 1, 'Maths PM', 2, 'L2', 'Location 2', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (2, 1, 'Maths PM', 2, 'L2', 'Location 2', 10, '2022-10-10');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (2, 2, '14:00:00', '15:00:00', true);

--- a/src/test/resources/test_data/seed-activity-id-2.sql
+++ b/src/test/resources/test_data/seed-activity-id-2.sql
@@ -4,14 +4,14 @@ values (2, 'PVI', 2, 2, true, false, false, false, 'H', 'English', 'English Leve
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (2, 2, 'Basic', 'A', 75, 0, 0);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (3, 2, 'English AM', 3, 'L3', 'Location 3', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (3, 2, 'English AM', 3, 'L3', 'Location 3', 10, '2022-10-21');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (1, 3, '10:00:00', '11:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (4, 2, 'English PM', 4, 'L4', 'Location 4', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (4, 2, 'English PM', 4, 'L4', 'Location 4', 10, '2022-10-21');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (2, 4, '14:00:00', '15:00:00', true);

--- a/src/test/resources/test_data/seed-activity-id-3.sql
+++ b/src/test/resources/test_data/seed-activity-id-3.sql
@@ -22,50 +22,50 @@ values (3, 3, 'Enhanced', 'C', 103, 0, 0);
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (4, 4, 'Gold', 'D', 104, 0, 0);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (1, 1, 'Geography AM', 1, 'L1', 'Location MDI 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Geography AM', 1, 'L1', 'Location MDI 1', 10, '2022-10-01');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (1, 1, '10:01:00', '11:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (2, 1, 'Geography PM', 2, 'L2', 'Location MDI 2', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (2, 1, 'Geography PM', 2, 'L2', 'Location MDI 2', 10, '2022-10-01');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (2, 2, '14:01:00', '15:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (3, 2, 'English AM', 2, 'L2', 'Location MDI 2', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (3, 2, 'English AM', 2, 'L2', 'Location MDI 2', 10, '2022-11-01');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (3, 3, '10:01:00', '11:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (4, 2, 'English PM', 1, 'L1', 'Location MDI 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (4, 2, 'English PM', 1, 'L1', 'Location MDI 1', 10, '2022-11-01');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (4, 4, '14:01:00', '15:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (5, 3, 'Maths AM', 3, 'L1', 'Location PVI 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (5, 3, 'Maths AM', 3, 'L1', 'Location PVI 1', 10, '2022-10-10');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (5, 5, '10:00:00', '11:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (6, 3, 'Maths PM', 4, 'L2', 'Location PVI 2', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (6, 3, 'Maths PM', 4, 'L2', 'Location PVI 2', 10, '2022-10-10');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (6, 6, '14:00:00', '15:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (7, 4, 'English AM', 4, 'L2', 'Location PVI 2', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (7, 4, 'English AM', 4, 'L2', 'Location PVI 2', 10, '2022-10-21');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (7, 7, '10:00:00', '11:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (8, 4, 'English PM', 3, 'L1', 'Location PVI 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (8, 4, 'English PM', 3, 'L1', 'Location PVI 1', 10, '2022-10-21');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (8, 8, '14:00:00', '15:00:00', true);

--- a/src/test/resources/test_data/seed-activity-id-4.sql
+++ b/src/test/resources/test_data/seed-activity-id-4.sql
@@ -1,14 +1,14 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
 values (4, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, null, null, current_timestamp, 'SEED USER');
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (1, 4, 'Maths AM', 1, 'L1', 'Location 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 4, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date);
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (1, 1, '10:00:00', '11:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (2, 4, 'Maths PM', 2, 'L2', 'Location 2', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (2, 4, 'Maths PM', 2, 'L2', 'Location 2', 10, current_date);
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (2, 2, '14:00:00', '15:00:00', true);

--- a/src/test/resources/test_data/seed-activity-id-5.sql
+++ b/src/test/resources/test_data/seed-activity-id-5.sql
@@ -1,8 +1,8 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
 values (5, 'PVI', 1, 1, false, false, false, false, 'H', 'Gym', 'Gym induction', current_date, null, null, null, current_timestamp, 'SEED USER');
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (1, 5, 'Gym induction AM', 1, 'L1', 'Location 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 5, 'Gym induction AM', 1, 'L1', 'Location 1', 10, current_date);
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (1, 1, '10:00:00', '11:00:00', true);

--- a/src/test/resources/test_data/seed-activity-id-6.sql
+++ b/src/test/resources/test_data/seed-activity-id-6.sql
@@ -4,14 +4,14 @@ values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1'
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'A', 125, 150, 1);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (1, 1, '10:00:00', '11:00:00', true);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (2, 1, 'Maths PM', 2, 'L2', 'Location 2', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (2, 1, 'Maths PM', 2, 'L2', 'Location 2', 10, '2022-10-10');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (2, 2, '14:00:00', '15:00:00', true);

--- a/src/test/resources/test_data/seed-activity-id-7.sql
+++ b/src/test/resources/test_data/seed-activity-id-7.sql
@@ -4,8 +4,8 @@ values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1'
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'A', 125, 150, 1);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (1, 1, '10:00:00', '11:00:00', true);

--- a/src/test/resources/test_data/seed-activity-id-8.sql
+++ b/src/test/resources/test_data/seed-activity-id-8.sql
@@ -4,8 +4,8 @@ values (1, 'PVI', 1, 1, true, true, true, true, 'H', 'Maths', 'Maths Level 1', '
 insert into activity_pay(activity_pay_id, activity_id, incentive_level, pay_band, rate, piece_rate, piece_rate_items)
 values (1, 1, 'Basic', 'A', 125, 150, 1);
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity)
-values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10);
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
 
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, wednesday_flag)
 values (1, 1, '10:00:00', '11:00:00', true, true);


### PR DESCRIPTION
Schedules can now have there own start and end dates. These cannot be outside the activity start and end dates.

These new fields have been added to support the ongoing UI work for activity schedule creation.

This will impact the creation of scheduled instances.  This will be addressed separately.

**IMPORTANT: Do not merge without talking to the team, this requires a DB drop.**