### PR TITLE
SDIT-423 Stick to springdoc version 2.0.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,8 +32,8 @@ dependencies {
   implementation("uk.gov.justice.service.hmpps:hmpps-sqs-spring-boot-starter:2.0.0-beta-13")
   implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.6.4")
 
-  // OpenAPI
-  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.4")
+  // OpenAPI - please keep this at version 2.0.2 for now as there is a breaking change to the @Schema required flag in 2.0.3
+  implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2")
 
   // Other dependencies
   implementation("org.apache.commons:commons-text:1.10.0")


### PR DESCRIPTION
Version 2.0.3 contains a breaking change that reverses the default of the required flag for non-nullable fields from true to false. This means we'd need to add `required = true` to all non-nullable fields with a @Schema annotation - which is a lot of work and seems completely wrong to me. So I'm trying to get springdoc to reverse this breaking change, but in the meantime we need to stick to v2.0.2 so that all non-nullable fields are required.