### PR TITLE
SAA-348: Date and time should not be in the past

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/CaseLoad.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/CaseLoad.kt
@@ -29,12 +29,13 @@ data class CaseLoad(
 ) {
   /**
    * Type of case load. Note: Reference Code CSLD_TYPE
-   * Values: COMM,INST,APP
+   * Values: COMM,INST,APP,DUMMY
    */
   enum class Type(val value: String) {
     @JsonProperty("COMM") COMM("COMM"),
     @JsonProperty("INST") INST("INST"),
-    @JsonProperty("APP") APP("APP")
+    @JsonProperty("APP") APP("APP"),
+    @JsonProperty("DUMMY") DUMMY("DUMMY")
   }
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentCreateRequest.kt
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 @Schema(
@@ -96,6 +97,9 @@ data class AppointmentCreateRequest(
 ) {
   @AssertTrue(message = "Internal location id must be supplied if in cell = false")
   private fun isInternalLocationId() = inCell || internalLocationId != null
+
+  @AssertTrue(message = "Start time must be in the future")
+  private fun isStartTime() = startDate == null || startTime == null || LocalDateTime.of(startDate, startTime) > LocalDateTime.now()
 
   @AssertTrue(message = "End time must be after the start time")
   private fun isEndTime() = startTime == null || endTime == null || endTime > startTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentCreateRequest.kt
@@ -99,7 +99,7 @@ data class AppointmentCreateRequest(
   private fun isInternalLocationId() = inCell || internalLocationId != null
 
   @AssertTrue(message = "Start time must be in the future")
-  private fun isStartTime() = startDate == null || startTime == null || LocalDateTime.of(startDate, startTime) > LocalDateTime.now()
+  private fun isStartTime() = startDate == null || startTime == null || startDate < LocalDate.now() || LocalDateTime.of(startDate, startTime) > LocalDateTime.now()
 
   @AssertTrue(message = "End time must be after the start time")
   private fun isEndTime() = startTime == null || endTime == null || endTime > startTime

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentCreateRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentCreateRequestTest.kt
@@ -61,6 +61,12 @@ class AppointmentCreateRequestTest {
   }
 
   @Test
+  fun `start time must be in the future`() {
+    val request = appointmentCreateRequest(startDate = LocalDate.now(), startTime = LocalTime.now().minusMinutes(1), endTime = LocalTime.now().plusHours(1))
+    assertSingleValidationError(validator.validate(request), "startTime", "Start time must be in the future")
+  }
+
+  @Test
   fun `end time must be supplied`() {
     val request = appointmentCreateRequest(endTime = null)
     assertSingleValidationError(validator.validate(request), "endTime", "End time must be supplied")


### PR DESCRIPTION
Prevents the creation of appointments where the start date and time are in the past. Previously the code would allow same day appointments that started earlier than the current time.