### PR TITLE
SAA-417 ensure both attendance creation and capacities take deallocated offenders into account.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -187,8 +187,6 @@ data class ActivitySchedule(
     slots.add(slot)
   }
 
-  fun getActiveAllocationsOnDate(date: LocalDate): List<Allocation> = this.allocations.filter { it.isActive(date) }
-
   fun allocatePrisoner(
     prisonerNumber: PrisonerNumber,
     payBand: PrisonPayBand,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -187,9 +187,7 @@ data class ActivitySchedule(
     slots.add(slot)
   }
 
-  fun getAllocationsOnDate(date: LocalDate): List<Allocation> = this.allocations.filter {
-    !date.isBefore(it.startDate) && (it.endDate == null || !date.isAfter(it.endDate))
-  }
+  fun getActiveAllocationsOnDate(date: LocalDate): List<Allocation> = this.allocations.filter { it.isActive(date) }
 
   fun allocatePrisoner(
     prisonerNumber: PrisonerNumber,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -11,7 +11,6 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.between
 import java.time.LocalDate
 import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation as ModelAllocation
@@ -65,8 +64,6 @@ data class Allocation(
   @Enumerated(EnumType.STRING)
   var prisonerStatus: PrisonerStatus = PrisonerStatus.ACTIVE
     private set
-
-  fun isActive(date: LocalDate) = date.between(startDate, endDate) && status(PrisonerStatus.ENDED).not()
 
   private fun activitySummary() = activitySchedule.activity.summary
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -66,7 +66,7 @@ data class Allocation(
   var prisonerStatus: PrisonerStatus = PrisonerStatus.ACTIVE
     private set
 
-  fun isActive(date: LocalDate) = date.between(startDate, endDate)
+  fun isActive(date: LocalDate) = date.between(startDate, endDate) && status(PrisonerStatus.ENDED).not()
 
   private fun activitySummary() = activitySchedule.activity.summary
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toPrisonerNumber
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ScheduledInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.PrisonerAllocationRequest
@@ -39,7 +40,8 @@ class ActivityScheduleService(
     date: LocalDate,
     timeSlot: TimeSlot?,
   ): List<InternalLocation> =
-    transformFilteredInstances(schedulesMatching(prisonCode, date, timeSlot)).mapNotNull { it.internalLocation }.distinct()
+    transformFilteredInstances(schedulesMatching(prisonCode, date, timeSlot)).mapNotNull { it.internalLocation }
+      .distinct()
 
   fun getActivitySchedulesByPrisonCode(
     prisonCode: String,
@@ -74,11 +76,9 @@ class ActivityScheduleService(
     filter { it.isRunningOn(date) && (timeSlot == null || it.timeSlot() == timeSlot) }
 
   fun getAllocationsBy(scheduleId: Long, activeOnly: Boolean = true) =
-    LocalDate.now().let { today ->
-      repository.findOrThrowNotFound(scheduleId).allocations()
-        .filter { !activeOnly || it.isActive(today) }
-        .toModelAllocations()
-    }
+    repository.findOrThrowNotFound(scheduleId).allocations()
+      .filter { !activeOnly || it.status(PrisonerStatus.ACTIVE) }
+      .toModelAllocations()
 
   fun getScheduleById(scheduleId: Long) = repository.findOrThrowNotFound(scheduleId).toModelSchedule()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
@@ -1,20 +1,18 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonerAllocations
-import java.time.LocalDate
 
 @Service
 class AllocationsService(private val allocationRepository: AllocationRepository) {
   fun findByPrisonCodeAndPrisonerNumbers(prisonCode: String, prisonNumbers: Set<String>, activeOnly: Boolean = true) =
-    LocalDate.now().let { today ->
-      allocationRepository
-        .findByPrisonCodeAndPrisonerNumbers(prisonCode, prisonNumbers.toList())
-        .filter { !activeOnly || it.isActive(today) }
-        .toModelPrisonerAllocations()
-    }
+    allocationRepository
+      .findByPrisonCodeAndPrisonerNumbers(prisonCode, prisonNumbers.toList())
+      .filter { !activeOnly || it.status(PrisonerStatus.ACTIVE) }
+      .toModelPrisonerAllocations()
 
   fun getAllocationById(id: Long) = allocationRepository.findOrThrowNotFound(id).toModel()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Attendance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceStatus
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ScheduledInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AttendanceUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceReasonRepository
@@ -59,7 +60,7 @@ class AttendancesService(
     scheduledInstanceRepository.findAllBySessionDate(date)
       .andAttendanceRequired()
       .forEach { instance ->
-        instance.forEachActiveAllocation(date) { allocation ->
+        instance.forEachActiveAllocation { allocation ->
           createAttendanceRecordIfNoPreExistingRecord(
             instance,
             allocation,
@@ -70,8 +71,8 @@ class AttendancesService(
 
   private fun List<ScheduledInstance>.andAttendanceRequired() = filter { it.attendanceRequired() }
 
-  private fun ScheduledInstance.forEachActiveAllocation(date: LocalDate, f: (allocation: Allocation) -> Unit) {
-    activitySchedule.allocations().filter { it.isActive(date) }.forEach { f(it) }
+  private fun ScheduledInstance.forEachActiveAllocation(f: (allocation: Allocation) -> Unit) {
+    activitySchedule.allocations().filter { it.status(PrisonerStatus.ACTIVE) }.forEach { f(it) }
   }
 
   // TODO not applying pay rates.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CapacityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CapacityService.kt
@@ -4,12 +4,12 @@ import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.CapacityAndAllocated
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
-import java.time.LocalDate
 
 @Service
 class CapacityService(
@@ -58,6 +58,6 @@ class CapacityService(
   }
 
   private fun ActivitySchedule.getAllocationsForToday(): List<Allocation> {
-    return this.getActiveAllocationsOnDate(LocalDate.now())
+    return this.allocations().filter { it.status(PrisonerStatus.ACTIVE) || it.status(PrisonerStatus.SUSPENDED) }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CapacityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CapacityService.kt
@@ -58,6 +58,6 @@ class CapacityService(
   }
 
   private fun ActivitySchedule.getAllocationsForToday(): List<Allocation> {
-    return this.getAllocationsOnDate(LocalDate.now())
+    return this.getActiveAllocationsOnDate(LocalDate.now())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -27,34 +27,6 @@ class ActivityScheduleTest {
   private val tomorrow = today.plusDays(1)
 
   @Test
-  fun `get allocations for date`() {
-    val schedule = activitySchedule(activity = activityEntity(), noAllocations = true).apply {
-      allocatePrisoner(
-        prisonerNumber = "A1234AA".toPrisonerNumber(),
-        startDate = LocalDate.of(2022, 12, 1),
-        payBand = lowPayBand,
-        bookingId = 1,
-        allocatedBy = "FAKE USER",
-      )
-
-      allocatePrisoner(
-        prisonerNumber = "A1234AB".toPrisonerNumber(),
-        startDate = LocalDate.of(2022, 11, 10),
-        endDate = LocalDate.of(2022, 11, 30),
-        payBand = lowPayBand,
-        bookingId = 2,
-        allocatedBy = "FAKE USER",
-      )
-    }
-
-    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2022-10-01"))).isEmpty()
-    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2022-11-10"))[0].bookingId).isEqualTo(2)
-    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2022-11-30"))[0].bookingId).isEqualTo(2)
-    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2022-12-01"))[0].bookingId).isEqualTo(1)
-    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2025-01-01"))[0].bookingId).isEqualTo(1)
-  }
-
-  @Test
   fun `converted to model lite`() {
     val expectedModel = ActivityScheduleLite(
       id = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -47,11 +47,11 @@ class ActivityScheduleTest {
       )
     }
 
-    assertThat(schedule.getAllocationsOnDate(LocalDate.parse("2022-10-01"))).isEmpty()
-    assertThat(schedule.getAllocationsOnDate(LocalDate.parse("2022-11-10"))[0].bookingId).isEqualTo(2)
-    assertThat(schedule.getAllocationsOnDate(LocalDate.parse("2022-11-30"))[0].bookingId).isEqualTo(2)
-    assertThat(schedule.getAllocationsOnDate(LocalDate.parse("2022-12-01"))[0].bookingId).isEqualTo(1)
-    assertThat(schedule.getAllocationsOnDate(LocalDate.parse("2025-01-01"))[0].bookingId).isEqualTo(1)
+    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2022-10-01"))).isEmpty()
+    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2022-11-10"))[0].bookingId).isEqualTo(2)
+    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2022-11-30"))[0].bookingId).isEqualTo(2)
+    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2022-12-01"))[0].bookingId).isEqualTo(1)
+    assertThat(schedule.getActiveAllocationsOnDate(LocalDate.parse("2025-01-01"))[0].bookingId).isEqualTo(1)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -3,52 +3,15 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.lowPayBand
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.mediumPayBand
 import java.time.LocalDate
 import java.time.LocalDateTime
 
 class AllocationTest {
 
-  private val schedule: ActivitySchedule = mock()
   private val today = LocalDate.now()
   private val yesterday = today.minusDays(1)
   private val tomorrow = today.plusDays(1)
-
-  private val allocationWithNoEndDate = Allocation(
-    activitySchedule = schedule,
-    prisonerNumber = "1234567890",
-    startDate = today,
-    allocatedBy = "FAKE USER",
-    allocatedTime = LocalDateTime.now(),
-    payBand = lowPayBand,
-  )
-
-  private val allocationWithEndDate = allocationWithNoEndDate.copy(endDate = tomorrow, payBand = mediumPayBand)
-
-  @Test
-  fun `check allocation active status that starts today with open end date`() {
-    with(allocationWithNoEndDate) {
-      assertThat(isActive(yesterday)).isFalse
-      assertThat(isActive(today)).isTrue
-      assertThat(isActive(tomorrow)).isTrue
-      assertThat(isActive(tomorrow.plusDays(1000))).isTrue
-      assertThat(payBand.payBandAlias).isEqualTo("Low")
-    }
-  }
-
-  @Test
-  fun `check allocation active status that starts today and ends tomorrow`() {
-    with(allocationWithEndDate) {
-      assertThat(isActive(yesterday)).isFalse
-      assertThat(isActive(today)).isTrue
-      assertThat(isActive(tomorrow)).isTrue
-      assertThat(isActive(tomorrow.plusDays(1))).isFalse
-      assertThat(payBand.payBandAlias).isEqualTo("Medium")
-    }
-  }
 
   @Test
   fun `check allocation ends`() {
@@ -74,25 +37,26 @@ class AllocationTest {
   @Test
   fun `check can deallocate active allocation`() {
     val dateTime = LocalDateTime.now()
+    val allocation = allocation()
 
-    assertThat(allocationWithEndDate.status(PrisonerStatus.ACTIVE)).isTrue
-    assertThat(allocationWithEndDate.deallocatedReason).isNull()
-    assertThat(allocationWithEndDate.deallocatedBy).isNull()
-    assertThat(allocationWithEndDate.deallocatedTime).isNull()
+    assertThat(allocation.status(PrisonerStatus.ACTIVE)).isTrue
+    assertThat(allocation.deallocatedReason).isNull()
+    assertThat(allocation.deallocatedBy).isNull()
+    assertThat(allocation.deallocatedTime).isNull()
 
-    allocationWithEndDate.deallocate(dateTime)
+    allocation.deallocate(dateTime)
 
-    assertThat(allocationWithEndDate.status(PrisonerStatus.ENDED)).isTrue
-    assertThat(allocationWithEndDate.deallocatedReason).isEqualTo("Allocation end date reached")
-    assertThat(allocationWithEndDate.deallocatedBy).isEqualTo("SYSTEM")
-    assertThat(allocationWithEndDate.deallocatedTime).isEqualTo(dateTime)
+    assertThat(allocation.status(PrisonerStatus.ENDED)).isTrue
+    assertThat(allocation.deallocatedReason).isEqualTo("Allocation end date reached")
+    assertThat(allocation.deallocatedBy).isEqualTo("SYSTEM")
+    assertThat(allocation.deallocatedTime).isEqualTo(dateTime)
   }
 
   @Test
   fun `check cannot deallocate if allocation already ended`() {
-    allocationWithEndDate.deallocate(LocalDateTime.now())
+    val allocation = allocation().apply { deallocate(LocalDateTime.now()) }
 
-    assertThatThrownBy { allocationWithEndDate.deallocate(LocalDateTime.now()) }
+    assertThatThrownBy { allocation.deallocate(LocalDateTime.now()) }
       .isInstanceOf(IllegalStateException::class.java)
       .hasMessage("Allocation with ID '-1' is already deallocated.")
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/CreateAttendanceRecordsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/CreateAttendanceRecordsJobIntegrationTest.kt
@@ -34,7 +34,7 @@ class CreateAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
       }
 
       with(schedules().findByDescription("Maths PM")) {
-        assertThat(allocations()).hasSize(3)
+        assertThat(allocations()).hasSize(2)
         assertThat(instances()).hasSize(1)
         assertThat(instances().first().attendances).isEmpty()
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Acti
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonPayBandRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelAllocations
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.Optional
 
 class ActivityScheduleServiceTest {
@@ -38,23 +39,9 @@ class ActivityScheduleServiceTest {
   }
 
   @Test
-  fun `future allocations for a given schedule are not returned`() {
-    val schedule = schedule().apply {
-      allocations().first().startDate = LocalDate.now().plusDays(1)
-    }
-
-    whenever(repository.findById(1)).thenReturn(Optional.of(schedule))
-
-    assertThat(service.getAllocationsBy(1)).isEmpty()
-  }
-
-  @Test
   fun `ended allocations for a given schedule are not returned`() {
     val schedule = schedule().apply {
-      allocations().first().apply {
-        startDate = LocalDate.now().minusDays(10)
-        endDate = LocalDate.now().minusDays(9)
-      }
+      allocations().first().apply { deallocate(LocalDateTime.now()) }
     }
 
     whenever(repository.findById(1)).thenReturn(Optional.of(schedule))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesServiceTest.kt
@@ -6,6 +6,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Attendance
@@ -47,6 +48,18 @@ class AttendancesServiceTest {
         status = AttendanceStatus.SCHEDULED,
       ),
     )
+  }
+
+  @Test
+  fun `attendance record is not created when allocation is inactive `() {
+    instance.activitySchedule.activity.attendanceRequired = true
+    allocation.deallocate(today.atStartOfDay())
+
+    whenever(scheduledInstanceRepository.findAllBySessionDate(today)).thenReturn(listOf(instance))
+
+    service.createAttendanceRecordsFor(today)
+
+    verifyNoInteractions(attendanceRepository)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesServiceTest.kt
@@ -34,7 +34,7 @@ class AttendancesServiceTest {
   private val tomorrow = today.plusDays(1)
 
   @Test
-  fun `attendance record is created when no pre-existing attendance record and attendance is required`() {
+  fun `attendance record is created when no pre-existing attendance record, attendance is required and allocation active`() {
     instance.activitySchedule.activity.attendanceRequired = true
 
     whenever(scheduledInstanceRepository.findAllBySessionDate(today)).thenReturn(listOf(instance))
@@ -51,7 +51,7 @@ class AttendancesServiceTest {
   }
 
   @Test
-  fun `attendance record is not created when allocation is inactive `() {
+  fun `attendance record is not created when allocation is not active`() {
     instance.activitySchedule.activity.attendanceRequired = true
     allocation.deallocate(today.atStartOfDay())
 
@@ -85,18 +85,6 @@ class AttendancesServiceTest {
 
     service.createAttendanceRecordsFor(today)
 
-    verify(attendanceRepository, never()).save(any())
-  }
-
-  @Test
-  fun `attendance record is not created today if allocation is active from tomorrow`() {
-    allocation.starts(tomorrow)
-
-    whenever(scheduledInstanceRepository.findAllBySessionDate(today)).thenReturn(listOf(instance))
-
-    service.createAttendanceRecordsFor(today)
-
-    verify(attendanceRepository, never()).existsAttendanceByScheduledInstanceAndPrisonerNumber(any(), any())
     verify(attendanceRepository, never()).save(any())
   }
 

--- a/src/test/resources/test_data/seed-activity-id-1.sql
+++ b/src/test/resources/test_data/seed-activity-id-1.sql
@@ -29,7 +29,7 @@ insert into allocation(allocation_id, activity_schedule_id, prisoner_number, boo
 values (2, 1, 'A22222A', 10002, 2, '2022-10-10', null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (3, 1, 'A33333A', 10003, 2, '2022-10-10', '2022-10-11', '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (3, 1, 'A33333A', 10003, 2, '2022-10-10', '2022-10-11', '2022-10-10 09:00:00', 'MRS BLOGS', '2022-10-11 09:00:00', 'SYSTEM', 'Allocation end data reached', null, null, null, 'ENDED');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (4, 2, 'A11111A', 10001, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');

--- a/src/test/resources/test_data/seed-activity-id-4.sql
+++ b/src/test/resources/test_data/seed-activity-id-4.sql
@@ -25,9 +25,6 @@ values (3, 2, 'A33333A', 10003, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'M
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (4, 2, 'A44444A', 10004, 4, '2022-10-10', null, '2022-10-10 10:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
-insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (5, 2, 'A22223A', 1023, 4, current_date + 1, null, current_timestamp, 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
-
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
 values (1, current_date, '10:00:00', '11:00:00', false, null, null, null, null);
 

--- a/src/test/resources/test_data/seed-activity-id-6.sql
+++ b/src/test/resources/test_data/seed-activity-id-6.sql
@@ -23,7 +23,7 @@ insert into allocation(allocation_id, activity_schedule_id, prisoner_number, boo
 values (2, 1, 'A22222A', 10002, 2, '2022-10-10', null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (3, 1, 'A33333A', 10003, 2, '2022-10-10', '2022-10-11', '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (3, 1, 'A33333A', 10003, 2, '2022-10-10', '2022-10-11', '2022-10-10 09:00:00', 'MRS BLOGS', '2022-10-11 09:00:00', 'SYSTEM', 'Allocation end data reached', null, null, null, 'ENDED');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (4, 2, 'A11111A', 10001, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');


### PR DESCRIPTION
Changes to attendance record creation and capacity calculations on the back of introducing a status field to allocations.

Having a status field on allocations removes the need to check the dates on them.

The status field will be managed going forwards to determine an allocations status.