### PR TITLE
SAA-615 changing default ID's to be 0 instead of -1. Defaulting to -1causes hibernate to do an update as well as an insert when an entity is persisted.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -28,7 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSes
 data class Activity(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val activityId: Long = -1,
+  val activityId: Long = 0,
 
   val prisonCode: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityCategory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityCategory.kt
@@ -12,7 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.
 data class ActivityCategory(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val activityCategoryId: Long = -1,
+  val activityCategoryId: Long = 0,
 
   val code: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityEligibility.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityEligibility.kt
@@ -14,7 +14,7 @@ import jakarta.persistence.Table
 data class ActivityEligibility(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val activityEligibilityId: Long = -1,
+  val activityEligibilityId: Long = 0,
 
   @OneToOne
   @JoinColumn(name = "eligibility_rule_id", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityMinimumEducationLevel.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityMinimumEducationLevel.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityM
 data class ActivityMinimumEducationLevel(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val activityMinimumEducationLevelId: Long = -1,
+  val activityMinimumEducationLevelId: Long = 0,
 
   @ManyToOne
   @JoinColumn(name = "activity_id", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPay.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPay.kt
@@ -15,7 +15,7 @@ import org.hibernate.Hibernate
 data class ActivityPay(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val activityPayId: Long = -1,
+  val activityPayId: Long = 0,
 
   @ManyToOne
   @JoinColumn(name = "activity_id", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -29,7 +29,7 @@ import java.time.temporal.ChronoUnit
 data class ActivitySchedule(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val activityScheduleId: Long = -1,
+  val activityScheduleId: Long = 0,
 
   @ManyToOne
   @JoinColumn(name = "activity_id", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSlot.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSlot.kt
@@ -18,7 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityS
 data class ActivityScheduleSlot(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val activityScheduleSlotId: Long = -1,
+  val activityScheduleSlotId: Long = 0,
 
   @ManyToOne
   @JoinColumn(name = "activity_schedule_id", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSuspension.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSuspension.kt
@@ -15,7 +15,7 @@ import java.time.LocalDate
 data class ActivityScheduleSuspension(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val activityScheduleSuspensionId: Long = -1,
+  val activityScheduleSuspensionId: Long = 0,
 
   @ManyToOne
   @JoinColumn(name = "activity_schedule_id", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTier.kt
@@ -12,7 +12,7 @@ import jakarta.persistence.Table
 data class ActivityTier(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val activityTierId: Long = -1,
+  val activityTierId: Long = 0,
 
   @Column(nullable = false)
   val code: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentInstance as AppointmentInstanceModel
 
 @Entity
+@Immutable
 @Table(name = "v_appointment_instance")
 data class AppointmentInstance(
   @Id

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceHistory.kt
@@ -15,7 +15,7 @@ import java.time.LocalDateTime
 data class AttendanceHistory(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val attendanceHistoryId: Long = -1,
+  val attendanceHistoryId: Long = 0,
 
   @ManyToOne
   @JoinColumn(name = "attendance_id", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceReason.kt
@@ -14,7 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Attendanc
 data class AttendanceReason(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val attendanceReasonId: Long = -1,
+  val attendanceReasonId: Long = 0,
 
   @Enumerated(EnumType.STRING)
   val code: AttendanceReasonEnum,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/DailyStatistics.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/DailyStatistics.kt
@@ -12,7 +12,7 @@ import java.time.LocalDate
 data class DailyStatistics(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val dailyStatisticsId: Long = -1,
+  val dailyStatisticsId: Long = 0,
 
   val statisticsDate: LocalDate,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EligibilityRule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EligibilityRule.kt
@@ -11,7 +11,7 @@ import jakarta.persistence.Table
 data class EligibilityRule(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  var eligibilityRuleId: Long = -1,
+  var eligibilityRuleId: Long = 0,
 
   val code: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventPriority.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventPriority.kt
@@ -13,7 +13,7 @@ import jakarta.persistence.Table
 data class EventPriority(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val eventPriorityId: Long = -1,
+  val eventPriorityId: Long = 0,
 
   val prisonCode: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventReview.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventReview.kt
@@ -12,7 +12,7 @@ import java.time.LocalDateTime
 data class EventReview(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val eventReviewId: Long = -1,
+  val eventReviewId: Long = 0,
 
   val serviceIdentifier: String?,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/LocalAuditRecord.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/LocalAuditRecord.kt
@@ -18,7 +18,7 @@ data class LocalAuditRecord(
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val localAuditId: Long = -1,
+  val localAuditId: Long = 0,
 
   val username: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonPayBand.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonPayBand.kt
@@ -14,7 +14,7 @@ data class PrisonPayBand(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   @Column(nullable = false)
-  val prisonPayBandId: Long = -1,
+  val prisonPayBandId: Long = 0,
 
   @Column(length = 10, nullable = false)
   val prisonCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonRegime.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonRegime.kt
@@ -12,7 +12,7 @@ import java.time.LocalTime
 data class PrisonRegime(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val prisonRegimeId: Long = -1,
+  val prisonRegimeId: Long = 0,
 
   val prisonCode: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonerHistory.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonerHistory.kt
@@ -12,7 +12,7 @@ import java.time.LocalDateTime
 data class PrisonerHistory(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val prisonerHistoryId: Long = -1,
+  val prisonerHistoryId: Long = 0,
 
   val historyType: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonerWaiting.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/PrisonerWaiting.kt
@@ -14,7 +14,7 @@ import java.time.LocalDateTime
 data class PrisonerWaiting(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val prisonerWaitingId: Long = -1,
+  val prisonerWaitingId: Long = 0,
 
   @ManyToOne
   @JoinColumn(name = "activity_id", nullable = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/RolloutPrison.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/RolloutPrison.kt
@@ -14,7 +14,7 @@ import java.time.LocalDate
 data class RolloutPrison(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  val rolloutPrisonId: Long = -1,
+  val rolloutPrisonId: Long = 0,
 
   val code: String,
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -50,7 +50,7 @@ class ActivityScheduleTest {
         minimumIncentiveLevel = "Basic",
         minimumEducationLevel = listOf(
           ActivityMinimumEducationLevel(
-            id = -1,
+            id = 0,
             educationLevelCode = "1",
             educationLevelDescription = "Reading Measure 1.0",
           ),
@@ -111,7 +111,7 @@ class ActivityScheduleTest {
           minimumIncentiveLevel = "Basic",
           minimumEducationLevel = listOf(
             ActivityMinimumEducationLevel(
-              id = -1,
+              id = 0,
               educationLevelCode = "1",
               educationLevelDescription = "Reading Measure 1.0",
             ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
@@ -96,7 +96,7 @@ class ActivityTest {
         minimumIncentiveLevel = "Basic",
         minimumEducationLevel = listOf(
           ModelActivityMinimumEducationLevel(
-            id = -1,
+            id = 0,
             educationLevelCode = "1",
             educationLevelDescription = "Reading Measure 1.0",
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.handlers
 
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
@@ -50,7 +50,7 @@ class OffenderReleasedEventHandlerTest {
       assertThat(it.status(PrisonerStatus.AUTO_SUSPENDED)).isTrue
       assertThat(it.suspendedBy).isEqualTo("SYSTEM")
       assertThat(it.suspendedReason).isEqualTo("Temporarily released from prison")
-      assertThat(it.suspendedTime).isCloseTo(LocalDateTime.now(), Assertions.within(60, ChronoUnit.SECONDS))
+      assertThat(it.suspendedTime).isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
     }
 
     verify(repository).saveAllAndFlush(any<List<Allocation>>())
@@ -98,7 +98,7 @@ class OffenderReleasedEventHandlerTest {
       assertThat(it.deallocatedBy).isEqualTo("SYSTEM")
       assertThat(it.deallocatedReason).isEqualTo("Released from prison")
       assertThat(it.deallocatedTime)
-        .isCloseTo(LocalDateTime.now(), Assertions.within(60, ChronoUnit.SECONDS))
+        .isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
     }
 
     verify(repository).saveAllAndFlush(any<List<Allocation>>())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -61,7 +61,7 @@ class TransformFunctionsTest {
       assertThat(tier).isEqualTo(ModelActivityTier(1, "T1", "Tier 1"))
       assertThat(eligibilityRules).containsExactly(
         ModelActivityEligibility(
-          -1,
+          0,
           ModelEligibilityRule(1, code = "OVER_21", description = "The prisoner must be over 21 to attend"),
         ),
       )
@@ -169,7 +169,7 @@ class TransformFunctionsTest {
       )
       assertThat(pay).containsExactly(
         ModelActivityPay(
-          id = -1,
+          id = 0,
           incentiveNomisCode = "BAS",
           incentiveLevel = "Basic",
           prisonPayBand = lowPayBand.toModelPrisonPayBand(),
@@ -184,7 +184,7 @@ class TransformFunctionsTest {
       assertThat(createdBy).isEqualTo("test")
       assertThat(minimumEducationLevel).containsExactly(
         ModelActivityMinimumEducationLevel(
-          id = -1,
+          id = 0,
           educationLevelCode = "1",
           educationLevelDescription = "Reading Measure 1.0",
         ),


### PR DESCRIPTION
See [Stackoverflow](https://stackoverflow.com/questions/49747891/kotlin-jpa-entity-id) for more details.

The knock of effect of -1 causes our entity listeners to fire for both insert and update when only insert events should be triggering.