### PR TITLE
SAA-490 get scheduled events in parallel using Kotlin coroutines

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -30,6 +30,7 @@ dependencies {
   implementation("org.springframework.boot:spring-boot-starter-webflux")
   implementation("org.springframework.boot:spring-boot-starter-data-jpa")
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:2.0.0-beta-13")
+  implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
   // OpenAPI
   implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisona
 
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
+import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.util.UriBuilder
 import reactor.core.publisher.Mono
@@ -48,6 +49,18 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .bodyToMono(typeReference<List<PrisonApiScheduledEvent>>())
   }
 
+  suspend fun getScheduledActivitiesAsync(bookingId: Long, dateRange: LocalDateRange): List<PrisonApiScheduledEvent> =
+    prisonApiWebClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/bookings/{bookingId}/activities")
+          .queryParam("fromDate", dateRange.start)
+          .queryParam("toDate", dateRange.endInclusive)
+          .build(bookingId)
+      }
+      .retrieve()
+      .awaitBody()
+
   fun getScheduledAppointments(bookingId: Long, dateRange: LocalDateRange): Mono<List<PrisonApiScheduledEvent>> {
     return prisonApiWebClient.get()
       .uri { uriBuilder: UriBuilder ->
@@ -59,6 +72,19 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       }
       .retrieve()
       .bodyToMono(typeReference<List<PrisonApiScheduledEvent>>())
+  }
+
+  suspend fun getScheduledAppointmentsAsync(bookingId: Long, dateRange: LocalDateRange): List<PrisonApiScheduledEvent> {
+    return prisonApiWebClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/bookings/{bookingId}/appointments")
+          .queryParam("fromDate", dateRange.start)
+          .queryParam("toDate", dateRange.endInclusive)
+          .build(bookingId)
+      }
+      .retrieve()
+      .awaitBody()
   }
 
   fun getScheduledAppointmentsForPrisonerNumbers(
@@ -93,6 +119,18 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .bodyToMono(typeReference<CourtHearings>())
   }
 
+  suspend fun getScheduledCourtHearingsAsync(bookingId: Long, dateRange: LocalDateRange): CourtHearings =
+    prisonApiWebClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/bookings/{bookingId}/court-hearings")
+          .queryParam("fromDate", dateRange.start)
+          .queryParam("toDate", dateRange.endInclusive)
+          .build(bookingId)
+      }
+      .retrieve()
+      .awaitBody()
+
   fun getScheduledCourtEventsForPrisonerNumbers(
     prisonCode: String,
     prisonerNumbers: Set<String>,
@@ -112,6 +150,24 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .bodyToMono(typeReference<List<PrisonerSchedule>>())
   }
 
+  suspend fun getScheduledCourtEventsForPrisonerNumbersAsync(
+    prisonCode: String,
+    prisonerNumbers: Set<String>,
+    date: LocalDate?,
+    timeSlot: TimeSlot?,
+  ): List<PrisonerSchedule> =
+    prisonApiWebClient.post()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/schedules/{prisonCode}/courtEvents")
+          .maybeQueryParam("date", date)
+          .maybeQueryParam("timeSlot", timeSlot)
+          .build(prisonCode)
+      }
+      .bodyValue(prisonerNumbers)
+      .retrieve()
+      .awaitBody()
+
   fun getScheduledVisits(bookingId: Long, dateRange: LocalDateRange): Mono<List<PrisonApiScheduledEvent>> {
     return prisonApiWebClient.get()
       .uri { uriBuilder: UriBuilder ->
@@ -124,6 +180,18 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .bodyToMono(typeReference<List<PrisonApiScheduledEvent>>())
   }
+
+  suspend fun getScheduledVisitsAsync(bookingId: Long, dateRange: LocalDateRange): List<PrisonApiScheduledEvent> =
+    prisonApiWebClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/bookings/{bookingId}/visits")
+          .queryParam("fromDate", dateRange.start)
+          .queryParam("toDate", dateRange.endInclusive)
+          .build(bookingId)
+      }
+      .retrieve()
+      .awaitBody()
 
   fun getScheduledVisitsForPrisonerNumbers(
     prisonCode: String,
@@ -144,6 +212,24 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .bodyToMono(typeReference<List<PrisonerSchedule>>())
   }
 
+  suspend fun getScheduledVisitsForPrisonerNumbersAsync(
+    prisonCode: String,
+    prisonerNumbers: Set<String>,
+    date: LocalDate?,
+    timeSlot: TimeSlot?,
+  ): List<PrisonerSchedule> =
+    prisonApiWebClient.post()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/schedules/{prisonCode}/visits")
+          .maybeQueryParam("date", date)
+          .maybeQueryParam("timeSlot", timeSlot)
+          .build(prisonCode)
+      }
+      .bodyValue(prisonerNumbers)
+      .retrieve()
+      .awaitBody()
+
   fun getScheduledActivitiesForPrisonerNumbers(
     prisonCode: String,
     prisonerNumbers: Set<String>,
@@ -162,6 +248,24 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .bodyToMono(typeReference<List<PrisonerSchedule>>())
 
+  suspend fun getScheduledActivitiesForPrisonerNumbersAsync(
+    prisonCode: String,
+    prisonerNumbers: Set<String>,
+    date: LocalDate?,
+    timeSlot: TimeSlot?,
+  ): List<PrisonerSchedule> =
+    prisonApiWebClient.post()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/schedules/{prisonCode}/activities")
+          .maybeQueryParam("date", date)
+          .maybeQueryParam("timeSlot", timeSlot)
+          .build(prisonCode)
+      }
+      .bodyValue(prisonerNumbers)
+      .retrieve()
+      .awaitBody()
+
   fun getExternalTransfersOnDate(
     agencyId: String,
     prisonerNumbers: Set<String>,
@@ -178,26 +282,21 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .bodyToMono(typeReference<List<PrisonerSchedule>>())
 
-  /*
-  Will possibly re-introduce this method if we ever need to get ALL activities in a prison from NOMIS.
-  At present, we only get these for either a prisoner, or a list of prisoners.
-
-  fun getScheduledActivitiesForDateRange(
-    prisonCode: String,
-    dateRange: LocalDateRange,
-  ): Mono<List<PrisonerSchedule>> {
-    return prisonApiWebClient.get()
+  suspend fun getExternalTransfersOnDateAsync(
+    agencyId: String,
+    prisonerNumbers: Set<String>,
+    date: LocalDate,
+  ): List<PrisonerSchedule> =
+    prisonApiWebClient.post()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/api/schedules/{prisonCode}/activities-by-date-range")
-          .queryParam("fromDate", dateRange.start)
-          .queryParam("toDate", dateRange.endInclusive)
-          .build(prisonCode)
+          .path("/api/schedules/{agencyId}/externalTransfers")
+          .queryParam("date", date)
+          .build(agencyId)
       }
+      .bodyValue(prisonerNumbers)
       .retrieve()
-      .bodyToMono(typeReference<List<PrisonerSchedule>>())
-  }
-   */
+      .awaitBody()
 
   fun getLocationsForType(agencyId: String, locationType: String): Mono<List<Location>> {
     return prisonApiWebClient.get()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisona
 
 import org.springframework.core.ParameterizedTypeReference
 import org.springframework.stereotype.Service
-import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.util.UriBuilder
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.CourtHearings

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -36,6 +36,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .bodyToMono(typeReference<InmateDetail>())
   }
 
+  // TODO: Replaced by async version below
   fun getScheduledActivities(bookingId: Long, dateRange: LocalDateRange): Mono<List<PrisonApiScheduledEvent>> {
     return prisonApiWebClient.get()
       .uri { uriBuilder: UriBuilder ->
@@ -74,6 +75,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .bodyToMono(typeReference<List<PrisonApiScheduledEvent>>())
   }
 
+  // TODO: Alter appointment switch to use async version
   suspend fun getScheduledAppointmentsAsync(bookingId: Long, dateRange: LocalDateRange): List<PrisonApiScheduledEvent> {
     return prisonApiWebClient.get()
       .uri { uriBuilder: UriBuilder ->
@@ -106,6 +108,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .bodyToMono(typeReference<List<PrisonerSchedule>>())
   }
 
+  // TODO: Replaced by async version below
   fun getScheduledCourtHearings(bookingId: Long, dateRange: LocalDateRange): Mono<CourtHearings> {
     return prisonApiWebClient.get()
       .uri { uriBuilder: UriBuilder ->
@@ -131,6 +134,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .awaitBody()
 
+  // TODO: Replaced by async version below
   fun getScheduledCourtEventsForPrisonerNumbers(
     prisonCode: String,
     prisonerNumbers: Set<String>,
@@ -168,6 +172,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .awaitBody()
 
+  // TODO: Replaced by async version below
   fun getScheduledVisits(bookingId: Long, dateRange: LocalDateRange): Mono<List<PrisonApiScheduledEvent>> {
     return prisonApiWebClient.get()
       .uri { uriBuilder: UriBuilder ->
@@ -193,6 +198,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .awaitBody()
 
+  // TODO: Replaced by async version below
   fun getScheduledVisitsForPrisonerNumbers(
     prisonCode: String,
     prisonerNumbers: Set<String>,
@@ -230,6 +236,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .awaitBody()
 
+  // TODO: Replaced by async version below
   fun getScheduledActivitiesForPrisonerNumbers(
     prisonCode: String,
     prisonerNumbers: Set<String>,
@@ -266,6 +273,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .awaitBody()
 
+  // TODO: Replaced by async version below
   fun getExternalTransfersOnDate(
     agencyId: String,
     prisonerNumbers: Set<String>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/api/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/api/PrisonerSearchApiClient.kt
@@ -19,7 +19,6 @@ class PrisonerSearchApiClient(private val prisonerSearchApiWebClient: WebClient)
       .bodyToMono(typeReference<List<Prisoner>>())
   }
 
-  // Not used (yet)
   suspend fun findByPrisonerNumbersAsync(prisonerNumbers: List<String>): List<Prisoner> =
     prisonerSearchApiWebClient.post()
       .uri("/prisoner-search/prisoner-numbers")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/api/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/api/PrisonerSearchApiClient.kt
@@ -19,6 +19,7 @@ class PrisonerSearchApiClient(private val prisonerSearchApiWebClient: WebClient)
       .bodyToMono(typeReference<List<Prisoner>>())
   }
 
+  // Not used (yet)
   suspend fun findByPrisonerNumbersAsync(prisonerNumbers: List<String>): List<Prisoner> =
     prisonerSearchApiWebClient.post()
       .uri("/prisoner-search/prisoner-numbers")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/api/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/api/PrisonerSearchApiClient.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisone
 
 import org.springframework.stereotype.Service
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.awaitBody
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.typeReference
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
@@ -9,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 
 @Service
 class PrisonerSearchApiClient(private val prisonerSearchApiWebClient: WebClient) {
+
   fun findByPrisonerNumbers(prisonerNumbers: List<String>): Mono<List<Prisoner>> {
     return prisonerSearchApiWebClient.post()
       .uri("/prisoner-search/prisoner-numbers")
@@ -16,4 +18,11 @@ class PrisonerSearchApiClient(private val prisonerSearchApiWebClient: WebClient)
       .retrieve()
       .bodyToMono(typeReference<List<Prisoner>>())
   }
+
+  suspend fun findByPrisonerNumbersAsync(prisonerNumbers: List<String>): List<Prisoner> =
+    prisonerSearchApiWebClient.post()
+      .uri("/prisoner-search/prisoner-numbers")
+      .bodyValue(PrisonerNumbers(prisonerNumbers))
+      .retrieve()
+      .awaitBody()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
@@ -77,7 +77,7 @@ class ScheduledEventController(private val scheduledEventService: ScheduledEvent
       ),
     ],
   )
-  suspend fun getScheduledEventsByPrisonAndPrisonerAndDateRange(
+  fun getScheduledEventsByPrisonAndPrisonerAndDateRange(
     @PathVariable("prisonCode")
     @Parameter(description = "The 3-digit prison code.")
     prisonCode: String,
@@ -157,7 +157,7 @@ class ScheduledEventController(private val scheduledEventService: ScheduledEvent
       ),
     ],
   )
-  suspend fun getScheduledEventsByPrisonAndPrisonersAndDateRange(
+  fun getScheduledEventsByPrisonAndPrisonersAndDateRange(
     @PathVariable("prisonCode")
     @Parameter(description = "The 3-character prison code.")
     prisonCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
@@ -77,7 +77,7 @@ class ScheduledEventController(private val scheduledEventService: ScheduledEvent
       ),
     ],
   )
-  fun getScheduledEventsByPrisonAndPrisonerAndDateRange(
+  suspend fun getScheduledEventsByPrisonAndPrisonerAndDateRange(
     @PathVariable("prisonCode")
     @Parameter(description = "The 3-digit prison code.")
     prisonCode: String,
@@ -157,7 +157,7 @@ class ScheduledEventController(private val scheduledEventService: ScheduledEvent
       ),
     ],
   )
-  fun getScheduledEventsByPrisonAndPrisonersAndDateRange(
+  suspend fun getScheduledEventsByPrisonAndPrisonersAndDateRange(
     @PathVariable("prisonCode")
     @Parameter(description = "The 3-character prison code.")
     prisonCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
@@ -1,6 +1,9 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
 import jakarta.persistence.EntityNotFoundException
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.runBlocking
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.CourtHearings
@@ -19,9 +22,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.prisonApiP
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.prisonApiScheduledEventToScheduledEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transformPrisonerScheduledActivityToScheduledEvents
 import java.time.LocalDate
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.runBlocking
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.ScheduledEvent as PrisonApiScheduledEvent
 
 @Service
@@ -146,8 +146,7 @@ class ScheduledEventService(
     val activities = async {
       if (prisonRolledOut.active) {
         emptyList()
-      }
-      else {
+      } else {
         prisonApiClient.getScheduledActivitiesAsync(prisoner.first, dateRange)
       }
     }
@@ -161,7 +160,7 @@ class ScheduledEventService(
       courtHearings.await(),
       visits.await(),
       activities.await(),
-      transfers.await()
+      transfers.await(),
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
@@ -69,13 +69,13 @@ class ScheduledEventService(
             setOf(prisonerNumber),
             dateRange.start,
             dateRange.endInclusive,
-            schedules.appointments.prisonApiScheduledEventToScheduledEvents(  // Can create a separate transform if required
+            schedules.appointments.prisonApiScheduledEventToScheduledEvents(
               prisonerNumber,
               EventType.APPOINTMENT.name,
               EventType.APPOINTMENT.defaultPriority,
               eventPriorities[EventType.APPOINTMENT],
             ),
-            schedules.courtHearings.prisonApiCourtHearingsToScheduledEvents(  // Can create a separate transform if required
+            schedules.courtHearings.prisonApiCourtHearingsToScheduledEvents(
               bookingId,
               prisonCode,
               prisonerNumber,
@@ -83,19 +83,19 @@ class ScheduledEventService(
               EventType.COURT_HEARING.defaultPriority,
               eventPriorities[EventType.COURT_HEARING],
             ),
-            schedules.visits.prisonApiScheduledEventToScheduledEvents(  // Can create a separate transform if required
+            schedules.visits.prisonApiScheduledEventToScheduledEvents(
               prisonerNumber,
               EventType.VISIT.name,
               EventType.VISIT.defaultPriority,
               eventPriorities[EventType.VISIT],
             ),
-            schedules.activities.prisonApiScheduledEventToScheduledEvents(  // Can create a separate transform if required
+            schedules.activities.prisonApiScheduledEventToScheduledEvents(
               prisonerNumber,
               EventType.ACTIVITY.name,
               EventType.ACTIVITY.defaultPriority,
               eventPriorities[EventType.ACTIVITY],
             ),
-            schedules.transfers.prisonApiPrisonerScheduleToScheduledEvents(  // Can create a separate transform if required
+            schedules.transfers.prisonApiPrisonerScheduleToScheduledEvents(
               prisonCode,
               EventType.EXTERNAL_TRANSFER.name,
               EventType.EXTERNAL_TRANSFER.defaultPriority,
@@ -144,10 +144,12 @@ class ScheduledEventService(
     }
 
     val activities = async {
-      if (prisonRolledOut.active) emptyList() else prisonApiClient.getScheduledActivitiesAsync(
-        prisoner.first,
-        dateRange
-      )
+      if (prisonRolledOut.active) {
+        emptyList()
+      }
+      else {
+        prisonApiClient.getScheduledActivitiesAsync(prisoner.first, dateRange)
+      }
     }
 
     val transfers = async {
@@ -274,7 +276,6 @@ class ScheduledEventService(
     date: LocalDate,
     timeSlot: TimeSlot?,
   ): MultiPrisonerSchedules = coroutineScope {
-
     val appointments = async {
       appointmentInstanceService.getPrisonerSchedules(
         rolloutPrison.code,
@@ -351,11 +352,11 @@ class ScheduledEventService(
     prisonCode: String,
     prisonerNumbers: Set<String>,
   ) = if (date == LocalDate.now()) {
-      prisonApiClient.getExternalTransfersOnDateAsync(prisonCode, prisonerNumbers, date)
-        .map { transfers -> transfers.redacted() }
-    } else {
-      emptyList()
-    }
+    prisonApiClient.getExternalTransfersOnDateAsync(prisonCode, prisonerNumbers, date)
+      .map { transfers -> transfers.redacted() }
+  } else {
+    emptyList()
+  }
 
   private fun PrisonerSchedule.redacted() = this.copy(
     comment = null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api
 
+import kotlinx.coroutines.runBlocking
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterAll
@@ -14,7 +15,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDat
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.wiremock.PrisonApiMockServer
 import java.time.LocalDate
-import kotlinx.coroutines.runBlocking
 
 class PrisonApiClientTest {
 
@@ -126,8 +126,8 @@ class PrisonApiClientTest {
         prisonApiClient.getScheduledActivitiesAsync(bookingId, dateRange)
       }
     }
-    .isInstanceOf(WebClientResponseException::class.java)
-    .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/activities?fromDate=2022-10-01&toDate=2022-11-05")
+      .isInstanceOf(WebClientResponseException::class.java)
+      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/activities?fromDate=2022-10-01&toDate=2022-11-05")
   }
 
   @Test
@@ -344,6 +344,5 @@ class PrisonApiClientTest {
     val externalTransfers = prisonApiClient.getExternalTransfersOnDateAsync(prisonCode, prisonerNumbers, date)
     assertThat(externalTransfers).hasSize(1)
     assertThat(externalTransfers.first().offenderNo).isEqualTo("B4793VX")
-
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
@@ -103,7 +104,7 @@ class PrisonApiClientTest {
   }
 
   @Test
-  fun `getScheduledActivities - success`(): Unit = runBlocking {
+  fun `getScheduledActivitiesAsync - success`(): Unit = runBlocking {
     val bookingId = 10001L
     val dateRange = LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
 
@@ -115,23 +116,31 @@ class PrisonApiClientTest {
   }
 
   @Test
-  fun `getScheduledActivities - not found`() {
+  fun `getScheduledActivities (currently unused) - success`() {
+    val bookingId = 10001L
+    val dateRange = LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
+
+    prisonApiMockServer.stubGetScheduledActivities(bookingId, dateRange.start, dateRange.endInclusive)
+
+    val scheduledActivities = prisonApiClient.getScheduledActivities(bookingId, dateRange).block()!!
+    assertThat(scheduledActivities).hasSize(2)
+    assertThat(scheduledActivities.first().bookingId).isEqualTo(10001L)
+  }
+
+  @Test
+  fun `getScheduledActivitiesAsync - not found`(): Unit = runBlocking {
     val bookingId = 0L
     val dateRange = LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
 
     prisonApiMockServer.stubGetScheduledActivitiesNotFound(bookingId, dateRange.start, dateRange.endInclusive)
 
-    assertThatThrownBy {
-      runBlocking {
-        prisonApiClient.getScheduledActivitiesAsync(bookingId, dateRange)
-      }
-    }
-      .isInstanceOf(WebClientResponseException::class.java)
-      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/activities?fromDate=2022-10-01&toDate=2022-11-05")
+    assertThrows<WebClientResponseException>(
+      "404 Not Found from GET http://localhost:8999/api/bookings/0/activities?fromDate=2022-10-01&toDate=2022-11-05",
+    ) { prisonApiClient.getScheduledActivitiesAsync(bookingId, dateRange) }
   }
 
   @Test
-  fun `getScheduledActivitiesForPrisonerNumbers - success`(): Unit = runBlocking {
+  fun `getScheduledActivitiesForPrisonerNumbersAsync - success`(): Unit = runBlocking {
     val prisonCode = "MDI"
     val prisonerNumbers = setOf("G4793VF", "A5193DY")
     val date = LocalDate.of(2022, 12, 14)
@@ -144,37 +153,56 @@ class PrisonApiClientTest {
   }
 
   @Test
-  fun `getCourtHearings by booking id - success`() {
+  fun `getScheduledActivitiesForPrisonerNumbers (currently unused) - success`() {
+    val prisonCode = "MDI"
+    val prisonerNumbers = setOf("G4793VF", "A5193DY")
+    val date = LocalDate.of(2022, 12, 14)
+
+    prisonApiMockServer.stubGetScheduledActivitiesForPrisonerNumbers(prisonCode, date)
+
+    val activities = prisonApiClient.getScheduledActivitiesForPrisonerNumbers(prisonCode, prisonerNumbers, date, null).block()!!
+    assertThat(activities).hasSize(2)
+    assertThat(activities.first().offenderNo).isIn("G4793VF", "A5193DY")
+  }
+
+  @Test
+  fun `getCourtHearingsAsync by booking id - success`(): Unit = runBlocking {
     val bookingId = 10001L
     val dateRange = LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
 
     prisonApiMockServer.stubGetCourtHearings(bookingId, dateRange.start, dateRange.endInclusive)
 
-    runBlocking {
-      val courtHearings = prisonApiClient.getScheduledCourtHearingsAsync(bookingId, dateRange)
-      assertThat(courtHearings.hearings).hasSize(4)
-      assertThat(courtHearings.hearings?.first()?.id).isEqualTo(1L)
-    }
+    val courtHearings = prisonApiClient.getScheduledCourtHearingsAsync(bookingId, dateRange)
+    assertThat(courtHearings.hearings).hasSize(4)
+    assertThat(courtHearings.hearings?.first()?.id).isEqualTo(1L)
   }
 
   @Test
-  fun `getCourtHearings by booking id - not found`() {
+  fun `getCourtHearings by booking id (currently unused) - success`() {
+    val bookingId = 10001L
+    val dateRange = LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
+
+    prisonApiMockServer.stubGetCourtHearings(bookingId, dateRange.start, dateRange.endInclusive)
+
+    val courtHearings = prisonApiClient.getScheduledCourtHearings(bookingId, dateRange).block()!!
+    assertThat(courtHearings.hearings).hasSize(4)
+    assertThat(courtHearings.hearings?.first()?.id).isEqualTo(1L)
+  }
+
+  @Test
+  fun `getCourtHearingsAsync by booking id - not found`(): Unit = runBlocking {
     val bookingId = 0L
     val dateRange = LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
 
     prisonApiMockServer.stubGetCourtHearingsNotFound(bookingId, dateRange.start, dateRange.endInclusive)
 
-    assertThatThrownBy {
-      runBlocking {
-        prisonApiClient.getScheduledCourtHearingsAsync(bookingId, dateRange)
-      }
-    }
-      .isInstanceOf(WebClientResponseException::class.java)
-      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/court-hearings?fromDate=2022-10-01&toDate=2022-11-05")
+    assertThrows<WebClientResponseException>(
+      "404 Not Found from GET http://localhost:8999/api/bookings/0/court-hearings?fromDate=2022-10-01&toDate=2022-11-05",
+    ) { prisonApiClient.getScheduledCourtHearingsAsync(bookingId, dateRange) }
   }
 
   @Test
-  fun `getCourtEventsForPrisonerNumbers - success`(): Unit = runBlocking {
+  fun `getCourtEventsForPrisonerNumbersAsync - success`(): Unit = runBlocking {
     val prisonCode = "MDI"
     val prisonerNumbers = setOf("G4793VF")
     val date = LocalDate.of(2022, 12, 14)
@@ -188,7 +216,20 @@ class PrisonApiClientTest {
   }
 
   @Test
-  fun `getScheduledVisits for booking id - success`(): Unit = runBlocking {
+  fun `getCourtEventsForPrisonerNumbers (currently unused) - success`() {
+    val prisonCode = "MDI"
+    val prisonerNumbers = setOf("G4793VF")
+    val date = LocalDate.of(2022, 12, 14)
+
+    prisonApiMockServer.stubGetCourtEventsForPrisonerNumbers(prisonCode, date)
+
+    val courtEvents = prisonApiClient.getScheduledCourtEventsForPrisonerNumbers(prisonCode, prisonerNumbers, date, null).block()!!
+    assertThat(courtEvents).hasSize(2)
+    assertThat(courtEvents.first().offenderNo).isEqualTo("G4793VF")
+  }
+
+  @Test
+  fun `getScheduledVisitsAsync for booking id - success`(): Unit = runBlocking {
     val bookingId = 10002L
     val dateRange = LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
 
@@ -200,23 +241,31 @@ class PrisonApiClientTest {
   }
 
   @Test
-  fun `getScheduledVisits for booking id - not found`() {
+  fun `getScheduledVisits (currently unused) for booking id - success`() {
+    val bookingId = 10002L
+    val dateRange = LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
+
+    prisonApiMockServer.stubGetScheduledVisits(bookingId, dateRange.start, dateRange.endInclusive)
+
+    val scheduledVisits = prisonApiClient.getScheduledVisits(bookingId, dateRange).block()!!
+    assertThat(scheduledVisits).hasSize(1)
+    assertThat(scheduledVisits.first().bookingId).isEqualTo(10002L)
+  }
+
+  @Test
+  fun `getScheduledVisitsAsync for booking id - not found`(): Unit = runBlocking {
     val bookingId = 0L
     val dateRange = LocalDateRange(LocalDate.of(2022, 10, 1), LocalDate.of(2022, 11, 5))
 
     prisonApiMockServer.stubGetScheduledVisitsNotFound(bookingId, dateRange.start, dateRange.endInclusive)
 
-    assertThatThrownBy {
-      runBlocking {
-        prisonApiClient.getScheduledVisitsAsync(bookingId, dateRange)
-      }
-    }
-      .isInstanceOf(WebClientResponseException::class.java)
-      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/0/visits?fromDate=2022-10-01&toDate=2022-11-05")
+    assertThrows<WebClientResponseException>(
+      "404 Not Found from GET http://localhost:8999/api/bookings/0/visits?fromDate=2022-10-01&toDate=2022-11-05",
+    ) { prisonApiClient.getScheduledVisitsAsync(bookingId, dateRange) }
   }
 
   @Test
-  fun `getScheduledVisitsForPrisonerNumbers - success`(): Unit = runBlocking {
+  fun `getScheduledVisitsForPrisonerNumbersAsync - success`(): Unit = runBlocking {
     val prisonCode = "MDI"
     val prisonerNumbers = setOf("A5193DY")
     val date = LocalDate.of(2022, 12, 14)
@@ -224,6 +273,19 @@ class PrisonApiClientTest {
     prisonApiMockServer.stubGetScheduledVisitsForPrisonerNumbers(prisonCode, date)
 
     val visits = prisonApiClient.getScheduledVisitsForPrisonerNumbersAsync(prisonCode, prisonerNumbers, date, null)
+    assertThat(visits).hasSize(2)
+    assertThat(visits.first().offenderNo).isEqualTo("A5193DY")
+  }
+
+  @Test
+  fun `getScheduledVisitsForPrisonerNumbers (currently unused) - success`() {
+    val prisonCode = "MDI"
+    val prisonerNumbers = setOf("A5193DY")
+    val date = LocalDate.of(2022, 12, 14)
+
+    prisonApiMockServer.stubGetScheduledVisitsForPrisonerNumbers(prisonCode, date)
+
+    val visits = prisonApiClient.getScheduledVisitsForPrisonerNumbers(prisonCode, prisonerNumbers, date, null).block()!!
     assertThat(visits).hasSize(2)
     assertThat(visits.first().offenderNo).isEqualTo("A5193DY")
   }
@@ -334,7 +396,20 @@ class PrisonApiClientTest {
   }
 
   @Test
-  fun `getExternalTransfersOnDate - success`(): Unit = runBlocking {
+  fun `getExternalTransfersOnDate (currently unused)- success`() {
+    val prisonCode = "MDI"
+    val prisonerNumbers = setOf("B4793VX")
+    val date = LocalDate.now()
+
+    prisonApiMockServer.stubGetExternalTransfersOnDate(prisonCode, prisonerNumbers, date)
+
+    val externalTransfers = prisonApiClient.getExternalTransfersOnDate(prisonCode, prisonerNumbers, date).block()!!
+    assertThat(externalTransfers).hasSize(1)
+    assertThat(externalTransfers.first().offenderNo).isEqualTo("B4793VX")
+  }
+
+  @Test
+  fun `getExternalTransfersOnDateAsync - success`(): Unit = runBlocking {
     val prisonCode = "MDI"
     val prisonerNumbers = setOf("B4793VX")
     val date = LocalDate.now()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
@@ -38,7 +38,7 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
         prisonerNumbers,
         LocalDate.of(2022, 10, 1),
         TimeSlot.AM,
-      )
+      ),
     ).thenReturn(result)
 
     val response =
@@ -400,10 +400,10 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
     date: LocalDate,
     timeSlot: String,
   ) = post("/scheduled-events/prison/$prisonCode?date=$date&timeSlot=$timeSlot") {
-      accept = MediaType.APPLICATION_JSON
-      contentType = MediaType.APPLICATION_JSON
-      content = mapper.writeValueAsBytes(
-        prisonerNumbers,
-      )
-    }
+    accept = MediaType.APPLICATION_JSON
+    contentType = MediaType.APPLICATION_JSON
+    content = mapper.writeValueAsBytes(
+      prisonerNumbers,
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
@@ -31,13 +31,14 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
   fun `getScheduledEventsByPrisonAndPrisonersAndDateRange - 200 response with events`() {
     val prisonerNumbers = setOf("G4793VF")
     val result = PrisonerScheduledEventsFixture.instance()
+
     whenever(
       scheduledEventService.getScheduledEventsByPrisonAndPrisonersAndDateRange(
         "MDI",
         prisonerNumbers,
         LocalDate.of(2022, 10, 1),
         TimeSlot.AM,
-      ),
+      )
     ).thenReturn(result)
 
     val response =
@@ -65,6 +66,7 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
   fun `getScheduledEventsByPrisonAndPrisonersAndDateRange - Error response when service throws exception`() {
     val prisonerNumbers = setOf("G4793VF")
     val result = this::class.java.getResource("/__files/error-500.json")?.readText()
+
     whenever(
       scheduledEventService.getScheduledEventsByPrisonAndPrisonersAndDateRange(
         "MDI",
@@ -74,16 +76,15 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
       ),
     ).thenThrow(RuntimeException("Error"))
 
-    val response =
-      mockMvc.getScheduledEventsByPrisonAndPrisonersAndDateRange(
-        "MDI",
-        prisonerNumbers,
-        LocalDate.of(2022, 10, 1),
-        TimeSlot.AM.name,
-      )
-        .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
-        .andExpect { status { is5xxServerError() } }
-        .andReturn().response
+    val response = mockMvc.getScheduledEventsByPrisonAndPrisonersAndDateRange(
+      "MDI",
+      prisonerNumbers,
+      LocalDate.of(2022, 10, 1),
+      TimeSlot.AM.name,
+    )
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON) } }
+      .andExpect { status { is5xxServerError() } }
+      .andReturn().response
 
     assertThat(response.contentAsString + "\n").isEqualTo(result)
 
@@ -208,7 +209,7 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
       startDate,
       endDate,
     )
-      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON) } }
       .andExpect { status { isOk() } }
       .andReturn().response
 
@@ -241,7 +242,7 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
       startDate,
       endDate,
     )
-      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON) } }
       .andExpect { status { is5xxServerError() } }
       .andReturn().response
 
@@ -391,16 +392,14 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
     prisonerNumber: String,
     startDate: LocalDate,
     endDate: LocalDate,
-  ) =
-    get("/scheduled-events/prison/$prisonCode?prisonerNumber=$prisonerNumber&startDate=$startDate&endDate=$endDate")
+  ) = get("/scheduled-events/prison/$prisonCode?prisonerNumber=$prisonerNumber&startDate=$startDate&endDate=$endDate")
 
   private fun MockMvc.getScheduledEventsByPrisonAndPrisonersAndDateRange(
     prisonCode: String,
     prisonerNumbers: Set<String>,
     date: LocalDate,
     timeSlot: String,
-  ) =
-    post("/scheduled-events/prison/$prisonCode?date=$date&timeSlot=$timeSlot") {
+  ) = post("/scheduled-events/prison/$prisonCode?date=$date&timeSlot=$timeSlot") {
       accept = MediaType.APPLICATION_JSON
       contentType = MediaType.APPLICATION_JSON
       content = mapper.writeValueAsBytes(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventServiceTest.kt
@@ -17,7 +17,6 @@ import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyBlocking
 import org.mockito.kotlin.whenever
-import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
@@ -143,12 +142,12 @@ class ScheduledEventServiceTest {
 
     if (withPrisonerDetailsException) {
       prisonerSearchApiClient.stub {
-        on { prisonerSearchApiClient.findByPrisonerNumbers(listOf(prisonerNumber)) } doThrow RuntimeException("Error")
+        on { runBlocking { prisonerSearchApiClient.findByPrisonerNumbersAsync(listOf(prisonerNumber)) } } doThrow RuntimeException("Error")
       }
     } else {
-      val prisonerDetails = Mono.just(listOf(PrisonerSearchPrisonerFixture.instance(prisonId = prisonOverride)))
+      val prisonerDetails = listOf(PrisonerSearchPrisonerFixture.instance(prisonId = prisonOverride))
       prisonerSearchApiClient.stub {
-        on { prisonerSearchApiClient.findByPrisonerNumbers(listOf(prisonerNumber)) } doReturn prisonerDetails
+        on { runBlocking { prisonerSearchApiClient.findByPrisonerNumbersAsync(listOf(prisonerNumber)) } } doReturn prisonerDetails
       }
     }
 


### PR DESCRIPTION
This PR:
* Replaces the Mono.zip and Mono<List<T>> return types from prison API with Kotlin coroutines and Deferred<List<T>>
* It uses runBlocking {} enclosures, suspend functions and async {} calls for visits, activities, transfers, and court hearings.
* Removes the confusing, multi-layered transform functions for scheduled events - much clearer (I think).
* Allows (as a next step) the individual transform of court hearings, activities, appointments, visits and transfers when needed.
* We already know that we want to treat these events differently, show different detail, so this will be required.
* Updates all affected tests.