### PR TITLE
SAA-499: Retrieve appointment instance endpoint for sync

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
@@ -7,56 +7,50 @@ import java.time.LocalTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentInstance as AppointmentInstanceModel
 
 @Entity
-@Table(name = "appointment_instance")
+@Table(name = "v_appointment_instance")
 data class AppointmentInstance(
   @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val appointmentInstanceId: Long = 0,
+  val appointmentInstanceId: Long,
 
-  @ManyToOne
-  @JoinColumn(name = "appointment_id", nullable = false)
-  val appointment: Appointment,
+  val appointmentId: Long,
 
-  @ManyToOne
-  @JoinColumn(name = "appointment_occurrence_id", nullable = false)
-  val appointmentOccurrence: AppointmentOccurrence,
+  val appointmentOccurrenceId: Long,
 
-  @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
-  @JoinColumn(name = "appointment_occurrence_allocation_id", nullable = false)
-  var appointmentOccurrenceAllocation: AppointmentOccurrenceAllocation,
+  val appointmentOccurrenceAllocationId: Long,
 
-  var categoryCode: String,
+  val categoryCode: String,
 
   val prisonCode: String,
 
-  var internalLocationId: Long?,
+  val internalLocationId: Long?,
 
-  var inCell: Boolean,
+  val inCell: Boolean,
 
   val prisonerNumber: String,
 
   val bookingId: Long,
 
-  var appointmentDate: LocalDate,
+  val appointmentDate: LocalDate,
 
-  var startTime: LocalTime,
+  val startTime: LocalTime,
 
-  var endTime: LocalTime?,
+  val endTime: LocalTime?,
 
-  var comment: String? = null,
-
-  var cancelled: Boolean = false,
+  val comment: String? = null,
 
   val created: LocalDateTime = LocalDateTime.now(),
 
   val createdBy: String,
 
-  var updated: LocalDateTime? = null,
+  val updated: LocalDateTime? = null,
 
-  var updatedBy: String? = null,
+  val updatedBy: String? = null,
 ) {
   fun toModel() = AppointmentInstanceModel(
     id = appointmentInstanceId,
+    appointmentId = appointmentId,
+    appointmentOccurrenceId = appointmentOccurrenceId,
+    appointmentOccurrenceAllocationId = appointmentOccurrenceAllocationId,
     categoryCode = categoryCode,
     prisonCode = prisonCode,
     internalLocationId = internalLocationId,
@@ -67,7 +61,10 @@ data class AppointmentInstance(
     startTime = startTime,
     endTime = endTime,
     comment = comment,
-    cancelled = cancelled,
+    created = created,
+    createdBy = createdBy,
+    updated = updated,
+    updatedBy = updatedBy,
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
@@ -1,13 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentInstance as AppointmentInstanceModel
 
@@ -19,8 +14,16 @@ data class AppointmentInstance(
   val appointmentInstanceId: Long = 0,
 
   @ManyToOne
+  @JoinColumn(name = "appointment_id", nullable = false)
+  val appointment: Appointment,
+
+  @ManyToOne
   @JoinColumn(name = "appointment_occurrence_id", nullable = false)
   val appointmentOccurrence: AppointmentOccurrence,
+
+  @OneToOne(fetch = FetchType.LAZY, cascade = [CascadeType.ALL])
+  @JoinColumn(name = "appointment_occurrence_allocation_id", nullable = false)
+  var appointmentOccurrenceAllocation: AppointmentOccurrenceAllocation,
 
   var categoryCode: String,
 
@@ -42,9 +45,15 @@ data class AppointmentInstance(
 
   var comment: String? = null,
 
-  var attended: Boolean? = null,
-
   var cancelled: Boolean = false,
+
+  val created: LocalDateTime = LocalDateTime.now(),
+
+  val createdBy: String,
+
+  var updated: LocalDateTime? = null,
+
+  var updatedBy: String? = null,
 ) {
   fun toModel() = AppointmentInstanceModel(
     id = appointmentInstanceId,
@@ -58,7 +67,6 @@ data class AppointmentInstance(
     startTime = startTime,
     endTime = endTime,
     comment = comment,
-    attended = attended,
     cancelled = cancelled,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrence.kt
@@ -62,17 +62,9 @@ data class AppointmentOccurrence(
   @Fetch(FetchMode.SUBSELECT)
   private val allocations: MutableList<AppointmentOccurrenceAllocation> = mutableListOf()
 
-  @OneToMany(mappedBy = "appointmentOccurrence", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
-  @Fetch(FetchMode.SUBSELECT)
-  private val instances: MutableList<AppointmentInstance> = mutableListOf()
-
   fun allocations() = allocations.toList()
 
   fun addAllocation(allocation: AppointmentOccurrenceAllocation) = allocations.add(allocation)
-
-  fun instances() = instances.toList()
-
-  fun addInstance(instance: AppointmentInstance) = instances.add(instance)
 
   fun prisonerNumbers() = allocations().map { allocation -> allocation.prisonerNumber }.distinct()
 
@@ -90,7 +82,6 @@ data class AppointmentOccurrence(
     updated = updated,
     updatedBy = updatedBy,
     allocations = allocations.toModel(),
-    instances = instances.toModel(),
   )
 
   fun toSummary(prisonCode: String, locationMap: Map<Long, Location>, userMap: Map<String, UserDetail>, appointmentComment: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Appointment.kt
@@ -40,7 +40,7 @@ data class Appointment(
     description =
     """
     The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.
-    Should be null if in cell = true
+    Will be null if in cell = true
     """,
     example = "123",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Appointment.kt
@@ -116,7 +116,7 @@ data class Appointment(
     description =
     """
     The username of the user authenticated via HMPPS auth that edited the appointment.
-    Usually a NOMIS username. Will be null if the appointment has not been altered since it was created
+    Will be null if the appointment has not been altered since it was created
     """,
     example = "AAA01U",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentInstance.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.time.LocalTime
 
 @Schema(
@@ -18,6 +19,18 @@ data class AppointmentInstance(
     example = "123456",
   )
   val id: Long,
+
+  @Schema(
+    description = "The internally generated identifier for the parent appointment occurrence",
+    example = "123456",
+  )
+  val AppointmentOccurrenceId: Long,
+
+  @Schema(
+    description = "The internally generated identifier for the parent appointment occurrence",
+    example = "123456",
+  )
+  val AppointmentOccurrenceId: Long,
 
   @Schema(
     description = "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
@@ -95,17 +108,44 @@ data class AppointmentInstance(
   val comment: String?,
 
   @Schema(
-    description =
-    """
-    Simple attendance marking model. Expectation that this will be enhanced to support non attendance reasons in future
-    """,
-    example = "false",
-  )
-  val attended: Boolean?,
-
-  @Schema(
     description = "Indicates that the parent appointment occurrence was cancelled",
     example = "false",
   )
   val cancelled: Boolean,
+
+  @Schema(
+    description = "The date and time this appointment instance was created. Will not change",
+  )
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  val created: LocalDateTime,
+
+  @Schema(
+    description =
+    """
+    The username of the user authenticated via HMPPS auth that created the appointment instance.
+    Usually a NOMIS username
+    """,
+    example = "AAA01U",
+  )
+  val createdBy: String,
+
+  @Schema(
+    description =
+    """
+    The date and time this appointment instance was last changed.
+    Will be null if the appointment instance has not been altered since it was created
+    """,
+  )
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  val updated: LocalDateTime?,
+
+  @Schema(
+    description =
+    """
+    The username of the user authenticated via HMPPS auth that edited the appointment instance.
+    Will be null if the appointment instance has not been altered since it was created
+    """,
+    example = "AAA01U",
+  )
+  val updatedBy: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentInstance.kt
@@ -21,16 +21,22 @@ data class AppointmentInstance(
   val id: Long,
 
   @Schema(
-    description = "The internally generated identifier for the parent appointment occurrence",
-    example = "123456",
+    description = "The internally generated identifier for the parent appointment",
+    example = "1234",
   )
-  val AppointmentOccurrenceId: Long,
+  val appointmentId: Long,
 
   @Schema(
     description = "The internally generated identifier for the parent appointment occurrence",
+    example = "12345",
+  )
+  val appointmentOccurrenceId: Long,
+
+  @Schema(
+    description = "The internally generated identifier for the parent appointment occurrence allocation",
     example = "123456",
   )
-  val AppointmentOccurrenceId: Long,
+  val appointmentOccurrenceAllocationId: Long,
 
   @Schema(
     description = "The NOMIS REFERENCE_CODES.CODE (DOMAIN = 'INT_SCH_RSN') value for mapping to NOMIS",
@@ -48,7 +54,7 @@ data class AppointmentInstance(
     description =
     """
     The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.
-    Should be null if in cell = true
+    Will be null if in cell = true
     """,
     example = "123",
   )
@@ -106,12 +112,6 @@ data class AppointmentInstance(
     example = "This appointment will help prisoner A1234BC adjust to life outside of prison",
   )
   val comment: String?,
-
-  @Schema(
-    description = "Indicates that the parent appointment occurrence was cancelled",
-    example = "false",
-  )
-  val cancelled: Boolean,
 
   @Schema(
     description = "The date and time this appointment instance was created. Will not change",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentOccurrence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentOccurrence.kt
@@ -29,7 +29,7 @@ data class AppointmentOccurrence(
     description =
     """
     The NOMIS AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID value for mapping to NOMIS.
-    Should be null if in cell = true
+    Will be null if in cell = true
     """,
     example = "123",
   )
@@ -118,14 +118,4 @@ data class AppointmentOccurrence(
     """,
   )
   val allocations: List<AppointmentOccurrenceAllocation> = emptyList(),
-
-  @Schema(
-    description =
-    """
-    The instance or instances of this appointment occurrence. Single non recurring appointments such as medical will have one
-    instance record. A group appointment e.g. gym or chaplaincy sessions will have more than one instance record.
-    Instances are at the occurrence level supporting alteration of attendees in any future occurrence.
-    """,
-  )
-  val instances: List<AppointmentInstance> = emptyList(),
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentOccurrenceAllocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentOccurrenceAllocation.kt
@@ -12,7 +12,7 @@ import io.swagger.v3.oas.annotations.media.Schema
 )
 data class AppointmentOccurrenceAllocation(
   @Schema(
-    description = "The internally generated identifier for this appointment allocation",
+    description = "The internally generated identifier for this appointment occurrence allocation",
     example = "123456",
   )
   val id: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentInstanceRepository.kt
@@ -1,15 +1,14 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
 
-import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
-import org.springframework.stereotype.Repository
+import org.springframework.data.repository.Repository
+import org.springframework.stereotype.Repository as RepositoryAnnotation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance
 import java.time.LocalDate
 import java.time.LocalTime
 
-@Repository
-interface AppointmentInstanceRepository : JpaRepository<AppointmentInstance, Long> {
-
+@RepositoryAnnotation
+interface AppointmentInstanceRepository : Repository<AppointmentInstance, Long> {
   @Query(
     value =
     "FROM AppointmentInstance ai " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentInstanceRepository.kt
@@ -2,10 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
 
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.Repository
-import org.springframework.stereotype.Repository as RepositoryAnnotation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance
 import java.time.LocalDate
 import java.time.LocalTime
+import org.springframework.stereotype.Repository as RepositoryAnnotation
 
 @RepositoryAnnotation
 interface AppointmentInstanceRepository : Repository<AppointmentInstance, Long> {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentInstanceRepository.kt
@@ -1,14 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
 
 import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.Repository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance
 import java.time.LocalDate
 import java.time.LocalTime
 import org.springframework.stereotype.Repository as RepositoryAnnotation
 
 @RepositoryAnnotation
-interface AppointmentInstanceRepository : Repository<AppointmentInstance, Long> {
+interface AppointmentInstanceRepository : ReadOnlyRepository<AppointmentInstance, Long> {
   @Query(
     value =
     "FROM AppointmentInstance ai " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ReadOnlyRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ReadOnlyRepository.kt
@@ -1,0 +1,14 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
+
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.data.repository.NoRepositoryBean
+import org.springframework.data.repository.Repository
+import java.util.Optional
+
+@NoRepositoryBean
+interface ReadOnlyRepository<T, ID> : Repository<T, ID> {
+  fun findById(id: ID): Optional<T>
+}
+
+inline fun <reified T, ID> ReadOnlyRepository<T, ID>.findOrThrowNotFound(id: ID): T =
+  this.findById(id).orElseThrow { EntityNotFoundException("${T::class.java.simpleName.spaceOut()} $id not found") }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentInstanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentInstanceController.kt
@@ -1,0 +1,65 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.http.MediaType
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.ResponseBody
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentInstance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AppointmentInstanceService
+
+@RestController
+@RequestMapping("/appointment-instances", produces = [MediaType.APPLICATION_JSON_VALUE])
+class AppointmentInstanceController(
+  private val appointmentInstanceService: AppointmentInstanceService,
+) {
+  @GetMapping(value = ["/{appointmentInstanceId}"])
+  @ResponseBody
+  @Operation(
+    summary = "Get an appointment instance by its id",
+    description = "Returns an appointment instance and its details by its unique identifier.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Appointment instance found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = AppointmentInstance::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The appointment instance for this ID was not found.",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  fun getAppointmentInstanceById(@PathVariable("appointmentInstanceId") appointmentInstanceId: Long): AppointmentInstance =
+    appointmentInstanceService.getAppointmentInstanceById(appointmentInstanceId)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentInstanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentInstanceService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDat
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.RolloutPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentInstanceRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toPrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toScheduledEvent
 import java.time.LocalDate
@@ -38,6 +39,9 @@ class AppointmentInstanceService(
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
+
+  fun getAppointmentInstanceById(appointmentInstanceId: Long) =
+    appointmentInstanceRepository.findOrThrowNotFound(appointmentInstanceId).toModel()
 
   fun getScheduledEvents(
     rolloutPrison: RolloutPrison,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
@@ -11,7 +11,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Appo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
 import java.security.Principal
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointment as AppointmentEntity
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance as AppointmentInstanceEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrence as AppointmentOccurrenceEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceAllocation as AppointmentOccurrenceAllocationEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointment as AppointmentModel
@@ -76,20 +75,6 @@ class AppointmentService(
                   appointmentOccurrence = this,
                   prisonerNumber = prisoner.prisonerNumber,
                   bookingId = prisoner.bookingId!!.toLong(),
-                ),
-              )
-              this.addInstance(
-                AppointmentInstanceEntity(
-                  appointmentOccurrence = this,
-                  prisonerNumber = prisoner.prisonerNumber,
-                  bookingId = prisoner.bookingId.toLong(),
-                  appointmentDate = this.startDate,
-                  categoryCode = request.categoryCode,
-                  endTime = this.endTime,
-                  inCell = this.inCell,
-                  internalLocationId = this.internalLocationId,
-                  prisonCode = request.prisonCode,
-                  startTime = this.startTime,
                 ),
               )
             }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -458,7 +458,7 @@ fun List<AppointmentInstance>.toScheduledEvent(
     eventType = eventType,
     eventTypeDesc = eventTypeDesc,
     eventClass = eventClass,
-    eventId = it.appointmentInstanceId,
+    eventId = it.appointmentOccurrenceId,
     eventStatus = eventStatus,
     eventDate = it.appointmentDate,
     eventSource = eventSource,

--- a/src/main/resources/migration/common/V2__appointments_baseline.sql
+++ b/src/main/resources/migration/common/V2__appointments_baseline.sql
@@ -64,29 +64,26 @@ CREATE INDEX idx_appointment_occurrence_allocation_appointment_occurrence_id ON 
 CREATE INDEX idx_appointment_occurrence_allocation_prisoner_number ON appointment_occurrence_allocation (prisoner_number);
 CREATE INDEX idx_appointment_occurrence_allocation_booking_id ON appointment_occurrence_allocation (booking_id);
 
-CREATE TABLE appointment_instance (
-    appointment_instance_id     bigserial   NOT NULL CONSTRAINT appointment_instance_pk PRIMARY KEY,
-    appointment_occurrence_id   bigint      NOT NULL REFERENCES appointment_occurrence (appointment_occurrence_id),
-    category_code               varchar(12) NOT NULL,
-    prison_code                 varchar(6)  NOT NULL,
-    internal_location_id        bigint,
-    in_cell                     boolean     NOT NULL DEFAULT false,
-    prisoner_number             varchar(10) NOT NULL,
-    booking_id                  bigint      NOT NULL,
-    appointment_date            date        NOT NULL,
-    start_time                  time        NOT NULL,
-    end_time                    time,
-    comment                     text,
-    attended                    boolean,
-    cancelled                   boolean     NOT NULL DEFAULT false
-);
-
-CREATE INDEX idx_appointment_instance_appointment_occurrence_id ON appointment_instance (appointment_occurrence_id);
-CREATE INDEX idx_appointment_instance_category_code ON appointment_instance (category_code);
-CREATE INDEX idx_appointment_instance_prison_code ON appointment_instance (prison_code);
-CREATE INDEX idx_appointment_instance_internal_location_id ON appointment_instance (internal_location_id);
-CREATE INDEX idx_appointment_instance_prisoner_number ON appointment_instance (prisoner_number);
-CREATE INDEX idx_appointment_instance_booking_id ON appointment_instance (booking_id);
-CREATE INDEX idx_appointment_instance_appointment_date ON appointment_instance (appointment_date);
-CREATE INDEX idx_appointment_instance_start_time ON appointment_instance (start_time);
-CREATE INDEX idx_appointment_instance_end_time ON appointment_instance (end_time);
+CREATE OR REPLACE VIEW v_appointment_instance AS
+    SELECT
+        aoa.appointment_occurrence_allocation_id AS appointment_instance_id,
+        a.appointment_id,
+        ao.appointment_occurrence_id,
+        aoa.appointment_occurrence_allocation_id,
+        a.category_code,
+        a.prison_code,
+        CASE WHEN ao.in_cell THEN null ELSE ao.internal_location_id END AS internal_location_id,
+        ao.in_cell,
+        aoa.prisoner_number,
+        aoa.booking_id,
+        ao.start_date AS appointment_date,
+        ao.start_time,
+        ao.end_time,
+        COALESCE(ao.comment, a.comment) AS comment,
+        a.created,
+        a.created_by,
+        ao.updated,
+        ao.updated_by
+    FROM appointment_occurrence_allocation aoa
+        JOIN appointment_occurrence ao on aoa.appointment_occurrence_id = ao.appointment_occurrence_id
+        JOIN appointment a on a.appointment_id = ao.appointment_id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstanceTest.kt
@@ -2,23 +2,21 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentInstanceEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentInstanceModel
 
 class AppointmentInstanceTest {
   @Test
   fun `entity to model mapping`() {
-    val appointmentEntity = appointmentEntity()
-    val entity = appointmentEntity.occurrences().first().instances().first()
-    val expectedModel = appointmentInstanceModel()
+    val entity = appointmentInstanceEntity()
+    val expectedModel = appointmentInstanceModel(entity.created, entity.updated)
     assertThat(entity.toModel()).isEqualTo(expectedModel)
   }
 
   @Test
   fun `entity list to model list mapping`() {
-    val appointmentEntity = appointmentEntity()
-    val entity = appointmentEntity.occurrences().first().instances().first()
-    val expectedModel = listOf(appointmentInstanceModel())
+    val entity = appointmentInstanceEntity()
+    val expectedModel = listOf(appointmentInstanceModel(entity.created, entity.updated))
     assertThat(listOf(entity).toModel()).isEqualTo(expectedModel)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
@@ -64,8 +64,6 @@ private fun appointmentOccurrenceEntity(appointment: Appointment, sequenceNumber
     updatedBy = "UPDATE.USER",
   ).apply {
     prisonerNumberToBookingIdMap.map { this.addAllocation(appointmentOccurrenceAllocationEntity(this, it.key, it.value)) }
-  }.apply {
-    prisonerNumberToBookingIdMap.map { this.addInstance(appointmentInstanceEntity(this, startDate, it.key, it.value)) }
   }
 
 private fun appointmentOccurrenceAllocationEntity(appointmentOccurrence: AppointmentOccurrence, prisonerNumber: String = "A1234BC", bookingId: Long = 456) =
@@ -76,25 +74,32 @@ private fun appointmentOccurrenceAllocationEntity(appointmentOccurrence: Appoint
     bookingId = bookingId,
   )
 
-private fun appointmentInstanceEntity(
-  appointmentOccurrence: AppointmentOccurrence,
+internal fun appointmentInstanceEntity(
+  internalLocationId: Long = 123,
+  inCell: Boolean = false,
   appointmentDate: LocalDate = LocalDate.now(),
   prisonerNumber: String = "A1234BC",
   bookingId: Long = 456,
+  createdBy: String = "CREATE.USER",
+  updatedBy: String? = "UPDATE.USER",
 ) =
   AppointmentInstance(
-    appointmentInstanceId = 1,
-    appointmentOccurrence = appointmentOccurrence,
+    appointmentInstanceId = 3,
+    appointmentId = 1,
+    appointmentOccurrenceId = 2,
+    appointmentOccurrenceAllocationId = 3,
     categoryCode = "TEST",
-    prisonCode = appointmentOccurrence.appointment.prisonCode,
-    internalLocationId = appointmentOccurrence.appointment.internalLocationId,
-    inCell = appointmentOccurrence.appointment.inCell,
+    prisonCode = "TPR",
+    internalLocationId = if (inCell) null else internalLocationId,
+    inCell = inCell,
     prisonerNumber = prisonerNumber,
     bookingId = bookingId,
     appointmentDate = appointmentDate,
-    startTime = appointmentOccurrence.appointment.startTime,
-    endTime = appointmentOccurrence.appointment.endTime,
+    startTime = LocalTime.of(9, 0),
+    endTime = LocalTime.of(10, 30),
     comment = "Appointment instance level comment",
-    attended = true,
-    cancelled = false,
+    created = LocalDateTime.now().minusDays(1),
+    createdBy = createdBy,
+    updated = LocalDateTime.now(),
+    updatedBy = updatedBy,
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
@@ -54,25 +54,31 @@ fun appointmentOccurrenceModel(updated: LocalDateTime?) =
     updated,
     "UPDATE.USER",
     allocations = listOf(appointmentOccurrenceAllocationModel()),
-    instances = listOf(appointmentInstanceModel()),
   )
 
-fun appointmentInstanceModel() =
-  AppointmentInstance(
-    1,
-    "TEST",
-    "TPR",
-    123,
-    false,
-    "A1234BC",
-    456,
-    LocalDate.now(),
-    LocalTime.of(9, 0),
-    LocalTime.of(10, 30),
-    "Appointment instance level comment",
-    attended = true,
-    cancelled = false,
-  )
+fun appointmentInstanceModel(
+  created: LocalDateTime = LocalDateTime.now().minusDays(1),
+  updated: LocalDateTime? = LocalDateTime.now(),
+) = AppointmentInstance(
+  3,
+  1,
+  2,
+  3,
+  "TEST",
+  "TPR",
+  123,
+  false,
+  "A1234BC",
+  456,
+  LocalDate.now(),
+  LocalTime.of(9, 0),
+  LocalTime.of(10, 30),
+  "Appointment instance level comment",
+  created = created,
+  "CREATE.USER",
+  updated = updated,
+  "UPDATE.USER",
+)
 
 fun appointmentCreateRequest(
   categoryCode: String? = "TEST",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentInstanceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentInstanceIntegrationTest.kt
@@ -1,0 +1,70 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentInstance
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+class AppointmentInstanceIntegrationTest : IntegrationTestBase() {
+  @Test
+  fun `get appointment instance authorisation required`() {
+    webTestClient.get()
+      .uri("/appointment-instances/1")
+      .exchange()
+      .expectStatus().isUnauthorized
+  }
+
+  @Sql(
+    "classpath:test_data/seed-appointment-single-id-1.sql",
+  )
+  @Test
+  fun `get appointment instance`() {
+    val appointmentInstance = webTestClient.getAppointmentInstanceById(3)
+
+    with(appointmentInstance!!) {
+      assertThat(id).isEqualTo(3)
+      assertThat(appointmentId).isEqualTo(1)
+      assertThat(appointmentOccurrenceId).isEqualTo(2)
+      assertThat(appointmentOccurrenceAllocationId).isEqualTo(3)
+      assertThat(categoryCode).isEqualTo("AC1")
+      assertThat(prisonCode).isEqualTo("TPR")
+      assertThat(internalLocationId).isEqualTo(123)
+      assertThat(inCell).isEqualTo(false)
+      assertThat(prisonerNumber).isEqualTo("A1234BC")
+      assertThat(bookingId).isEqualTo(456)
+      assertThat(appointmentDate).isEqualTo(LocalDate.now())
+      assertThat(startTime).isEqualTo(LocalTime.of(9, 0))
+      assertThat(endTime).isEqualTo(LocalTime.of(10, 30))
+      assertThat(comment).isEqualTo("Appointment occurrence level comment")
+      assertThat(created).isCloseTo(LocalDateTime.now(), within(60, java.time.temporal.ChronoUnit.SECONDS))
+      assertThat(createdBy).isEqualTo("TEST.USER")
+      assertThat(updated).isNull()
+      assertThat(updatedBy).isNull()
+    }
+  }
+
+  @Test
+  fun `get appointment instance by unknown id returns 404 not found`() {
+    webTestClient.get()
+      .uri("/appointment-instances/-1")
+      .headers(setAuthorisation(roles = listOf()))
+      .exchange()
+      .expectStatus().isNotFound
+  }
+
+  private fun WebTestClient.getAppointmentInstanceById(id: Long) =
+    get()
+      .uri("/appointment-instances/$id")
+      .headers(setAuthorisation(roles = listOf()))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(AppointmentInstance::class.java)
+      .returnResult().responseBody
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentIntegrationTest.kt
@@ -19,9 +19,6 @@ import java.time.LocalTime
 import java.time.temporal.ChronoUnit
 
 class AppointmentIntegrationTest : IntegrationTestBase() {
-  @Sql(
-    "classpath:test_data/seed-appointment-single-id-1.sql",
-  )
   @Test
   fun `get appointment authorisation required`() {
     webTestClient.get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentIntegrationTest.kt
@@ -8,7 +8,6 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointment
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentOccurrenceAllocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentRepeat
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentRepeatPeriod
@@ -65,13 +64,6 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
           assertThat(updated).isNull()
           assertThat(updatedBy).isNull()
           with(allocations) {
-            assertThat(size).isEqualTo(1)
-            with(get(0)) {
-              assertThat(prisonerNumber).isEqualTo("A1234BC")
-              assertThat(bookingId).isEqualTo(456)
-            }
-          }
-          with(instances) {
             assertThat(size).isEqualTo(1)
             with(get(0)) {
               assertThat(prisonerNumber).isEqualTo("A1234BC")
@@ -217,14 +209,6 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
               assertThat(bookingId).isEqualTo(1)
             }
           }
-          with(instances) {
-            assertThat(size).isEqualTo(1)
-            with(first()) {
-              assertThat(id).isGreaterThan(0)
-              assertThat(prisonerNumber).isEqualTo(request.prisonerNumbers.first())
-              assertThat(bookingId).isEqualTo(1)
-            }
-          }
         }
       }
     }
@@ -270,31 +254,6 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
               listOf(
                 AppointmentOccurrenceAllocation(id = 1, prisonerNumber = "A12345BC", bookingId = 1),
                 AppointmentOccurrenceAllocation(id = 2, prisonerNumber = "B23456CE", bookingId = 2),
-              ),
-            ),
-          )
-          with(instances) {
-            assertThat(size).isEqualTo(2)
-          }
-          assertThat(
-            instances.containsAll(
-              listOf(
-                AppointmentInstance(
-                  id = -1,
-                  categoryCode = "TEST",
-                  prisonCode = "TPR", internalLocationId = 123, inCell = false, prisonerNumber = "A12345BC",
-                  bookingId = 1, appointmentDate = LocalDate.now().plusDays(1),
-                  startTime = LocalTime.of(13, 0), endTime = LocalTime.of(14, 30),
-                  comment = null, attended = null, cancelled = false,
-                ),
-                AppointmentInstance(
-                  id = -1,
-                  categoryCode = "TEST",
-                  prisonCode = "TPR", internalLocationId = 123, inCell = false, prisonerNumber = "B23456CE",
-                  bookingId = 2, appointmentDate = LocalDate.now().plusDays(1),
-                  startTime = LocalTime.of(13, 0), endTime = LocalTime.of(14, 30),
-                  comment = null, attended = null, cancelled = false,
-                ),
               ),
             ),
           )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentInstanceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentInstanceControllerTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
+
+import jakarta.persistence.EntityNotFoundException
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentInstanceEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AppointmentInstanceService
+
+@WebMvcTest(controllers = [AppointmentInstanceController::class])
+@ContextConfiguration(classes = [AppointmentInstanceController::class])
+class AppointmentInstanceControllerTest : ControllerTestBase<AppointmentInstanceController>() {
+  @MockBean
+  private lateinit var appointmentInstanceService: AppointmentInstanceService
+
+  override fun controller() = AppointmentInstanceController(appointmentInstanceService)
+
+  @Test
+  fun `200 response when get appointment instance by valid id`() {
+    val appointmentInstance = appointmentInstanceEntity().toModel()
+
+    whenever(appointmentInstanceService.getAppointmentInstanceById(1)).thenReturn(appointmentInstance)
+
+    val response = mockMvc.getAppointmentInstanceById(1)
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isOk() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).isEqualTo(mapper.writeValueAsString(appointmentInstance))
+
+    verify(appointmentInstanceService).getAppointmentInstanceById(1)
+  }
+
+  @Test
+  fun `404 response when get appointment instance by invalid id`() {
+    whenever(appointmentInstanceService.getAppointmentInstanceById(-1)).thenThrow(EntityNotFoundException("Appointment Instance -1 not found"))
+
+    val response = mockMvc.getAppointmentInstanceById(-1)
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isNotFound() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).contains("Appointment Instance -1 not found")
+
+    verify(appointmentInstanceService).getAppointmentInstanceById(-1)
+  }
+
+  private fun MockMvc.getAppointmentInstanceById(id: Long) = get("/appointment-instances/{appointmentInstanceId}", id)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentInstanceServiceTest.kt
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalTim
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.RolloutPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCategoryReferenceCode
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentInstanceEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.locations
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.prisonerSchedules
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.prisoners
@@ -87,7 +87,7 @@ class AppointmentInstanceServiceTest {
           eventType = "APP",
           eventTypeDesc = "Appointment",
           eventClass = "INT_MOV",
-          eventId = 1,
+          eventId = 2,
           eventStatus = "SCH",
           eventDate = startDate,
           eventSource = "APP",
@@ -99,7 +99,7 @@ class AppointmentInstanceServiceTest {
 
       whenever(rolloutPrison.isAppointmentsEnabled()).thenReturn(true)
       whenever(appointmentInstanceRepository.findByBookingIdAndDateRange(bookingId, startDate, endDate))
-        .thenReturn(appointmentEntity(startDate = startDate).occurrences().first().instances())
+        .thenReturn(listOf(appointmentInstanceEntity(appointmentDate = startDate)))
       whenever(referenceCodeService.getReferenceCodesMap(ReferenceCodeDomain.APPOINTMENT_CATEGORY)).thenReturn(mapOf("TEST" to appointmentCategoryReferenceCode()))
 
       val actualScheduledEvents = appointmentInstanceService.getScheduledEvents(rolloutPrison, bookingId, dateRange)
@@ -166,7 +166,7 @@ class AppointmentInstanceServiceTest {
       whenever(prisonerSearchApiClient.findByPrisonerNumbers(prisonerNumbers.toList())).thenReturn(Mono.just(prisoners(prisonerNumber = prisonerNumbers.first())))
       whenever(rolloutPrison.isAppointmentsEnabled()).thenReturn(true)
       whenever(appointmentInstanceRepository.findByPrisonCodeAndPrisonerNumberAndDateAndTime(eq(prisonCode), eq(prisonerNumbers), eq(startDate), any(), any()))
-        .thenReturn(appointmentEntity(startDate = startDate, prisonerNumberToBookingIdMap = mapOf("P123" to 456)).occurrences().first().instances())
+        .thenReturn(listOf(appointmentInstanceEntity(appointmentDate = startDate, prisonerNumber = "P123", bookingId = 456)))
 
       val actualPrisonerSchedules = appointmentInstanceService.getPrisonerSchedules(prisonCode, prisonerNumbers, rolloutPrison, startDate, timeSlot)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentInstanceServiceTest.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
+import jakarta.persistence.EntityNotFoundException
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
@@ -30,6 +32,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import java.time.format.DateTimeFormatter
+import java.util.Optional
 
 class AppointmentInstanceServiceTest {
 
@@ -48,6 +51,24 @@ class AppointmentInstanceServiceTest {
     appointmentInstanceRepository,
     prisonRegimeService,
   )
+
+  @Nested
+  @DisplayName("getAppointmentInstanceById")
+  inner class GetAppointmentInstanceById {
+    @Test
+    fun `returns an appointment instance for known appointment instance id`() {
+      val entity = appointmentInstanceEntity()
+      whenever(appointmentInstanceRepository.findById(1)).thenReturn(Optional.of(entity))
+      assertThat(appointmentInstanceService.getAppointmentInstanceById(1)).isEqualTo(entity.toModel())
+    }
+
+    @Test
+    fun `throws entity not found exception for unknown appointment instance id`() {
+      Assertions.assertThatThrownBy { appointmentInstanceService.getAppointmentInstanceById(0) }
+        .isInstanceOf(EntityNotFoundException::class.java)
+        .hasMessage("Appointment Instance 0 not found")
+    }
+  }
 
   @Nested
   @DisplayName("getScheduledEvents")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentServiceTest.kt
@@ -25,15 +25,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userCaseLoads
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentOccurrenceAllocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentRepeat
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentRepository
 import java.lang.IllegalArgumentException
 import java.security.Principal
-import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.LocalTime
 import java.time.temporal.ChronoUnit
 import java.util.Optional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentRepeatPeriod as AppointmentRepeatPeriodModel
@@ -214,13 +211,6 @@ class AppointmentServiceTest {
               assertThat(bookingId).isEqualTo(1)
             }
           }
-          with(instances()) {
-            assertThat(size).isEqualTo(1)
-            with(first()) {
-              assertThat(prisonerNumber).isEqualTo(request.prisonerNumbers.first())
-              assertThat(bookingId).isEqualTo(1)
-            }
-          }
         }
       }
     }
@@ -257,26 +247,6 @@ class AppointmentServiceTest {
           listOf(
             AppointmentOccurrenceAllocation(id = 0, prisonerNumber = "A12345BC", bookingId = 1),
             AppointmentOccurrenceAllocation(id = 0, prisonerNumber = "B23456CE", bookingId = 2),
-          ),
-        )
-        assertThat(occurrences().first().instances().toModel()).containsAll(
-          listOf(
-            AppointmentInstance(
-              id = 0,
-              categoryCode = "TEST",
-              prisonCode = "TPR", internalLocationId = 123, inCell = false, prisonerNumber = "A12345BC",
-              bookingId = 1, appointmentDate = LocalDate.now().plusDays(1),
-              startTime = LocalTime.of(13, 0), endTime = LocalTime.of(14, 30),
-              comment = null, attended = null, cancelled = false,
-            ),
-            AppointmentInstance(
-              id = 0,
-              categoryCode = "TEST",
-              prisonCode = "TPR", internalLocationId = 123, inCell = false, prisonerNumber = "B23456CE",
-              bookingId = 2, appointmentDate = LocalDate.now().plusDays(1),
-              startTime = LocalTime.of(13, 0), endTime = LocalTime.of(14, 30),
-              comment = null, attended = null, cancelled = false,
-            ),
           ),
         )
       }

--- a/src/test/resources/test_data/clean-all-data.sql
+++ b/src/test/resources/test_data/clean-all-data.sql
@@ -22,7 +22,6 @@ truncate table prison_pay_band restart identity;
 truncate table prison_regime restart identity;
 
 --Appointments
-truncate table appointment_instance;
 truncate table appointment_occurrence_allocation;
 truncate table appointment_occurrence;
 truncate table appointment_schedule;

--- a/src/test/resources/test_data/seed-appointment-deleted-id-2.sql
+++ b/src/test/resources/test_data/seed-appointment-deleted-id-2.sql
@@ -2,7 +2,7 @@ INSERT INTO appointment (appointment_id, category_code, prison_code, internal_lo
 VALUES (1, 'AC1', 'TPR', 123, false, now()::date, '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER', true);
 
 INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (1, 1, 1, 123, false, now()::date, '09:00', '10:30', 'Appointment occurrence level comment');
+VALUES (2, 1, 1, 123, false, now()::date, '09:00', '10:30', 'Appointment occurrence level comment');
 
 INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
-VALUES (1, 1, 'A1234BC', 456);
+VALUES (3, 2, 'A1234BC', 456);

--- a/src/test/resources/test_data/seed-appointment-deleted-id-2.sql
+++ b/src/test/resources/test_data/seed-appointment-deleted-id-2.sql
@@ -1,2 +1,8 @@
 INSERT INTO appointment (appointment_id, category_code, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, comment, created, created_by, deleted)
 VALUES (1, 'AC1', 'TPR', 123, false, now()::date, '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER', true);
+
+INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, internal_location_id, in_cell, start_date, start_time, end_time, comment)
+VALUES (1, 1, 1, 123, false, now()::date, '09:00', '10:30', 'Appointment occurrence level comment');
+
+INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+VALUES (1, 1, 'A1234BC', 456);

--- a/src/test/resources/test_data/seed-appointment-single-id-1.sql
+++ b/src/test/resources/test_data/seed-appointment-single-id-1.sql
@@ -7,7 +7,3 @@ VALUES (1, 1, 1, 123, false, now()::date, '09:00', '10:30', 'Appointment occurre
 INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
 VALUES (1, 1, 'A1234BC', 456);
 
-INSERT INTO appointment_instance (appointment_instance_id, appointment_occurrence_id, category_code, prison_code, internal_location_id,
-                                  in_cell, prisoner_number, booking_id, appointment_date, start_time, end_time, comment, attended, cancelled)
-VALUES(1, 1, 'AC1', 'TPR', 123, false, 'A1234BC', 456, now()::date, '09:00', '10:30', 'Appointment level comment', null, false);
-

--- a/src/test/resources/test_data/seed-appointment-single-id-1.sql
+++ b/src/test/resources/test_data/seed-appointment-single-id-1.sql
@@ -2,8 +2,8 @@ INSERT INTO appointment (appointment_id, category_code, prison_code, internal_lo
 VALUES (1, 'AC1', 'TPR', 123, false, now()::date, '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
 
 INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (1, 1, 1, 123, false, now()::date, '09:00', '10:30', 'Appointment occurrence level comment');
+VALUES (2, 1, 1, 123, false, now()::date, '09:00', '10:30', 'Appointment occurrence level comment');
 
 INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
-VALUES (1, 1, 'A1234BC', 456);
+VALUES (3, 2, 'A1234BC', 456);
 


### PR DESCRIPTION
Key points:

- Have replaced the appointment_instance table with a view to reduce data duplication
- This is being merged into the SAA-484 PR as both contain database changes and I'd like both to go out at once