### PR TITLE
SAA-320 initial commit for scheduled instance job to use start and end dates of the schedule as well as the activity.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSuspension.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSuspension.kt
@@ -7,6 +7,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.between
 import java.time.LocalDate
 
 @Entity
@@ -23,4 +24,24 @@ data class ActivityScheduleSuspension(
   val suspendedFrom: LocalDate,
 
   val suspendedUntil: LocalDate? = null,
-)
+) {
+  init {
+    failIfSlotDateBoundariesAreInvalid()
+  }
+
+  private fun failIfSlotDateBoundariesAreInvalid() {
+    if (suspendedUntil != null && suspendedUntil.isAfter(suspendedFrom).not()) {
+      throw IllegalArgumentException("Until date must be after suspend from date")
+    }
+
+    if (suspendedFrom.isBefore(activitySchedule.startDate)) {
+      throw IllegalArgumentException("Suspension dates must be the same or between the schedule dates")
+    }
+
+    if (suspendedUntil != null && activitySchedule.endDate != null && suspendedUntil.isAfter(activitySchedule.endDate)) {
+      throw IllegalArgumentException("Suspension dates must be the same or between the schedule dates")
+    }
+  }
+
+  fun isSuspendedOn(date: LocalDate) = date.between(suspendedFrom, suspendedUntil)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -58,7 +58,7 @@ class ActivityScheduleService(
     val filteredInstances = repository.findAllByActivity_PrisonCode(prisonCode)
       .selectSchedulesAtLocation(locationId)
       .selectSchedulesWithActiveActivitiesOn(date)
-      .flatMap { it.instances }
+      .flatMap { it.instances() }
       .selectInstancesRunningOn(date, timeSlot)
 
     return filteredInstances.groupBy { it.activitySchedule }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -283,7 +283,7 @@ fun List<EntityActivitySchedule>.toModelSchedules() = map { it.toModelSchedule()
 fun EntityActivitySchedule.toModelSchedule() =
   ModelActivitySchedule(
     id = this.activityScheduleId,
-    instances = this.instances.toModelScheduledInstances(),
+    instances = this.instances().toModelScheduledInstances(),
     allocations = this.allocations().toModelAllocations(),
     description = this.description,
     suspensions = this.suspensions.toModelSuspensions(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSuspensionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSuspensionTest.kt
@@ -1,0 +1,69 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import java.time.LocalDate
+
+class ActivityScheduleSuspensionTest {
+
+  private val startDate = LocalDate.now()
+  private val untilDate = startDate.plusDays(1)
+  private val beforeStart = startDate.minusDays(1)
+  private val afterUntil = untilDate.plusDays(1)
+  private val schedule = activityEntity().schedules().first().apply { endDate = afterUntil }
+  private val suspension = ActivityScheduleSuspension(
+    activitySchedule = schedule,
+    suspendedFrom = startDate,
+    suspendedUntil = untilDate
+  )
+
+  @Test
+  fun `check suspension is in effect`() {
+    assertThat(suspension.isSuspendedOn(startDate)).isTrue
+    assertThat(suspension.isSuspendedOn(untilDate)).isTrue
+  }
+
+  @Test
+  fun `check suspension is not in effect`() {
+    assertThat(suspension.isSuspendedOn(beforeStart)).isFalse
+    assertThat(suspension.isSuspendedOn(afterUntil)).isFalse
+  }
+
+  @Test
+  fun `fails if until date not after start`() {
+    assertThatThrownBy {
+      ActivityScheduleSuspension(
+        activitySchedule = schedule,
+        suspendedFrom = startDate,
+        suspendedUntil = startDate
+      )
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Until date must be after suspend from date")
+  }
+
+  @Test
+  fun `fails if slot dates outside of schedule dates`() {
+    assertThatThrownBy {
+      ActivityScheduleSuspension(
+        activitySchedule = schedule,
+        suspendedFrom = schedule.startDate.minusDays(1),
+        suspendedUntil = untilDate
+      )
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Suspension dates must be the same or between the schedule dates")
+
+    assertThatThrownBy {
+      ActivityScheduleSuspension(
+        activitySchedule = schedule,
+        suspendedFrom = schedule.startDate,
+        suspendedUntil = schedule.endDate!!.plusDays(1)
+      )
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Suspension dates must be the same or between the schedule dates")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstanceTest.kt
@@ -7,7 +7,7 @@ import java.time.LocalDate
 
 class ScheduledInstanceTest {
 
-  private val instance = activityEntity().schedules().first().instances.first()
+  private val instance = activityEntity().schedules().first().instances().first()
 
   @Test
   fun `instance is not cancelled`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -13,7 +13,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Eligibil
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerWaiting
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.RolloutPrison
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ScheduledInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transform
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -117,7 +116,8 @@ internal fun activitySchedule(
   runsOnBankHolidays: Boolean = false,
   startDate: LocalDate? = null,
   noSlots: Boolean = false,
-  noAllocations: Boolean = false
+  noAllocations: Boolean = false,
+  noInstances: Boolean = false
 ) =
   ActivitySchedule(
     activityScheduleId = activityScheduleId,
@@ -129,24 +129,6 @@ internal fun activitySchedule(
     internalLocationDescription = "Education - R1",
     startDate = startDate ?: activity.startDate
   ).apply {
-    this.instances.add(
-      ScheduledInstance(
-        scheduledInstanceId = 1,
-        activitySchedule = this,
-        sessionDate = timestamp.toLocalDate(),
-        startTime = timestamp.toLocalTime(),
-        endTime = timestamp.toLocalTime()
-      ).apply {
-        this.attendances.add(
-          Attendance(
-            attendanceId = 1,
-            scheduledInstance = this,
-            prisonerNumber = "A11111A",
-            posted = false
-          )
-        )
-      }
-    )
     if (!noAllocations) {
       this.allocatePrisoner(
         prisonerNumber = "A1234AA".toPrisonerNumber(),
@@ -172,6 +154,21 @@ internal fun activitySchedule(
           runsOnBankHoliday = runsOnBankHolidays
         )
       )
+    }
+    if (!noInstances && !noSlots) {
+      this.addInstance(
+        sessionDate = timestamp.toLocalDate(),
+        slot = this.slots().first()
+      ).apply {
+        this.attendances.add(
+          Attendance(
+            attendanceId = 1,
+            scheduledInstance = this,
+            prisonerNumber = "A11111A",
+            posted = false
+          )
+        )
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/CreateAttendanceRecordsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/CreateAttendanceRecordsJobIntegrationTest.kt
@@ -29,14 +29,14 @@ class CreateAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
 
       with(schedules().findByDescription("Maths AM")) {
         assertThat(allocations()).hasSize(2)
-        assertThat(instances).hasSize(1)
-        assertThat(instances.first().attendances).isEmpty()
+        assertThat(instances()).hasSize(1)
+        assertThat(instances().first().attendances).isEmpty()
       }
 
       with(schedules().findByDescription("Maths PM")) {
         assertThat(allocations()).hasSize(3)
-        assertThat(instances).hasSize(1)
-        assertThat(instances.first().attendances).isEmpty()
+        assertThat(instances()).hasSize(1)
+        assertThat(instances().first().attendances).isEmpty()
       }
     }
 
@@ -44,10 +44,10 @@ class CreateAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
 
     with(activityRepository.findById(4).orElseThrow()) {
       with(schedules().findByDescription("Maths AM")) {
-        assertThat(instances.first().attendances).hasSize(2)
+        assertThat(instances().first().attendances).hasSize(2)
       }
       with(schedules().findByDescription("Maths PM")) {
-        assertThat(instances.first().attendances).hasSize(2)
+        assertThat(instances().first().attendances).hasSize(2)
       }
     }
 
@@ -76,8 +76,8 @@ class CreateAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
 
       with(schedules().findByDescription("Gym induction AM")) {
         assertThat(allocations()).hasSize(2)
-        assertThat(instances).hasSize(1)
-        assertThat(instances.first().attendances).isEmpty()
+        assertThat(instances()).hasSize(1)
+        assertThat(instances().first().attendances).isEmpty()
       }
     }
 
@@ -85,7 +85,7 @@ class CreateAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
 
     with(activityRepository.findById(5).orElseThrow()) {
       with(schedules().findByDescription("Gym induction AM")) {
-        assertThat(instances.first().attendances).isEmpty()
+        assertThat(instances().first().attendances).isEmpty()
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateActivitySessionsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateActivitySessionsJobTest.kt
@@ -15,7 +15,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityScheduleSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityScheduleSuspension
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.RolloutPrison
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ScheduledInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityRepository
@@ -55,7 +54,7 @@ class CreateActivitySessionsJobTest {
       this.forEach { activity ->
         assertThat(activity.prisonCode).isIn(listOf("LEI", "MDI"))
         activity.schedules().forEach { schedule ->
-          schedule.instances.forEach { instance ->
+          schedule.instances().forEach { instance ->
             assertThat(instance.sessionDate).isBetween(today, toDate)
           }
         }
@@ -83,7 +82,7 @@ class CreateActivitySessionsJobTest {
         assertThat(activity.schedules()).hasSize(1)
         activity.schedules().forEach { schedule ->
           assertThat(schedule.slots()).hasSize(2)
-          schedule.instances.forEach { instance ->
+          schedule.instances().forEach { instance ->
             assertThat(instance.sessionDate).isBetween(today, toDate)
             assertThat(instance.startTime).isIn(listOf(LocalTime.of(9, 30), LocalTime.of(13, 30)))
           }
@@ -158,7 +157,7 @@ class CreateActivitySessionsJobTest {
       this.forEach { activity ->
         assertThat(activity.prisonCode).isEqualTo("MDI")
         activity.schedules().forEach { schedule ->
-          schedule.instances.forEach { instance ->
+          schedule.instances().forEach { instance ->
             assertThat(instance.sessionDate).isBetween(today, toDate)
           }
         }
@@ -184,9 +183,13 @@ class CreateActivitySessionsJobTest {
         noSchedules = true
       ).apply {
         this.addSchedule(
-          activitySchedule(activity = this, activityScheduleId = 1, monday = true, noAllocations = true).apply {
-            this.instances.clear()
-          }
+          activitySchedule(
+            activity = this,
+            activityScheduleId = 1,
+            monday = true,
+            noAllocations = true,
+            noInstances = true
+          )
         )
       },
       activityEntity(
@@ -198,9 +201,14 @@ class CreateActivitySessionsJobTest {
         noSchedules = true
       ).apply {
         this.addSchedule(
-          activitySchedule(activity = this, activityScheduleId = 2, monday = false, tuesday = true, noAllocations = true).apply {
-            this.instances.clear()
-          }
+          activitySchedule(
+            activity = this,
+            activityScheduleId = 2,
+            monday = false,
+            tuesday = true,
+            noAllocations = true,
+            noInstances = true
+          )
         )
       },
       activityEntity(
@@ -212,9 +220,14 @@ class CreateActivitySessionsJobTest {
         noSchedules = true
       ).apply {
         this.addSchedule(
-          activitySchedule(activity = this, activityScheduleId = 3, monday = false, wednesday = true, noAllocations = true).apply {
-            this.instances.clear()
-          }
+          activitySchedule(
+            activity = this,
+            activityScheduleId = 3,
+            monday = false,
+            wednesday = true,
+            noAllocations = true,
+            noInstances = true
+          )
         )
       },
     )
@@ -229,9 +242,13 @@ class CreateActivitySessionsJobTest {
         noSchedules = true
       ).apply {
         this.addSchedule(
-          activitySchedule(activity = this, activityScheduleId = 4, monday = true, noAllocations = true).apply {
-            this.instances.clear()
-          }
+          activitySchedule(
+            activity = this,
+            activityScheduleId = 4,
+            monday = true,
+            noAllocations = true,
+            noInstances = true
+          )
         )
       },
       activityEntity(
@@ -243,9 +260,14 @@ class CreateActivitySessionsJobTest {
         noSchedules = true
       ).apply {
         this.addSchedule(
-          activitySchedule(activity = this, activityScheduleId = 5, monday = false, tuesday = true, noAllocations = true).apply {
-            this.instances.clear()
-          }
+          activitySchedule(
+            activity = this,
+            activityScheduleId = 5,
+            monday = false,
+            tuesday = true,
+            noAllocations = true,
+            noInstances = true
+          )
         )
       },
       activityEntity(
@@ -257,9 +279,14 @@ class CreateActivitySessionsJobTest {
         noSchedules = true
       ).apply {
         this.addSchedule(
-          activitySchedule(activity = this, activityScheduleId = 6, monday = false, wednesday = true, noAllocations = true).apply {
-            this.instances.clear()
-          }
+          activitySchedule(
+            activity = this,
+            activityScheduleId = 6,
+            monday = false,
+            wednesday = true,
+            noAllocations = true,
+            noInstances = true
+          )
         )
       },
     )
@@ -284,15 +311,11 @@ class CreateActivitySessionsJobTest {
             friday = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
             saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
             sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
+            noInstances = true
           ).apply {
-            this.instances.clear()
-            this.instances.add(
-              ScheduledInstance(
-                activitySchedule = this,
-                sessionDate = LocalDate.now(),
-                startTime = LocalTime.now(),
-                endTime = LocalTime.now()
-              )
+            this.addInstance(
+              sessionDate = LocalDate.now(),
+              slot = this.slots().first()
             )
           }
         )
@@ -319,8 +342,8 @@ class CreateActivitySessionsJobTest {
             friday = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
             saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
             sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
+            noInstances = true
           ).apply {
-            this.instances.clear()
             this.suspensions.clear()
             this.suspensions.add(
               ActivityScheduleSuspension(
@@ -355,8 +378,8 @@ class CreateActivitySessionsJobTest {
             saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
             sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
             runsOnBankHolidays = false,
+            noInstances = true
           ).apply {
-            this.instances.clear()
             this.suspensions.clear()
           }
         )
@@ -384,8 +407,8 @@ class CreateActivitySessionsJobTest {
             saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
             sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
             runsOnBankHolidays = true,
+            noInstances = true
           ).apply {
-            this.instances.clear()
             this.suspensions.clear()
           }
         )
@@ -412,9 +435,8 @@ class CreateActivitySessionsJobTest {
             friday = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
             saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
             sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
-            noSlots = true
+            noSlots = true,
           ).apply {
-            this.instances.clear()
             this.suspensions.clear()
             this.addSlot(
               ActivityScheduleSlot(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledInstanceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledInstanceControllerTest.kt
@@ -30,7 +30,7 @@ class ScheduledInstanceControllerTest : ControllerTestBase<ScheduledInstanceCont
 
   @Test
   fun `200 response when get instance by ID found`() {
-    val instance = activityEntity().schedules().first().instances.first().toModel()
+    val instance = activityEntity().schedules().first().instances().first().toModel()
 
     whenever(scheduledInstanceService.getActivityScheduleInstanceById(1)).thenReturn(instance)
 
@@ -60,7 +60,7 @@ class ScheduledInstanceControllerTest : ControllerTestBase<ScheduledInstanceCont
 
   @Test
   fun `200 response when get attendances by schedule ID found`() {
-    val attendances = activityEntity().schedules().first().instances.first().attendances.map { transform(it) }
+    val attendances = activityEntity().schedules().first().instances().first().attendances.map { transform(it) }
 
     whenever(attendancesService.findAttendancesByScheduledInstance(1)).thenReturn(attendances)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesServiceTest.kt
@@ -27,7 +27,7 @@ class AttendancesServiceTest {
   private val activity = activityEntity()
   private val activitySchedule = activity.schedules().first()
   private val allocation = activitySchedule.allocations().first()
-  private val instance = activitySchedule.instances.first()
+  private val instance = activitySchedule.instances().first()
   private val attendance = instance.attendances.first()
   private val today = LocalDate.now()
   private val tomorrow = today.plusDays(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -55,10 +55,10 @@ class TransformFunctionsTest {
           id = 1,
           instances = listOf(
             ModelScheduledInstance(
-              id = 1,
+              id = -1,
               date = timestamp.toLocalDate(),
               startTime = timestamp.toLocalTime(),
-              endTime = timestamp.toLocalTime(),
+              endTime = timestamp.toLocalTime().plusHours(1),
               cancelled = false,
               attendances = listOf(
                 ModelAttendance(


### PR DESCRIPTION
Initial changes to include the start and end dates of a schedule when creating instances of a schedule.

Includes adding some extra validation on the entities themselves around dates and also adding missing unit tests for pulling out schedules from activities for scheduling.