### PR TITLE
SAA-401 adding new seeded activity category to support allocating prisoners to unemployed activities e.g. retired.

### DIFF
--- a/src/main/resources/migration/data/R__1_2__activity_categories.sql
+++ b/src/main/resources/migration/data/R__1_2__activity_categories.sql
@@ -5,6 +5,7 @@ values (1, 'SAA_EDUCATION', 'Education', 'Such as classes in English, maths, con
        (4, 'SAA_GYM_SPORTS_FITNESS', 'Gym, sport and fitness', 'Such as sport clubs, like football, fitness classes and gym sessions'),
        (5, 'SAA_INDUCTION', 'Induction', 'Such as gym induction, education assessments, health and safety workshops'),
        (6, 'SAA_INTERVENTIONS', 'Intervention programmes', 'Such as programmes for behaviour management, drug and alcohol misuse and community rehabilitation'),
-       (7, 'SAA_LEISURE_SOCIAL', 'Leisure and social', 'Such as association, library time and social clubs, like music or art');
+       (7, 'SAA_LEISURE_SOCIAL', 'Leisure and social', 'Such as association, library time and social clubs, like music or art'),
+       (8, 'SAA_UNEMPLOYMENT', 'Not in work', 'Such as unemployed, retired, long-term sick, or on remand');
 
-alter sequence activity_category_activity_category_id_seq restart with 8;
+alter sequence activity_category_activity_category_id_seq restart with 9;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityCategoryIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityCategoryIntegrationTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.tes
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.industriesCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.interventionsCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.leisureAndSocialCategory
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.notInWorkCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.servicesCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCategory
 
@@ -24,7 +25,8 @@ class ActivityCategoryIntegrationTest : IntegrationTestBase() {
       gymSportsFitnessCategory,
       inductionCategory,
       interventionsCategory,
-      leisureAndSocialCategory
+      leisureAndSocialCategory,
+      notInWorkCategory
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/testdata/IntegrationTestActivityCategories.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/testdata/IntegrationTestActivityCategories.kt
@@ -9,3 +9,4 @@ val gymSportsFitnessCategory = ActivityCategory(id = 4, code = "SAA_GYM_SPORTS_F
 val inductionCategory = ActivityCategory(id = 5, code = "SAA_INDUCTION", name = "Induction", description = "Such as gym induction, education assessments, health and safety workshops")
 val interventionsCategory = ActivityCategory(id = 6, code = "SAA_INTERVENTIONS", name = "Intervention programmes", description = "Such as programmes for behaviour management, drug and alcohol misuse and community rehabilitation")
 val leisureAndSocialCategory = ActivityCategory(id = 7, code = "SAA_LEISURE_SOCIAL", name = "Leisure and social", description = "Such as association, library time and social clubs, like music or art")
+val notInWorkCategory = ActivityCategory(id = 8, code = "SAA_UNEMPLOYMENT", name = "Not in work", description = "Such as unemployed, retired, long-term sick, or on remand")

--- a/src/test/resources/test_data/seed-reference-data.sql
+++ b/src/test/resources/test_data/seed-reference-data.sql
@@ -12,7 +12,8 @@ values (1, 'SAA_EDUCATION', 'Education', 'Such as classes in English, maths, con
        (4, 'SAA_GYM_SPORTS_FITNESS', 'Gym, sport and fitness', 'Such as sport clubs, like football, fitness classes and gym sessions'),
        (5, 'SAA_INDUCTION', 'Induction', 'Such as gym induction, education assessments, health and safety workshops'),
        (6, 'SAA_INTERVENTIONS', 'Intervention programmes', 'Such as programmes for behaviour management, drug and alcohol misuse and community rehabilitation'),
-       (7, 'SAA_LEISURE_SOCIAL', 'Leisure and social', 'Such as association, library time and social clubs, like music or art');
+       (7, 'SAA_LEISURE_SOCIAL', 'Leisure and social', 'Such as association, library time and social clubs, like music or art'),
+       (8, 'SAA_UNEMPLOYMENT', 'Not in work', 'Such as unemployed, retired, long-term sick, or on remand');
 
 --
 -- Tiers


### PR DESCRIPTION
**REQUIRES DB TO BE DROPPED PRIOR TO MERGE**

This will display as follows on activity creation in the frontend:

![image](https://user-images.githubusercontent.com/60104344/221544936-7455c9b0-1e49-45ec-a7ee-4d250f19fe02.png)
