### PR TITLE
SAA-420: Cancel schedule instance

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -78,6 +78,8 @@ data class Allocation(
     deallocatedTime = dateTime
   }
 
+  fun isAllocated() = deallocatedTime == null
+
   fun status(status: PrisonerStatus) = prisonerStatus == status
 
   fun toModel() =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -58,6 +58,25 @@ data class Attendance(
   override fun toString(): String {
     return this::class.simpleName + "(attendanceId = $attendanceId )"
   }
+
+  fun cancel(reason: AttendanceReason, payIncentiveCode: String?) {
+    status = AttendanceStatus.COMPLETED
+    payAmount = if (payIncentiveCode != null) getPay(payIncentiveCode)?.rate ?: 0 else 0
+    attendanceReason = reason
+    comment = scheduledInstance.cancelledReason
+    recordedTime = scheduledInstance.cancelledTime
+    recordedBy = scheduledInstance.cancelledBy
+  }
+
+  private fun getPay(incentiveCode: String): ActivityPay? {
+    val currentAllocation = scheduledInstance.activitySchedule.allocations()
+      .filter { it.isAllocated() }
+      .find { it.prisonerNumber == prisonerNumber }
+
+    return scheduledInstance.activitySchedule.activity.activityPay()
+      .filter { it.payBand.prisonPayBandId == currentAllocation?.payBand?.prisonPayBandId }
+      .find { it.incentiveNomisCode == incentiveCode }
+  }
 }
 
 enum class AttendanceStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
@@ -75,6 +75,7 @@ data class ScheduledInstance(
     cancelled = this.cancelled,
     cancelledTime = this.cancelledTime,
     cancelledBy = this.cancelledBy,
+    cancelledReason = this.cancelledReason,
     attendances = this.attendances.map { attendance -> transform(attendance) },
   )
 
@@ -83,6 +84,20 @@ data class ScheduledInstance(
   fun timeSlot() = TimeSlot.slot(startTime)
 
   fun attendanceRequired() = activitySchedule.activity.attendanceRequired
+
+  fun cancelSession(reason: String, by: String, cancelComment: String?, f: (List<Attendance>) -> Unit) {
+    if (cancelled) throw IllegalArgumentException("The schedule instance has already been cancelled")
+
+    val today = LocalDateTime.now().withNano(0)
+    if (sessionDate < today.toLocalDate()) throw IllegalArgumentException("The schedule instance has ended")
+
+    cancelled = true
+    cancelledReason = reason
+    cancelledTime = today
+    cancelledBy = by
+    comment = cancelComment
+    if (attendances.isNotEmpty()) f(attendances)
+  }
 }
 
 fun List<ScheduledInstance>.toModel() = map { it.toModel() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleInstance.kt
@@ -34,6 +34,9 @@ data class ActivityScheduleInstance(
   @Schema(description = "The person who cancelled this scheduled instance (or null if not cancelled)", example = "Adam Smith")
   val cancelledBy: String? = null,
 
+  @Schema(description = "The reason this scheduled instance was cancelled", example = "Staff unavailable")
+  val cancelledReason: String? = null,
+
   @Schema(description = "The list of attendees")
   val attendances: List<Attendance>,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ScheduleInstanceCancelRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ScheduleInstanceCancelRequest.kt
@@ -1,0 +1,20 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+import jakarta.validation.constraints.NotEmpty
+import jakarta.validation.constraints.Size
+
+@Schema(description = "Request object for cancelling a schedule instance")
+data class ScheduleInstanceCancelRequest(
+  @field:NotEmpty(message = "Cancellation reason must be supplied")
+  @field:Size(max = 100, message = "Cancellation reason must not exceed {max} characters")
+  @Schema(description = "The reason for cancelling the schedule instance", example = "No tutor available")
+  val reason: String,
+
+  @field:NotEmpty(message = "Username must be supplied")
+  @Schema(description = "The username of the user cancelling the schedule instance", example = "RJ56DDE")
+  val username: String,
+
+  @Schema(description = "A field for any additional comments", example = "Resume tomorrow")
+  val comment: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceReasonRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceReasonRepository.kt
@@ -3,4 +3,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceReason
 
-interface AttendanceReasonRepository : JpaRepository<AttendanceReason, Long>
+interface AttendanceReasonRepository : JpaRepository<AttendanceReason, Long> {
+  fun findByCode(code: String): AttendanceReason
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledInstanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledInstanceController.kt
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses
 import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Attendance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ScheduleInstanceCancelRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.UncancelScheduledInstanceRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AttendancesService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ScheduledInstanceService
@@ -210,4 +212,50 @@ class ScheduledInstanceController(
   ) {
     scheduledInstanceService.uncancelScheduledInstance(instanceId)
   }
+
+  @PutMapping(value = ["/{instanceId}/cancel"])
+  @ResponseBody
+  @Operation(
+    summary = "Cancel a scheduled instance",
+    description = "Cancels scheduled instance and associated attendance records",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "204",
+        description = "Scheduled instance successfully cancelled",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The scheduled instance was not found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun cancelScheduledInstance(
+    @PathVariable("instanceId")
+    instanceId: Long,
+    @Valid
+    @RequestBody
+    @Parameter(
+      description = "The scheduled instance cancellation request",
+      required = true,
+    )
+    scheduleInstanceCancelRequest: ScheduleInstanceCancelRequest,
+  ): ResponseEntity<Any> = scheduledInstanceService.cancelScheduledInstance(instanceId, scheduleInstanceCancelRequest).let { ResponseEntity.noContent().build() }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
@@ -1,15 +1,22 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.toModel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleInstance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ScheduleInstanceCancelRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceReasonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ScheduledInstanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
 
 @Service
-class ScheduledInstanceService(private val repository: ScheduledInstanceRepository) {
+class ScheduledInstanceService(
+  private val repository: ScheduledInstanceRepository,
+  private val attendanceReasonRepository: AttendanceReasonRepository,
+  private val prisonerSearchApiClient: PrisonerSearchApiClient,
+) {
   fun getActivityScheduleInstanceById(id: Long): ActivityScheduleInstance =
     repository.findOrThrowNotFound(id).toModel()
 
@@ -35,5 +42,26 @@ class ScheduledInstanceService(private val repository: ScheduledInstanceReposito
     val scheduledInstance = repository.findOrThrowNotFound(id)
     scheduledInstance.uncancel()
     repository.save(scheduledInstance)
+  }
+
+  fun cancelScheduledInstance(instanceId: Long, scheduleInstanceCancelRequest: ScheduleInstanceCancelRequest) {
+    val scheduledInstance = repository.findOrThrowNotFound(instanceId)
+
+    scheduledInstance.cancelSession(
+      reason = scheduleInstanceCancelRequest.reason,
+      by = scheduleInstanceCancelRequest.username,
+      cancelComment = scheduleInstanceCancelRequest.comment,
+    ) { attendanceList ->
+      val attendanceReason = attendanceReasonRepository.findByCode("CANC")
+      val prisonerNumbers = scheduledInstance.attendances.map { it.prisonerNumber }
+      val prisoners = prisonerSearchApiClient.findByPrisonerNumbers(prisonerNumbers).block()?.associateBy { it.prisonerNumber }
+
+      attendanceList.forEach {
+        val payIncentiveCode = prisoners?.get(it.prisonerNumber)?.currentIncentive?.level?.code
+        it.cancel(attendanceReason, payIncentiveCode)
+      }
+    }
+
+    repository.saveAndFlush(scheduledInstance)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
@@ -3,9 +3,16 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.attendanceReasons
 import java.time.LocalDateTime
 
 class AttendanceTest {
+  private val activity = activityEntity()
+  private val activitySchedule = activity.schedules().first()
+  private val instance = activitySchedule.instances().first()
+  private val attendance = instance.attendances.first()
+  private val today = LocalDateTime.now()
 
   @Test
   fun `waiting method sets the state correctly`() {
@@ -28,5 +35,20 @@ class AttendanceTest {
       assertThat(recordedBy).isNull()
       assertThat(recordedTime).isNull()
     }
+  }
+
+  @Test
+  fun `can cancel attendance`() {
+    val attendanceReason = attendanceReasons()["CANC"]!!
+    val canceledInstance = instance.copy(cancelledBy = "USER1", cancelledTime = today, cancelledReason = "Staff unavailable")
+    val attendanceWithCanceledInstance = attendance.copy(scheduledInstance = canceledInstance)
+
+    attendanceWithCanceledInstance.cancel(attendanceReason, "BAS")
+    assertThat(attendanceWithCanceledInstance.status).isEqualTo(AttendanceStatus.COMPLETED)
+    assertThat(attendanceWithCanceledInstance.payAmount).isEqualTo(30)
+    assertThat(attendanceWithCanceledInstance.attendanceReason).isEqualTo(attendanceReason)
+    assertThat(attendanceWithCanceledInstance.comment).isEqualTo("Staff unavailable")
+    assertThat(attendanceWithCanceledInstance.recordedTime).isEqualTo(today)
+    assertThat(attendanceWithCanceledInstance.recordedBy).isEqualTo("USER1")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -176,7 +176,7 @@ internal fun activitySchedule(
           Attendance(
             attendanceId = 1,
             scheduledInstance = this,
-            prisonerNumber = "A11111A",
+            prisonerNumber = "A1234AA",
           ),
         )
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleInstanceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleInstanceIntegrationTest.kt
@@ -7,10 +7,14 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.CurrentIncentive
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.IncentiveLevel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleInstance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ScheduleInstanceCancelRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.UncancelScheduledInstanceRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSearchPrisonerFixture
 import java.time.LocalDate
 
 class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
@@ -101,7 +105,7 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
       val response = webTestClient.uncancelScheduledInstance(1, "CAN1234", "Mr Cancel")
       response.expectStatus().isNoContent
 
-      with(webTestClient.getScheduledInstanceById(1)) {
+      with(webTestClient.getScheduledInstanceById(1)!!) {
         assertThat(cancelled).isFalse
         assertThat(cancelledBy).isNull()
 
@@ -137,12 +141,85 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
     }
   }
 
-  private fun WebTestClient.uncancelScheduledInstance(id: Long, username: String, displayName: String) = put()
-    .uri("/scheduled-instances/$id/uncancel")
-    .bodyValue(UncancelScheduledInstanceRequest(username, displayName))
-    .accept(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisation(roles = listOf()))
-    .exchange()
+  @Nested
+  @DisplayName("cancelScheduledInstance")
+  inner class CancelScheduledInstance {
+    @Test
+    @Sql("classpath:test_data/seed-activity-id-16.sql")
+    fun success() {
+      prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
+        listOf("A11111A", "A22222A"),
+        listOf(
+          PrisonerSearchPrisonerFixture.instance(
+            prisonerNumber = "A11111A",
+            bookingId = 456,
+            prisonId = "TPR",
+            currentIncentive = CurrentIncentive(
+              level = IncentiveLevel(
+                description = "Basic",
+                code = "BAS",
+              ),
+              dateTime = LocalDate.now().toString(),
+              nextReviewDate = LocalDate.now(),
+            ),
+          ),
+          PrisonerSearchPrisonerFixture.instance(
+            prisonerNumber = "A22222A",
+            bookingId = 456,
+            prisonId = "TPR",
+            currentIncentive = CurrentIncentive(
+              level = IncentiveLevel(
+                description = "Basic",
+                code = "BAS",
+              ),
+              dateTime = LocalDate.now().toString(),
+              nextReviewDate = LocalDate.now(),
+            ),
+          ),
+        ),
+      )
+
+      webTestClient.cancelScheduledInstance(1, "Location unavailable", "USER1")
+
+      with(webTestClient.getScheduledInstanceById(1)!!) {
+        assertThat(cancelled).isTrue
+        assertThat(cancelledBy).isEqualTo("USER1")
+
+        with(attendances.first()) {
+          assertThat(attendanceReason!!.code).isEqualTo("CANC")
+          assertThat(status).isEqualTo("COMPLETED")
+          assertThat(comment).isEqualTo("Location unavailable")
+          assertThat(recordedBy).isEqualTo("USER1")
+          assertThat(recordedTime).isNotNull
+        }
+      }
+    }
+
+    @Test
+    @Sql("classpath:test_data/seed-activity-id-16.sql")
+    fun `404 - scheduled instance not found`() {
+      val response = webTestClient.cancelScheduledInstance(4, "Location unavailable", "USER1")
+      response.expectStatus().isNotFound
+    }
+
+    @Test
+    @Sql("classpath:test_data/seed-activity-id-16.sql")
+    fun `400 - scheduled instance in past`() {
+      val response = webTestClient.cancelScheduledInstance(2, "Location unavailable", "USER1")
+      response
+        .expectStatus().isBadRequest
+        .expectBody().jsonPath("developerMessage").isEqualTo("The schedule instance has ended")
+    }
+
+    @Test
+    @Sql("classpath:test_data/seed-activity-id-16.sql")
+    fun `400 - scheduled instance has been canceled`() {
+      val response = webTestClient.cancelScheduledInstance(3, "Location unavailable", "USER1")
+      response
+        .expectStatus().isBadRequest
+        .expectBody().jsonPath("developerMessage").isEqualTo("The schedule instance has already been cancelled")
+    }
+  }
 
   private fun WebTestClient.getScheduledInstanceById(id: Long) = get()
     .uri("/scheduled-instances/$id")
@@ -153,6 +230,20 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
     .expectBody(ActivityScheduleInstance::class.java)
     .returnResult().responseBody
+
+  private fun WebTestClient.uncancelScheduledInstance(id: Long, username: String, displayName: String) = put()
+    .uri("/scheduled-instances/$id/uncancel")
+    .bodyValue(UncancelScheduledInstanceRequest(username, displayName))
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(roles = listOf()))
+    .exchange()
+
+  private fun WebTestClient.cancelScheduledInstance(id: Long, reason: String, username: String, comment: String? = null) = put()
+    .uri("/scheduled-instances/$id/cancel")
+    .bodyValue(ScheduleInstanceCancelRequest(reason, username, comment))
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisation(roles = listOf()))
+    .exchange()
 
   private fun WebTestClient.getScheduledInstancesBy(
     prisonCode: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleInstanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleInstanceTest.kt
@@ -28,6 +28,7 @@ class ActivityScheduleInstanceTest : ModelTest() {
       endTime = originalEndTime,
       cancelled = true,
       cancelledTime = originalCancelledTime,
+      cancelledReason = "Staff unavailable",
       attendances = emptyList(),
       activitySchedule = ActivityScheduleLite(
         id = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AttendanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AttendanceTest.kt
@@ -17,7 +17,6 @@ class AttendanceTest : ModelTest() {
       prisonerNumber = "1234",
       recordedTime = originalRecordedTime,
       status = "Y",
-
     )
 
     val json = objectMapper.writeValueAsString(attendance)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesServiceTest.kt
@@ -24,14 +24,17 @@ class AttendancesServiceTest {
   private val attendanceRepository: AttendanceRepository = mock()
   private val attendanceReasonRepository: AttendanceReasonRepository = mock()
   private val service =
-    AttendancesService(scheduledInstanceRepository, attendanceRepository, attendanceReasonRepository)
+    AttendancesService(
+      scheduledInstanceRepository,
+      attendanceRepository,
+      attendanceReasonRepository,
+    )
   private val activity = activityEntity()
   private val activitySchedule = activity.schedules().first()
   private val allocation = activitySchedule.allocations().first()
   private val instance = activitySchedule.instances().first()
   private val attendance = instance.attendances.first()
   private val today = LocalDate.now()
-  private val tomorrow = today.plusDays(1)
 
   @Test
   fun `attendance record is created when no pre-existing attendance record, attendance is required and allocation active`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSearchPrisonerFixture.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSearchPrisonerFixture.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.CurrentIncentive
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.IncentiveLevel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
 import java.time.LocalDate
 
@@ -24,6 +26,11 @@ object PrisonerSearchPrisonerFixture {
     middleNames: String = "James",
     prisonId: String? = "MDI",
     cellLocation: String? = "1-2-3",
+    currentIncentive: CurrentIncentive? = CurrentIncentive(
+      level = IncentiveLevel("Basic", "BAS"),
+      dateTime = "2020-07-20T10:36:53",
+      nextReviewDate = LocalDate.of(2021, 7, 20),
+    ),
   ) =
     Prisoner(
       prisonerNumber = prisonerNumber,
@@ -45,5 +52,6 @@ object PrisonerSearchPrisonerFixture {
       middleNames = middleNames,
       prisonId = prisonId,
       cellLocation = cellLocation,
+      currentIncentive = currentIncentive,
     )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -73,7 +73,7 @@ class TransformFunctionsTest {
               attendances = listOf(
                 ModelAttendance(
                   id = 1,
-                  prisonerNumber = "A11111A",
+                  prisonerNumber = "A1234AA",
                   status = "SCHEDULED",
                 ),
               ),

--- a/src/test/resources/test_data/seed-activity-id-16.sql
+++ b/src/test/resources/test_data/seed-activity-id-16.sql
@@ -37,8 +37,17 @@ values (4, 2, 'A11111A', 10001, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'M
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (5, 2, 'A22222A', 10002, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
-insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
-values (1, now(), '10:00:00', '11:00:00', true, now(), 'Old Canceller', 'Nobody Available', null);
+insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, 1, now()::date, '10:00:00', '11:00:00', false, null, null, null, null);
+
+insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (2, 2, '2022-10-10', '14:00:00', '15:00:00', false, null, null, null, null);
+
+insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (3, 2, now()::date, '14:00:00', '15:00:00', true, now(), 'USER1', 'Location unavailable', null);
 
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, posted, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
-values (1, 1, 'A22222A', 1, 'Attendance Comment', null, now(), 'Old Recorder', 'WAIT', 150, null, null);
+values (1, 1, 'A11111A', null, null, false, null, null, 'WAIT', null, null, null);
+
+insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (2, 1, 'A22222A', null, null, null, null, 'WAIT', null, null, null);


### PR DESCRIPTION
## Overview

Adds cancel scheduled instance endpoint, `/scheduled-instances/{instanceId}/cancel`

Calling this endpoint will cancel the schedule instance, and update the status and pay of any associated attendance records.