### PR TITLE
SAA-584: Appointment location and review comments.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ScheduledEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ScheduledEvent.kt
@@ -14,7 +14,7 @@ data class ScheduledEvent(
   @Schema(description = "The source of this event - valid values are NOMIS or SAA (scheduling activities and appointments)", example = "NOMIS")
   val eventSource: String?,
 
-  @Schema(description = "The event type (APPOINTMENT, ACTIVITY, COURT, TRANSFER, ADJUDICATION, VISIT)", example = "APPOINTMENT")
+  @Schema(description = "The event type (APPOINTMENT, ACTIVITY, COURT_HEARING, EXTERNAL_TRANSFER, ADJUDICATION_HEARING, VISIT)", example = "APPOINTMENT")
   val eventType: String?,
 
   @Schema(description = "For activities from SAA the ID for the activity scheduled instance, or null when from NOMIS", example = "9999")
@@ -41,7 +41,7 @@ data class ScheduledEvent(
   @Schema(description = "The NOMIS location code for this event", example = "MDI-HB1-EDUCATION-RM1")
   val internalLocationCode: String?,
 
-  @Schema(description = "The NOMIS location description for this event", example = "Room One")
+  @Schema(description = "The NOMIS location description for this event", example = "Education Room One")
   val internalLocationDescription: String?,
 
   @Schema(description = "Event category code (e.g appointment category code, activity category code)", example = "GOVE")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -128,7 +128,7 @@ fun transformAppointmentInstanceToScheduledEvents(
     bookingId = it.bookingId,
     internalLocationId = it.internalLocationId,
     internalLocationCode = locationsForAppointmentsMap[it.internalLocationId]?.internalLocationCode ?: "Unknown",
-    internalLocationDescription = locationsForAppointmentsMap[it.internalLocationId]?.description ?: "Unknown",
+    internalLocationDescription = locationsForAppointmentsMap[it.internalLocationId]?.userDescription ?: "Unknown",
     eventId = null,
     appointmentInstanceId = it.appointmentInstanceId,
     appointmentOccurrenceId = it.appointmentOccurrenceId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
@@ -42,6 +42,7 @@ fun appointmentLocation(locationId: Long, prisonCode: String) =
     locationUsage = "APP",
     agencyId = prisonCode,
     currentOccupancy = 2,
+    userDescription = "Test Appointment Location",
   )
 
 fun appointmentCategoryReferenceCode(code: String = "TEST", description: String = "Test Category") =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
@@ -498,7 +498,7 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
     @Test
     @Sql("classpath:test_data/make-MDI-rollout-active-for-both.sql")
     @Sql("classpath:test_data/seed-activity-for-events.sql")
-    @Sql("classpath:test_data/seed-appointment-single-id-4.sql")
+    @Sql("classpath:test_data/seed-appointment-group-id-4.sql")
     fun `POST - multiple prisoners - activities and appointments active - 200 success`() {
       val prisonCode = "MDI"
       val prisonerNumbers = listOf("G4793VF", "A5193DY")

--- a/src/test/resources/test_data/seed-appointment-group-id-4.sql
+++ b/src/test/resources/test_data/seed-appointment-group-id-4.sql
@@ -1,5 +1,5 @@
 INSERT INTO appointment (appointment_id, appointment_type, category_code, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, comment, created, created_by)
-VALUES (3, 'INDIVIDUAL', 'AC1', 'MDI', 123, false, '2022-10-01', '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
+VALUES (3, 'GROUP', 'AC1', 'MDI', 123, false, '2022-10-01', '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
 
 INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, internal_location_id, in_cell, start_date, start_time, end_time, comment)
 VALUES (3, 3, 1, 123, false, '2022-10-01', '09:00', '10:30', 'Appointment occurrence level comment');


### PR DESCRIPTION
Minor changes only.
* Use the correct location description for appointments (`userDescription` in place of `description` on a Location object)
* Addressed one or two review comments.