### PR TITLE
SAA-372: Make riskLevel a mandatory field on an activity

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -61,7 +61,7 @@ data class Activity(
 
   var endDate: LocalDate? = null,
 
-  var riskLevel: String? = null,
+  var riskLevel: String,
 
   var minimumIncentiveNomisCode: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Activity.kt
@@ -62,8 +62,8 @@ data class Activity(
   @JsonFormat(pattern = "dd/MM/yyyy")
   val endDate: LocalDate? = null,
 
-  @Schema(description = "The most recent risk assessment level for this activity", example = "High")
-  val riskLevel: String?,
+  @Schema(description = "The most recent risk assessment level for this activity", example = "high")
+  val riskLevel: String,
 
   @Schema(description = "The NOMIS code for the minimum incentive/earned privilege level for this activity", example = "BAS")
   val minimumIncentiveNomisCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityLite.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityLite.kt
@@ -36,8 +36,8 @@ data class ActivityLite(
   @Schema(description = "The category for this activity, one of the high-level categories")
   val category: ActivityCategory,
 
-  @Schema(description = "The most recent risk assessment level for this activity", example = "High")
-  val riskLevel: String?,
+  @Schema(description = "The most recent risk assessment level for this activity", example = "high")
+  val riskLevel: String,
 
   @Schema(description = "The NOMIS code for the minimum incentive/earned privilege level for this activity", example = "BAS")
   val minimumIncentiveNomisCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
@@ -55,8 +55,9 @@ data class ActivityCreateRequest(
   @Schema(description = "The list of pay rates that can apply to this activity")
   val pay: List<ActivityPayCreateRequest> = emptyList(),
 
+  @field:NotEmpty(message = "Risk level must be supplied")
   @field:Size(max = 10, message = "Risk level should not exceed {max} characters")
-  @Schema(description = "The most recent risk assessment level for this activity", example = "High")
+  @Schema(description = "The most recent risk assessment level for this activity", example = "high")
   val riskLevel: String?,
 
   @field:NotEmpty(message = "Minimum incentive level NOMIS code must be supplied")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -74,7 +74,7 @@ class ActivityService(
       description = request.description,
       startDate = request.startDate ?: LocalDate.now(),
       endDate = request.endDate,
-      riskLevel = request.riskLevel,
+      riskLevel = request.riskLevel!!,
       minimumIncentiveNomisCode = request.minimumIncentiveNomisCode!!,
       minimumIncentiveLevel = request.minimumIncentiveLevel!!,
       createdTime = LocalDateTime.now(),

--- a/src/main/resources/migration/common/V1__baseline.sql
+++ b/src/main/resources/migration/common/V1__baseline.sql
@@ -100,7 +100,7 @@ CREATE TABLE activity (
   description          varchar(300),
   start_date           date         NOT NULL,
   end_date             date,
-  risk_level           varchar(10),
+  risk_level           varchar(10)  NOT NULL,
   minimum_incentive_nomis_code varchar(3) NOT NULL,
   minimum_incentive_level      varchar(10) NOT NULL,
   created_time         timestamp    NOT NULL,

--- a/src/main/resources/migration/data/R__2_1__activities.sql
+++ b/src/main/resources/migration/data/R__2_1__activities.sql
@@ -1,7 +1,7 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths level 1', 'A basic maths course suitable for introduction to the subject', '2022-10-10', null, null, 'BAS', 'Basic', '2022-10-10 09:00:00', 'SEED USER'),
-       (2, 'MDI', 1, 1, true, false, false, false, 'H', 'English level 1', 'A basic english course suitable for introduction to the subject', '2022-10-10', null, null, 'BAS', 'Basic', '2022-10-10 09:00:00', 'SEED USER'),
-       (3, 'MDI', 3, 1, true, false, false, false, 'H', 'Wing cleaning', 'Cleaning and upkeep of the wing', '2022-10-10', null, null, 'BAS', 'Basic', '2022-10-10 09:00:00', 'SEED USER'),
-       (4, 'MDI', 4, 1, false, false, false, false, 'H', 'Gym', 'Time for exercise', '2022-10-10', null, null, 'BAS', 'Basic', '2022-10-10 09:00:00', 'SEED USER');
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths level 1', 'A basic maths course suitable for introduction to the subject', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-10-10 09:00:00', 'SEED USER'),
+       (2, 'MDI', 1, 1, true, false, false, false, 'H', 'English level 1', 'A basic english course suitable for introduction to the subject', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-10-10 09:00:00', 'SEED USER'),
+       (3, 'MDI', 3, 1, true, false, false, false, 'H', 'Wing cleaning', 'Cleaning and upkeep of the wing', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-10-10 09:00:00', 'SEED USER'),
+       (4, 'MDI', 4, 1, false, false, false, false, 'H', 'Gym', 'Time for exercise', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-10-10 09:00:00', 'SEED USER');
 
 alter sequence activity_activity_id_seq restart with 5

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -146,7 +146,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           prisonCode = "PVI",
           summary = "Maths",
           description = "Maths Level 1",
-          riskLevel = "High",
+          riskLevel = "high",
           minimumIncentiveNomisCode = "BAS",
           minimumIncentiveLevel = "Basic",
           category = ActivityCategory(
@@ -181,7 +181,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           payPerSession = PayPerSession.H,
           summary = "Maths",
           description = "Maths Level 1",
-          riskLevel = "High",
+          riskLevel = "high",
           minimumIncentiveNomisCode = "BAS",
           minimumIncentiveLevel = "Basic",
           category = ActivityCategory(
@@ -227,7 +227,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           prisonCode = "PVI",
           summary = "Maths",
           description = "Maths Level 1",
-          riskLevel = "High",
+          riskLevel = "high",
           minimumIncentiveNomisCode = "BAS",
           minimumIncentiveLevel = "Basic",
           category = ActivityCategory(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
@@ -34,7 +34,7 @@ class PrisonIntegrationTest : IntegrationTestBase() {
         payPerSession = PayPerSession.H,
         summary = "Maths",
         description = "Maths Level 1",
-        riskLevel = "High",
+        riskLevel = "high",
         minimumIncentiveNomisCode = "BAS",
         minimumIncentiveLevel = "Basic",
         category = ActivityCategory(
@@ -65,7 +65,7 @@ class PrisonIntegrationTest : IntegrationTestBase() {
         payPerSession = PayPerSession.H,
         summary = "Maths",
         description = "Maths Level 1",
-        riskLevel = "High",
+        riskLevel = "high",
         minimumIncentiveNomisCode = "BAS",
         minimumIncentiveLevel = "Basic",
         category = ActivityCategory(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
@@ -138,6 +138,7 @@ class ActivityControllerTest : ControllerTestBase<ActivityController>() {
             value(containsString("Activity summary must be supplied"))
             value(containsString("Minimum incentive level NOMIS code must be supplied"))
             value(containsString("Minimum incentive level must be supplied"))
+            value(containsString("Risk level must be supplied"))
           }
         }
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceFixture.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceFixture.kt
@@ -45,6 +45,7 @@ object ScheduledInstanceFixture {
         startDate = LocalDate.of(2022, 10, 1),
         minimumIncentiveNomisCode = "BAS",
         minimumIncentiveLevel = "Basic",
+        riskLevel = "high",
         createdTime = LocalDateTime.of(2022, 10, 1, 12, 0, 0),
         createdBy = "CREATED BY"
       ),

--- a/src/test/resources/__files/activity/activity-create-request-1.json
+++ b/src/test/resources/__files/activity/activity-create-request-1.json
@@ -8,6 +8,7 @@
   "eligibilityRuleIds": [1],
   "minimumIncentiveNomisCode": "BAS",
   "minimumIncentiveLevel": "Basic",
+  "riskLevel": "high",
   "pay": [
     {
       "incentiveNomisCode": "BAS",

--- a/src/test/resources/__files/activity/activity-create-request-2.json
+++ b/src/test/resources/__files/activity/activity-create-request-2.json
@@ -6,6 +6,7 @@
   "payPerSession": "H",
   "minimumIncentiveNomisCode": "BAS",
   "minimumIncentiveLevel": "Basic",
+  "riskLevel": "high",
   "pay": [
     {
       "incentiveNomisCode": "BAS",

--- a/src/test/resources/__files/activity/activity-create-request-invalid-1.json
+++ b/src/test/resources/__files/activity/activity-create-request-invalid-1.json
@@ -1,6 +1,7 @@
 {
   "attendanceRequired": false,
   "eligibilityRuleIds": [1],
+  "riskLevel": "high",
   "pay": [
     {
       "incentiveNomisCode": "BAS",

--- a/src/test/resources/__files/activity/activity-create-request-invalid-2.json
+++ b/src/test/resources/__files/activity/activity-create-request-invalid-2.json
@@ -6,6 +6,7 @@
   "categoryId": 1,
   "tierId": 1,
   "eligibilityRuleIds": [1],
+  "riskLevel": "high",
   "pay": [
     {
       "incentiveNomisCode": "BAS",

--- a/src/test/resources/__files/activity/activity-create-response-1.json
+++ b/src/test/resources/__files/activity/activity-create-response-1.json
@@ -66,6 +66,7 @@
   "endDate": null,
   "minimumIncentiveNomisCode": "BAS",
   "minimumIncentiveLevel": "Basic",
+  "riskLevel": "high",
   "createdTime": "16/12/2022 14:38",
   "createdBy": "activities-management-admin-1"
 }

--- a/src/test/resources/__files/activity/activity-entity-1.json
+++ b/src/test/resources/__files/activity/activity-entity-1.json
@@ -19,6 +19,7 @@
   "startDate": "2022-06-25",
   "minimumIncentiveNomisCode": "BAS",
   "minimumIncentiveLevel": "Basic",
+  "riskLevel": "high",
   "createdTime": "2022-06-26T14:38:00",
   "createdBy": "activities-management-admin-1"
 }

--- a/src/test/resources/test_data/seed-activity-id-1.sql
+++ b/src/test/resources/test_data/seed-activity-id-1.sql
@@ -1,5 +1,5 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'High', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-10.sql
+++ b/src/test/resources/test_data/seed-activity-id-10.sql
@@ -2,7 +2,7 @@
 -- One activity with one schedule, one slot and one instance but no allocations
 --
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (10, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, null, 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (10, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
 values (1, 10, 'Geography AM', 1, 'L1', 'Location MDI 1', 10, '2022-10-01');

--- a/src/test/resources/test_data/seed-activity-id-2.sql
+++ b/src/test/resources/test_data/seed-activity-id-2.sql
@@ -1,5 +1,5 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'PVI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, null, 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (2, 'PVI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (2, 2, 'BAS', 'Basic', 1, 75, 0, 0);

--- a/src/test/resources/test_data/seed-activity-id-3.sql
+++ b/src/test/resources/test_data/seed-activity-id-3.sql
@@ -1,14 +1,14 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, null, 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (1, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'MDI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-11-01', null, null, 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (2, 'MDI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-11-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (3, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, null, 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (3, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (4, 'PVI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, null, 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (4, 'PVI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 101, 0, 0);

--- a/src/test/resources/test_data/seed-activity-id-4.sql
+++ b/src/test/resources/test_data/seed-activity-id-4.sql
@@ -1,5 +1,5 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (4, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, null, 'BAS', 'Basic', current_timestamp, 'SEED USER');
+values (4, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', current_timestamp, 'SEED USER');
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
 values (1, 4, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date);

--- a/src/test/resources/test_data/seed-activity-id-5.sql
+++ b/src/test/resources/test_data/seed-activity-id-5.sql
@@ -1,5 +1,5 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (5, 'PVI', 1, 1, false, false, false, false, 'H', 'Gym', 'Gym induction', current_date, null, null, 'BAS', 'Basic', current_timestamp, 'SEED USER');
+values (5, 'PVI', 1, 1, false, false, false, false, 'H', 'Gym', 'Gym induction', current_date, null, 'high', 'BAS', 'Basic', current_timestamp, 'SEED USER');
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
 values (1, 5, 'Gym induction AM', 1, 'L1', 'Location 1', 10, current_date);

--- a/src/test/resources/test_data/seed-activity-id-6.sql
+++ b/src/test/resources/test_data/seed-activity-id-6.sql
@@ -1,5 +1,5 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, null, 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-7.sql
+++ b/src/test/resources/test_data/seed-activity-id-7.sql
@@ -1,5 +1,5 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, null, 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-8.sql
+++ b/src/test/resources/test_data/seed-activity-id-8.sql
@@ -1,5 +1,5 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, true, true, true, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'High', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+values (1, 'PVI', 1, 1, true, true, true, true, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-9.sql
+++ b/src/test/resources/test_data/seed-activity-id-9.sql
@@ -1,6 +1,5 @@
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (9, 'MDI', 1, 1, true, true, true, true, 'H', 'Maths', 'Maths Level 1', current_date, null, 'High', 'BAS', 'Basic', current_timestamp, 'SEED USER');
+values (9, 'MDI', 1, 1, true, true, true, true, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', current_timestamp, 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 9, 'BAS', 'Basic', 1, 125, 150, 1);
-


### PR DESCRIPTION
- `riskLevel` is mandatory
- Updated seeded data to reflect
- Frontend already supports this
- Syscon need not be informed