### PR TITLE
SAA-353 adding new endpoint to support the retrieval of allocations by id.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -11,6 +11,7 @@ import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.between
 import java.time.LocalDate
 import java.time.LocalDateTime
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation as ModelAllocation
 
 @Entity
 @Table(name = "allocation")
@@ -50,4 +51,18 @@ data class Allocation(
   fun activitySummary() = activitySchedule.activity.summary
 
   fun scheduleDescription() = activitySchedule.description
+
+  fun toModel() =
+    ModelAllocation(
+      id = allocationId,
+      prisonerNumber = prisonerNumber,
+      bookingId = bookingId,
+      payBandId = payBand.prisonPayBandId,
+      startDate = startDate,
+      endDate = endDate,
+      allocatedTime = allocatedTime,
+      allocatedBy = allocatedBy,
+      activitySummary = activitySummary(),
+      scheduleDescription = activitySchedule.description
+    )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationController.kt
@@ -1,0 +1,74 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationsService
+
+@RestController
+@RequestMapping("/allocations", produces = [MediaType.APPLICATION_JSON_VALUE])
+class AllocationController(private val allocationsService: AllocationsService) {
+
+  @GetMapping(value = ["/id/{allocationId}"])
+  @ResponseBody
+  @Operation(
+    summary = "Get an allocation by its id",
+    description = "Returns a single allocation and its details by its unique identifier.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "allocation found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = Allocation::class)
+          )
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class)
+          )
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class)
+          )
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The allocation for this ID was not found.",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class)
+          )
+        ],
+      )
+    ]
+  )
+  fun getAllocationById(@PathVariable("allocationId") allocationId: Long) =
+    allocationsService.getAllocationById(allocationId)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonerAllocations
 import java.time.LocalDate
 
@@ -14,4 +15,6 @@ class AllocationsService(private val allocationRepository: AllocationRepository)
         .filter { !activeOnly || it.isActive(today) }
         .toModelPrisonerAllocations()
     }
+
+  fun getAllocationById(id: Long) = allocationRepository.findOrThrowNotFound(id).toModel()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -35,7 +35,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityS
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleInstance as ModelActivityScheduleInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleSlot as ModelActivityScheduleSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityTier as ModelActivityTier
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation as ModelAllocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Attendance as ModelAttendance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AttendanceReason as ModelAttendanceReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.EligibilityRule as ModelEligibilityRule
@@ -459,20 +458,7 @@ private fun PrisonApiCourtHearings.prisonApiCourtHearingsToScheduledEvents(
   )
 }
 
-fun List<EntityAllocation>.toModelAllocations() = map {
-  ModelAllocation(
-    id = it.allocationId,
-    prisonerNumber = it.prisonerNumber,
-    bookingId = it.bookingId,
-    payBandId = it.payBand.prisonPayBandId,
-    startDate = it.startDate,
-    endDate = it.endDate,
-    allocatedTime = it.allocatedTime,
-    allocatedBy = it.allocatedBy,
-    activitySummary = it.activitySummary(),
-    scheduleDescription = it.scheduleDescription()
-  )
-}
+fun List<EntityAllocation>.toModelAllocations() = map { it.toModel() }
 
 fun List<EntityAllocation>.toModelPrisonerAllocations() =
   toModelAllocations().groupBy { it.prisonerNumber }.map { PrisonerAllocations(it.key, it.value) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -172,6 +172,8 @@ internal fun activitySchedule(
     }
   }
 
+internal fun allocation() = activitySchedule(activityEntity()).allocations().first()
+
 private fun activityWaiting(
   activity: Activity,
   timestamp: LocalDateTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
+import java.time.LocalDate
+import java.time.LocalDateTime
+
+class AllocationIntegrationTest : IntegrationTestBase() {
+
+  @Sql(
+    "classpath:test_data/seed-activity-id-1.sql"
+  )
+  @Test
+  fun `get allocation by id`() {
+    with(webTestClient.getAllocationBy(1)!!) {
+      assertThat(prisonerNumber).isEqualTo("A11111A")
+      assertThat(payBandId).isEqualTo(1)
+      assertThat(startDate).isEqualTo(java.time.LocalDate.of(2022, 10, 10))
+      assertThat(endDate).isNull()
+      assertThat(allocatedBy).isEqualTo("MR BLOGS")
+      assertThat(allocatedTime).isEqualTo(java.time.LocalDateTime.of(2022, 10, 10, 9, 0))
+    }
+
+    with(webTestClient.getAllocationBy(2)!!) {
+      assertThat(prisonerNumber).isEqualTo("A22222A")
+      assertThat(payBandId).isEqualTo(2)
+      assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
+      assertThat(endDate).isNull()
+      assertThat(allocatedBy).isEqualTo("MRS BLOGS")
+      assertThat(allocatedTime).isEqualTo(LocalDateTime.of(2022, 10, 10, 9, 0))
+    }
+  }
+
+  private fun WebTestClient.getAllocationBy(allocationId: Long) =
+    get()
+      .uri("/allocations/id/$allocationId")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf()))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(Allocation::class.java)
+      .returnResult().responseBody
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationControllerTest.kt
@@ -1,0 +1,53 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
+
+import jakarta.persistence.EntityNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationsService
+
+@WebMvcTest(controllers = [AllocationController::class])
+@ContextConfiguration(classes = [AllocationController::class])
+class AllocationControllerTest : ControllerTestBase<AllocationController>() {
+
+  @MockBean
+  private lateinit var allocationsService: AllocationsService
+
+  override fun controller() = AllocationController(allocationsService)
+
+  @Test
+  fun `200 response when get allocation by ID found`() {
+    val allocation = allocation().toModel()
+
+    whenever(allocationsService.getAllocationById(1)).thenReturn(allocation)
+
+    val response = mockMvc.getAllocationById(1)
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isOk() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).isEqualTo(mapper.writeValueAsString(allocation))
+
+    verify(allocationsService).getAllocationById(1)
+  }
+
+  @Test
+  fun `404 response when get allocation by ID found`() {
+    whenever(allocationsService.getAllocationById(any())).thenThrow(EntityNotFoundException("not found"))
+
+    mockMvc.getAllocationById(1)
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isNotFound() } }
+  }
+
+  private fun MockMvc.getAllocationById(id: Long) = get("/allocations/id/{allocationId}", id)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationServiceTest.kt
@@ -1,12 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
+import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonerAllocations
+import java.util.Optional
 
 class AllocationServiceTest {
   private val repository: AllocationRepository = mock()
@@ -25,5 +30,25 @@ class AllocationServiceTest {
         prisonNumbers.toSet()
       )
     ).isEqualTo(allocations.toModelPrisonerAllocations())
+  }
+
+  @Test
+  fun `transformed allocation returned when find by id`() {
+    val expected = allocation()
+
+    whenever(repository.findById(expected.allocationId)).thenReturn(Optional.of(expected))
+
+    assertThat(service.getAllocationById(expected.allocationId)).isEqualTo(expected.toModel())
+  }
+
+  @Test
+  fun `find by id throws entity not found for unknown allocation`() {
+    whenever(repository.findById(any())).thenReturn(Optional.empty())
+
+    assertThatThrownBy {
+      service.getAllocationById(1)
+    }
+      .isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessage("Allocation 1 not found")
   }
 }


### PR DESCRIPTION
On the back of the data sync work back to NOMIS we need support the retrieval of prisoner allocations by it's id for the mapping service to use.