### PR TITLE
SAA-357. Expose the full pay bands instead of just the ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Tools required:
 
 `$ ./gradlew`
 
-`$ ./gradlew clean build`
+`$ ./gradlew clean build` 
 
 ## Running the service
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -57,7 +57,7 @@ data class Allocation(
       id = allocationId,
       prisonerNumber = prisonerNumber,
       bookingId = bookingId,
-      payBandId = payBand.prisonPayBandId,
+      prisonPayBand = payBand.toModel(),
       startDate = startDate,
       endDate = endDate,
       allocatedTime = allocatedTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonPayBand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonPayBand.kt
@@ -31,7 +31,7 @@ data class PrisonPayBand(
   @Column(name = "nomis_pay_band", nullable = false)
   val nomisPayBand: Int
 ) {
-  fun toModel(): ModelPrisonPayBand = ModelPrisonPayBand(
+  fun toModel() = ModelPrisonPayBand(
 
     id = prisonPayBandId,
     displaySequence = displaySequence,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonPayBand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonPayBand.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonPayBand as ModelPrisonPayBand
 
 @Entity
 @Table(name = "prison_pay_band")
@@ -29,4 +30,14 @@ data class PrisonPayBand(
 
   @Column(name = "nomis_pay_band", nullable = false)
   val nomisPayBand: Int
-)
+) {
+  fun toModel(): ModelPrisonPayBand = ModelPrisonPayBand(
+
+    id = prisonPayBandId,
+    displaySequence = displaySequence,
+    alias = payBandAlias,
+    description = payBandDescription,
+    nomisPayBand = nomisPayBand,
+    prisonCode = prisonCode
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
@@ -21,8 +21,8 @@ data class Allocation(
 
   val scheduleDescription: String,
 
-  @Schema(description = "Where a prison uses pay bands to differentiate earnings, this is the pay band identifier given to this prisoner", example = "1")
-  val payBandId: Long,
+  @Schema(description = "Where a prison uses pay bands to differentiate earnings, this is the pay band given to this prisoner")
+  val prisonPayBand: PrisonPayBand,
 
   @Schema(description = "The date when the prisoner will start the activity", example = "10/09/2022")
   @JsonFormat(pattern = "dd/MM/yyyy")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -11,9 +11,9 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand1
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand3
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandOne
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandThree
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandTwo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivitySchedule
@@ -266,7 +266,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
       assertThat(pay).hasSize(1)
       pay.map {
         assertThat(it.incentiveLevel).isEqualTo("Basic")
-        assertThat(it.prisonPayBand).isEqualTo(testPayBand1)
+        assertThat(it.prisonPayBand).isEqualTo(testPentonvillePayBandOne)
         assertThat(it.rate).isEqualTo(125)
         assertThat(it.pieceRate).isEqualTo(150)
         assertThat(it.pieceRateItems).isEqualTo(1)
@@ -290,7 +290,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsMorning.allocatedPrisoner("A11111A")) {
-      assertThat(prisonPayBand).isEqualTo(testPayBand1)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandOne)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -298,7 +298,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsMorning.allocatedPrisoner("A22222A")) {
-      assertThat(prisonPayBand).isEqualTo(testPayBand2)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandTwo)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")
@@ -316,7 +316,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsAfternoon.allocatedPrisoner("A11111A")) {
-      assertThat(prisonPayBand).isEqualTo(testPayBand3)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandThree)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -324,7 +324,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsAfternoon.allocatedPrisoner("A22222A")) {
-      assertThat(prisonPayBand).isEqualTo(testPayBand3)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandThree)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")
@@ -345,7 +345,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
       assertThat(tier).isEqualTo(ActivityTier(2, "T2", "Tier 2"))
       pay.map {
         assertThat(it.incentiveLevel).isEqualTo("Basic")
-        assertThat(it.prisonPayBand).isEqualTo(testPayBand1)
+        assertThat(it.prisonPayBand).isEqualTo(testPentonvillePayBandOne)
         assertThat(it.rate).isEqualTo(75)
         assertThat(it.pieceRate).isEqualTo(0)
         assertThat(it.pieceRateItems).isEqualTo(0)
@@ -369,7 +369,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishMorning.allocatedPrisoner("B11111B")) {
-      assertThat(prisonPayBand).isEqualTo(testPayBand1)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandOne)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -377,7 +377,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishMorning.allocatedPrisoner("B22222B")) {
-      assertThat(prisonPayBand).isEqualTo(testPayBand2)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandTwo)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")
@@ -396,7 +396,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishAfternoon.allocatedPrisoner("B11111B")) {
-      assertThat(prisonPayBand).isEqualTo(testPayBand3)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandThree)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -404,7 +404,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishAfternoon.allocatedPrisoner("B22222B")) {
-      assertThat(prisonPayBand).isEqualTo(testPayBand3)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandThree)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -11,6 +11,9 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand1
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand3
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivitySchedule
@@ -263,7 +266,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
       assertThat(pay).hasSize(1)
       pay.map {
         assertThat(it.incentiveLevel).isEqualTo("Basic")
-        assertThat(it.prisonPayBand.id).isEqualTo(1)
+        assertThat(it.prisonPayBand).isEqualTo(testPayBand1)
         assertThat(it.rate).isEqualTo(125)
         assertThat(it.pieceRate).isEqualTo(150)
         assertThat(it.pieceRateItems).isEqualTo(1)
@@ -287,7 +290,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsMorning.allocatedPrisoner("A11111A")) {
-      assertThat(payBandId).isEqualTo(1)
+      assertThat(prisonPayBand).isEqualTo(testPayBand1)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -295,7 +298,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsMorning.allocatedPrisoner("A22222A")) {
-      assertThat(payBandId).isEqualTo(2)
+      assertThat(prisonPayBand).isEqualTo(testPayBand2)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")
@@ -313,7 +316,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsAfternoon.allocatedPrisoner("A11111A")) {
-      assertThat(payBandId).isEqualTo(3)
+      assertThat(prisonPayBand).isEqualTo(testPayBand3)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -321,7 +324,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsAfternoon.allocatedPrisoner("A22222A")) {
-      assertThat(payBandId).isEqualTo(3)
+      assertThat(prisonPayBand).isEqualTo(testPayBand3)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")
@@ -342,7 +345,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
       assertThat(tier).isEqualTo(ActivityTier(2, "T2", "Tier 2"))
       pay.map {
         assertThat(it.incentiveLevel).isEqualTo("Basic")
-        assertThat(it.prisonPayBand.id).isEqualTo(1)
+        assertThat(it.prisonPayBand).isEqualTo(testPayBand1)
         assertThat(it.rate).isEqualTo(75)
         assertThat(it.pieceRate).isEqualTo(0)
         assertThat(it.pieceRateItems).isEqualTo(0)
@@ -366,7 +369,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishMorning.allocatedPrisoner("B11111B")) {
-      assertThat(payBandId).isEqualTo(1)
+      assertThat(prisonPayBand).isEqualTo(testPayBand1)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -374,7 +377,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishMorning.allocatedPrisoner("B22222B")) {
-      assertThat(payBandId).isEqualTo(2)
+      assertThat(prisonPayBand).isEqualTo(testPayBand2)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")
@@ -393,7 +396,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishAfternoon.allocatedPrisoner("B11111B")) {
-      assertThat(payBandId).isEqualTo(3)
+      assertThat(prisonPayBand).isEqualTo(testPayBand3)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -401,7 +404,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishAfternoon.allocatedPrisoner("B22222B")) {
-      assertThat(payBandId).isEqualTo(3)
+      assertThat(prisonPayBand).isEqualTo(testPayBand3)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -5,9 +5,11 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand1
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import java.time.LocalDate
 import java.time.LocalDateTime
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
 
 class AllocationIntegrationTest : IntegrationTestBase() {
 
@@ -18,7 +20,7 @@ class AllocationIntegrationTest : IntegrationTestBase() {
   fun `get allocation by id`() {
     with(webTestClient.getAllocationBy(1)!!) {
       assertThat(prisonerNumber).isEqualTo("A11111A")
-      assertThat(payBandId).isEqualTo(1)
+      assertThat(prisonPayBand).isEqualTo(testPayBand1)
       assertThat(startDate).isEqualTo(java.time.LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -27,7 +29,7 @@ class AllocationIntegrationTest : IntegrationTestBase() {
 
     with(webTestClient.getAllocationBy(2)!!) {
       assertThat(prisonerNumber).isEqualTo("A22222A")
-      assertThat(payBandId).isEqualTo(2)
+      assertThat(prisonPayBand).isEqualTo(testPayBand2)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -6,10 +6,10 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand1
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import java.time.LocalDate
 import java.time.LocalDateTime
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
 
 class AllocationIntegrationTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand1
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandOne
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandTwo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -20,7 +20,7 @@ class AllocationIntegrationTest : IntegrationTestBase() {
   fun `get allocation by id`() {
     with(webTestClient.getAllocationBy(1)!!) {
       assertThat(prisonerNumber).isEqualTo("A11111A")
-      assertThat(prisonPayBand).isEqualTo(testPayBand1)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandOne)
       assertThat(startDate).isEqualTo(java.time.LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -29,7 +29,7 @@ class AllocationIntegrationTest : IntegrationTestBase() {
 
     with(webTestClient.getAllocationBy(2)!!) {
       assertThat(prisonerNumber).isEqualTo("A22222A")
-      assertThat(prisonPayBand).isEqualTo(testPayBand2)
+      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandTwo)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocatio
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
 import java.time.LocalDate
 import java.time.LocalDateTime
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
 
 class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
@@ -6,12 +6,12 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand1
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand3
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
 import java.time.LocalDate
 import java.time.LocalDateTime
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
 
 class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
@@ -5,6 +5,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand1
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand3
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
 import java.time.LocalDate
@@ -29,7 +31,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10001,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          payBandId = 1,
+          prisonPayBand = testPayBand1,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
@@ -41,7 +43,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10001,
           activitySummary = "Maths",
           scheduleDescription = "Maths PM",
-          payBandId = 3,
+          prisonPayBand = testPayBand3,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
@@ -58,7 +60,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10002,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          payBandId = 2,
+          prisonPayBand = testPayBand2,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
@@ -70,7 +72,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10002,
           activitySummary = "Maths",
           scheduleDescription = "Maths PM",
-          payBandId = 3,
+          prisonPayBand = testPayBand3,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
@@ -99,7 +101,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10001,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          payBandId = 1,
+          prisonPayBand = testPayBand1,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
@@ -111,7 +113,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10001,
           activitySummary = "Maths",
           scheduleDescription = "Maths PM",
-          payBandId = 3,
+          prisonPayBand = testPayBand3,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
@@ -128,7 +130,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10002,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          payBandId = 2,
+          prisonPayBand = testPayBand2,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
@@ -140,7 +142,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10002,
           activitySummary = "Maths",
           scheduleDescription = "Maths PM",
-          payBandId = 3,
+          prisonPayBand = testPayBand3,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
@@ -157,7 +159,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10003,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          payBandId = 2,
+          prisonPayBand = testPayBand2,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = LocalDate.of(2022, 10, 11),
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
@@ -5,9 +5,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand1
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand2
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPayBand3
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandOne
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandThree
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandTwo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
 import java.time.LocalDate
@@ -32,7 +32,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10001,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          prisonPayBand = testPayBand1,
+          prisonPayBand = testPentonvillePayBandOne,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
@@ -44,7 +44,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10001,
           activitySummary = "Maths",
           scheduleDescription = "Maths PM",
-          prisonPayBand = testPayBand3,
+          prisonPayBand = testPentonvillePayBandThree,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
@@ -61,7 +61,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10002,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          prisonPayBand = testPayBand2,
+          prisonPayBand = testPentonvillePayBandTwo,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
@@ -73,7 +73,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10002,
           activitySummary = "Maths",
           scheduleDescription = "Maths PM",
-          prisonPayBand = testPayBand3,
+          prisonPayBand = testPentonvillePayBandThree,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
@@ -102,7 +102,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10001,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          prisonPayBand = testPayBand1,
+          prisonPayBand = testPentonvillePayBandOne,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
@@ -114,7 +114,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10001,
           activitySummary = "Maths",
           scheduleDescription = "Maths PM",
-          prisonPayBand = testPayBand3,
+          prisonPayBand = testPentonvillePayBandThree,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
@@ -131,7 +131,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10002,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          prisonPayBand = testPayBand2,
+          prisonPayBand = testPentonvillePayBandTwo,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
@@ -143,7 +143,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10002,
           activitySummary = "Maths",
           scheduleDescription = "Maths PM",
-          prisonPayBand = testPayBand3,
+          prisonPayBand = testPentonvillePayBandThree,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
@@ -160,7 +160,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           bookingId = 10003,
           activitySummary = "Maths",
           scheduleDescription = "Maths AM",
-          prisonPayBand = testPayBand2,
+          prisonPayBand = testPentonvillePayBandTwo,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = LocalDate.of(2022, 10, 11),
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/testdata/IntegrationTestPayBands.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/testdata/IntegrationTestPayBands.kt
@@ -2,6 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.te
 
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonPayBand
 
-val testPayBand1 = PrisonPayBand(1, 1, "Pay band 1 (lowest)", "Pay band 1 (lowest)", 1, "PVI")
-val testPayBand2 = PrisonPayBand(2, 2, "Pay band 2", "Pay band 2", 2, "PVI")
-val testPayBand3 = PrisonPayBand(3, 3, "Pay band 3", "Pay band 3", 3, "PVI")
+val testPentonvillePayBandOne = PrisonPayBand(1, 1, "Pay band 1 (lowest)", "Pay band 1 (lowest)", 1, "PVI")
+val testPentonvillePayBandTwo = PrisonPayBand(2, 2, "Pay band 2", "Pay band 2", 2, "PVI")
+val testPentonvillePayBandThree = PrisonPayBand(3, 3, "Pay band 3", "Pay band 3", 3, "PVI")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/testdata/IntegrationTestPayBands.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/testdata/IntegrationTestPayBands.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata
+
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonPayBand
+
+val testPayBand1 = PrisonPayBand(1, 1, "Pay band 1 (lowest)", "Pay band 1 (lowest)", 1, "PVI")
+val testPayBand2 = PrisonPayBand(2, 2, "Pay band 2", "Pay band 2", 2, "PVI")
+val testPayBand3 = PrisonPayBand(3, 3, "Pay band 3", "Pay band 3", 3, "PVI")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -8,6 +8,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rollout
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RolloutPrison
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -76,7 +77,14 @@ class TransformFunctionsTest {
               id = -1,
               prisonerNumber = "A1234AA",
               bookingId = 10001,
-              payBandId = lowPayBand.prisonPayBandId,
+              prisonPayBand = PrisonPayBand(
+                id = lowPayBand.prisonPayBandId,
+                displaySequence = lowPayBand.displaySequence,
+                alias = lowPayBand.payBandAlias,
+                description = lowPayBand.payBandDescription,
+                prisonCode = lowPayBand.prisonCode,
+                nomisPayBand = lowPayBand.nomisPayBand
+              ),
               startDate = timestamp.toLocalDate(),
               endDate = null,
               allocatedTime = timestamp,


### PR DESCRIPTION
Expose the full pay bands over the API instead of just the ID. 

I've added the Pay Bands used by the integration tests into a single file as they need to match those in the DB seed file and, should that seed file change, the corresponding Pay Band expectations need only be changed in one place (as opposed to being scattered across the tests)