### PR TITLE
SAA-352 bring the outbound domain even message inline with the ADR, requires AdditionalInfo object as part of message.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -70,7 +70,7 @@ class ActivityService(
       activityCategory = category,
       activityTier = tier,
       attendanceRequired = request.attendanceRequired,
-      summary = request.summary!!,
+      summary = request.summary,
       description = request.description,
       startDate = request.startDate ?: LocalDate.now(),
       endDate = request.endDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.S
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.EventsPublisher
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.OutboundHMPPSDomainEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ScheduleCreatedInformation
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -506,9 +507,9 @@ class ActivityIntegrationTest : IntegrationTestBase() {
 
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo("activities.activity-schedule.created")
-      assertThat(identifier).isEqualTo(1L)
+      assertThat(additionalInformation).isEqualTo(ScheduleCreatedInformation(1))
       assertThat(occurredAt).isEqualToIgnoringSeconds(LocalDateTime.now())
-      assertThat(description).isEqualTo("new activity schedule with identifier 1 has been created in the activities management service")
+      assertThat(description).isEqualTo("A new activity schedule has been created in the activities management service")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/OutboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/OutboundEventsServiceTest.kt
@@ -14,30 +14,30 @@ class OutboundEventsServiceTest {
   private val eventCaptor = argumentCaptor<OutboundHMPPSDomainEvent>()
 
   @Test
-  fun `activity created with id 1 is sent to the events publisher`() {
+  fun `activity schedule created event with id 1 is sent to the events publisher`() {
     outboundEventsService.send(OutboundEvent.ACTIVITY_SCHEDULE_CREATED, 1L)
 
     verify(eventsPublisher).send(eventCaptor.capture())
 
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo("activities.activity-schedule.created")
-      assertThat(identifier).isEqualTo(1L)
+      assertThat(additionalInformation).isEqualTo(ScheduleCreatedInformation(1))
       assertThat(occurredAt).isEqualToIgnoringSeconds(LocalDateTime.now())
-      assertThat(description).isEqualTo("new activity schedule with identifier 1 has been created in the activities management service")
+      assertThat(description).isEqualTo("A new activity schedule has been created in the activities management service")
     }
   }
 
   @Test
-  fun `activity created with id 99 is sent to the events publisher`() {
+  fun `activity schedule created event with id 99 is sent to the events publisher`() {
     outboundEventsService.send(OutboundEvent.ACTIVITY_SCHEDULE_CREATED, 99L)
 
     verify(eventsPublisher).send(eventCaptor.capture())
 
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo("activities.activity-schedule.created")
-      assertThat(identifier).isEqualTo(99L)
+      assertThat(additionalInformation).isEqualTo(ScheduleCreatedInformation(99))
       assertThat(occurredAt).isEqualToIgnoringSeconds(LocalDateTime.now())
-      assertThat(description).isEqualTo("new activity schedule with identifier 99 has been created in the activities management service")
+      assertThat(description).isEqualTo("A new activity schedule has been created in the activities management service")
     }
   }
 }


### PR DESCRIPTION
The ADR for message formats related to this change can be found in Confluence.