### PR TITLE
SAA-554 initial commit to introduce finer grained feature switching, particularly around sending and receiving events.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/FeatureSwitches.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/FeatureSwitches.kt
@@ -1,0 +1,35 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config
+
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.core.env.Environment
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.OutboundEvent
+
+@Component
+class FeatureSwitches(private val environment: Environment) {
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun isEnabled(feature: Feature, defaultValue: Boolean = false): Boolean =
+    get(feature.label, Boolean::class.java, defaultValue)
+
+  fun isEnabled(outboundEvent: OutboundEvent, defaultValue: Boolean = false): Boolean =
+    get("feature.event.${outboundEvent.eventType}", Boolean::class.java, defaultValue)
+
+  private inline fun <reified T> get(property: String, type: Class<T>, defaultValue: T) =
+    environment.getProperty(property, type).let {
+      if (it == null) {
+        log.info("property '$property' not configured, defaulting to $defaultValue")
+        defaultValue
+      } else {
+        it
+      }
+    }
+}
+
+enum class Feature(val label: String) {
+  OUTBOUND_EVENTS_ENABLED("feature.events.sns.enabled"),
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventsPublisher.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventsPublisher.kt
@@ -3,28 +3,29 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
-import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.sns.model.MessageAttributeValue
 import software.amazon.awssdk.services.sns.model.PublishRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.FeatureSwitches
 import uk.gov.justice.hmpps.sqs.HmppsQueueService
 
 @Service
 class EventsPublisher(
   private val hmppsQueueService: HmppsQueueService,
   private val mapper: ObjectMapper,
-  @Value("\${feature.events.sns.enabled:false}")
-  private val enabled: Boolean,
+  features: FeatureSwitches,
 ) {
+  private val outboundEventsEnabled = features.isEnabled(Feature.OUTBOUND_EVENTS_ENABLED)
 
   companion object {
     const val TOPIC_ID = "domainevents"
 
-    val log: Logger = LoggerFactory.getLogger(this::class.java)
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
   init {
-    log.info("SNS enabled = $enabled")
+    log.info("Outbound SNS events enabled = $outboundEventsEnabled")
   }
 
   private val domainEventsTopic by lazy {
@@ -32,7 +33,7 @@ class EventsPublisher(
   }
 
   internal fun send(event: OutboundHMPPSDomainEvent) {
-    if (enabled) {
+    if (outboundEventsEnabled) {
       domainEventsTopic.snsClient.publish(
         PublishRequest.builder()
           .topicArn(domainEventsTopic.arn)
@@ -47,9 +48,6 @@ class EventsPublisher(
     log.info("Ignoring publishing event $event")
   }
 
-  private fun metaData(payload: OutboundHMPPSDomainEvent): Map<String, MessageAttributeValue> {
-    val messageAttributes: MutableMap<String, MessageAttributeValue> = HashMap()
-    messageAttributes["eventType"] = MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build()
-    return messageAttributes
-  }
+  private fun metaData(payload: OutboundHMPPSDomainEvent) =
+    mapOf("eventType" to MessageAttributeValue.builder().dataType("String").stringValue(payload.eventType).build())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventsService.kt
@@ -30,36 +30,41 @@ class OutboundEventsService(private val publisher: EventsPublisher) {
     when (outboundEvent) {
       ACTIVITY_SCHEDULE_CREATED -> publisher.send(ACTIVITY_SCHEDULE_CREATED.event(ScheduleCreatedInformation(identifier)))
       PRISONER_ALLOCATED -> publisher.send(PRISONER_ALLOCATED.event(PrisonerAllocatedInformation(identifier)))
-      APPOINTMENT_INSTANCE_CREATED -> publisher.send(APPOINTMENT_INSTANCE_CREATED.event(AppointmentInstanceCreatedInformation(identifier)))
+      APPOINTMENT_INSTANCE_CREATED -> publisher.send(
+        APPOINTMENT_INSTANCE_CREATED.event(
+          AppointmentInstanceCreatedInformation(identifier),
+        ),
+      )
     }
   }
 }
 
-enum class OutboundEvent {
-  ACTIVITY_SCHEDULE_CREATED {
+enum class OutboundEvent(val eventType: String) {
+  ACTIVITY_SCHEDULE_CREATED("activities.activity-schedule.created") {
     override fun event(additionalInformation: AdditionalInformation) =
       OutboundHMPPSDomainEvent(
-        eventType = "activities.activity-schedule.created",
+        eventType = eventType,
         additionalInformation = additionalInformation,
         description = "A new activity schedule has been created in the activities management service",
       )
   },
-  PRISONER_ALLOCATED {
+  PRISONER_ALLOCATED("activities.prisoner.allocated") {
     override fun event(additionalInformation: AdditionalInformation) =
       OutboundHMPPSDomainEvent(
-        eventType = "activities.prisoner.allocated",
+        eventType = eventType,
         additionalInformation = additionalInformation,
         description = "A prisoner has been allocated to an activity in the activities management service",
       )
   },
-  APPOINTMENT_INSTANCE_CREATED {
+  APPOINTMENT_INSTANCE_CREATED("appointments.appointment-instance.created") {
     override fun event(additionalInformation: AdditionalInformation) =
       OutboundHMPPSDomainEvent(
-        eventType = "appointments.appointment-instance.created",
+        eventType = eventType,
         additionalInformation = additionalInformation,
         description = "A new appointment instance has been created in the activities management service",
       )
-  }, ;
+  },
+  ;
 
   abstract fun event(additionalInformation: AdditionalInformation): OutboundHMPPSDomainEvent
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/FeatureSwitchesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/FeatureSwitchesTest.kt
@@ -1,0 +1,60 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.OutboundEvent
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@ActiveProfiles("test")
+class FeatureSwitchesTest {
+
+  @TestPropertySource(
+    properties = [
+      "feature.events.sns.enabled=true",
+      "feature.event.activities.activity-schedule.created=true",
+      "feature.event.activities.prisoner.allocated=true",
+      "feature.event.appointments.appointment-instance.created=true",
+    ],
+  )
+  @Nested
+  @DisplayName("Features are enabled when set")
+  inner class EnabledFeatures(@Autowired val featureSwitches: FeatureSwitches) {
+    @Test
+    fun `features are enabled`() {
+      assertThat(featureSwitches.isEnabled(Feature.OUTBOUND_EVENTS_ENABLED)).isTrue
+      assertThat(featureSwitches.isEnabled(OutboundEvent.ACTIVITY_SCHEDULE_CREATED)).isTrue
+      assertThat(featureSwitches.isEnabled(OutboundEvent.PRISONER_ALLOCATED)).isTrue
+      assertThat(featureSwitches.isEnabled(OutboundEvent.APPOINTMENT_INSTANCE_CREATED)).isTrue
+    }
+  }
+
+  @Nested
+  @DisplayName("Features are disabled by default")
+  inner class DisabledFeatures(@Autowired val featureSwitches: FeatureSwitches) {
+    @Test
+    fun `features are disabled by default`() {
+      assertThat(featureSwitches.isEnabled(Feature.OUTBOUND_EVENTS_ENABLED)).isFalse
+      assertThat(featureSwitches.isEnabled(OutboundEvent.ACTIVITY_SCHEDULE_CREATED)).isFalse
+      assertThat(featureSwitches.isEnabled(OutboundEvent.PRISONER_ALLOCATED)).isFalse
+      assertThat(featureSwitches.isEnabled(OutboundEvent.APPOINTMENT_INSTANCE_CREATED)).isFalse
+    }
+  }
+
+  @Nested
+  @DisplayName("Features can be defaulted when not present")
+  inner class DefaultedFeatures(@Autowired val featureSwitches: FeatureSwitches) {
+    @Test
+    fun `features are defaulted`() {
+      assertThat(featureSwitches.isEnabled(Feature.OUTBOUND_EVENTS_ENABLED, true)).isTrue
+      assertThat(featureSwitches.isEnabled(OutboundEvent.ACTIVITY_SCHEDULE_CREATED, true)).isTrue
+      assertThat(featureSwitches.isEnabled(OutboundEvent.PRISONER_ALLOCATED, true)).isTrue
+      assertThat(featureSwitches.isEnabled(OutboundEvent.APPOINTMENT_INSTANCE_CREATED, true)).isTrue
+    }
+  }
+}


### PR DESCRIPTION
The upshot of this PR will hopefully mean we can add the code for raising events prior to them be used outside of our service.

If events are raised and published but not consumed then alerts can/will be raised on the DPS alerts channel.