### PR TITLE
SAA-330 removing query constraint on scheduled instances requiring an allocation when pulling back a list.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
@@ -14,12 +14,10 @@ interface ScheduledInstanceRepository : JpaRepository<ScheduledInstance, Long> {
     """
     SELECT si FROM ScheduledInstance si 
     WHERE EXISTS (
-      SELECT 1 FROM si.activitySchedule.allocations a 
-      WHERE a.activitySchedule.activity.prisonCode = :prisonCode 
+      SELECT 1 FROM si.activitySchedule s
+      WHERE s.activity.prisonCode = :prisonCode 
       AND si.sessionDate >= :startDate
       AND si.sessionDate <= :endDate
-      AND (si.cancelled is null or si.cancelled = false)
-      AND a.startDate <= si.sessionDate AND (a.endDate is null or a.endDate >= si.sessionDate)
     )
     """
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleInstanceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleInstanceIntegrationTest.kt
@@ -4,6 +4,9 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleInstance
 import java.time.LocalDate
 
@@ -31,19 +34,10 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:test_data/seed-activity-id-3.sql")
   fun `getActivityScheduleInstances - returns all 20 rows without the time slot`() {
-    val prisonCode = "MDI"
     val startDate = LocalDate.of(2022, 10, 1)
     val endDate = LocalDate.of(2022, 11, 5)
 
-    val scheduledInstances = webTestClient.get()
-      .uri("/prisons/$prisonCode/scheduled-instances?startDate=$startDate&endDate=$endDate")
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf()))
-      .exchange()
-      .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBodyList(ActivityScheduleInstance::class.java)
-      .returnResult().responseBody
+    val scheduledInstances = webTestClient.getScheduledInstancesBy(moorlandPrisonCode, startDate, endDate)
 
     assertThat(scheduledInstances).hasSize(20)
   }
@@ -51,20 +45,10 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:test_data/seed-activity-id-3.sql")
   fun `getActivityScheduleInstances - returns 10 rows with the time slot filter`() {
-    val prisonCode = "MDI"
     val startDate = LocalDate.of(2022, 10, 1)
     val endDate = LocalDate.of(2022, 11, 5)
-    val timeSlot = "am"
 
-    val scheduledInstances = webTestClient.get()
-      .uri("/prisons/$prisonCode/scheduled-instances?startDate=$startDate&endDate=$endDate&slot=$timeSlot")
-      .accept(MediaType.APPLICATION_JSON)
-      .headers(setAuthorisation(roles = listOf()))
-      .exchange()
-      .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBodyList(ActivityScheduleInstance::class.java)
-      .returnResult().responseBody
+    val scheduledInstances = webTestClient.getScheduledInstancesBy(moorlandPrisonCode, startDate, endDate, TimeSlot.AM)
 
     assertThat(scheduledInstances).hasSize(10)
   }
@@ -72,12 +56,51 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:test_data/seed-activity-id-3.sql")
   fun `getActivityScheduleInstances - date range precludes 4 rows from the sample of 20`() {
-    val prisonCode = "MDI"
     val startDate = LocalDate.of(2022, 10, 2)
     val endDate = LocalDate.of(2022, 11, 4)
 
-    val scheduledInstances = webTestClient.get()
-      .uri("/prisons/$prisonCode/scheduled-instances?startDate=$startDate&endDate=$endDate")
+    val scheduledInstances = webTestClient.getScheduledInstancesBy(moorlandPrisonCode, startDate, endDate)
+
+    assertThat(scheduledInstances).hasSize(16)
+  }
+
+  @Test
+  @Sql("classpath:test_data/seed-activity-id-10.sql")
+  fun `getActivityScheduleInstances - returns instance when no allocations`() {
+    val startDate = LocalDate.of(2022, 10, 1)
+    val endDate = LocalDate.of(2022, 11, 5)
+
+    val scheduledInstances = webTestClient.getScheduledInstancesBy(moorlandPrisonCode, startDate, endDate, TimeSlot.AM)
+
+    assertThat(scheduledInstances).hasSize(1)
+  }
+
+  @Test
+  @Sql("classpath:test_data/seed-activity-id-10.sql")
+  fun `getActivityScheduleInstances - returns no instance when match on time slot`() {
+    val startDate = LocalDate.of(2022, 10, 1)
+    val endDate = LocalDate.of(2022, 11, 5)
+
+    val scheduledInstances = webTestClient.getScheduledInstancesBy(moorlandPrisonCode, startDate, endDate, TimeSlot.PM)
+
+    assertThat(scheduledInstances).isEmpty()
+  }
+
+  private fun WebTestClient.getScheduledInstancesBy(
+    prisonCode: String,
+    startDate: LocalDate,
+    endDate: LocalDate,
+    timeSlot: TimeSlot? = null
+  ) =
+    get()
+      .uri { builder ->
+        builder
+          .path("/prisons/$prisonCode/scheduled-instances")
+          .queryParam("startDate", startDate)
+          .queryParam("endDate", endDate)
+          .maybeQueryParam("slot", timeSlot)
+          .build()
+      }
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf()))
       .exchange()
@@ -85,7 +108,4 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectBodyList(ActivityScheduleInstance::class.java)
       .returnResult().responseBody
-
-    assertThat(scheduledInstances).hasSize(16)
-  }
 }

--- a/src/test/resources/test_data/seed-activity-id-10.sql
+++ b/src/test/resources/test_data/seed-activity-id-10.sql
@@ -1,0 +1,14 @@
+--
+-- One activity with one schedule, one slot and one instance but no allocations
+--
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_level, created_time, created_by)
+values (10, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, null, null, '2022-9-21 00:00:00', 'SEED USER');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 10, 'Geography AM', 1, 'L1', 'Location MDI 1', 10, '2022-10-01');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
+values (1, 1, '10:01:00', '11:00:00', true);
+
+insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by)
+values (1, 1, '2022-10-01', '10:01:00', '11:00:00', false, null, null);


### PR DESCRIPTION
This is a subtle change the endpoint which returns a list of scheduled instances at a given prison on given dates and time.

If no there were no allocations to a scheduled instance then it would be would be excluded from the results.  This restriction has now been removed.