### PR TITLE
SAA-422 small refactoring exercise to consolodate the allocations job. This is going to be extended to include additional tasks in upcoming work.

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-cronjob.yaml
@@ -21,4 +21,4 @@ spec:
             args:
               - /bin/sh
               - -c
-              - curl --fail -X POST http://hmpps-activities-management-api/job/deallocate-offenders
+              - curl --fail -X POST http://hmpps-activities-management-api/job/manage-allocations

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.OffenderDeallocationService
 
 @Component
-class OffenderDeallocationJob(private val offenderDeallocationService: OffenderDeallocationService) {
+class ManageAllocationsJob(private val offenderDeallocationService: OffenderDeallocationService) {
 
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerController.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.CreateAttendanceRecordsJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.CreateScheduledInstancesJob
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.OffenderDeallocationJob
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.ManageAllocationsJob
 
 // These endpoints are secured in the ingress rather than the app so that they can be called from
 // within the namespace without requiring authentication
@@ -20,7 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.OffenderDea
 class JobTriggerController(
   private val createScheduledInstancesJob: CreateScheduledInstancesJob,
   private val createAttendanceRecordsJob: CreateAttendanceRecordsJob,
-  private val offenderDeallocationJob: OffenderDeallocationJob,
+  private val manageAllocationsJob: ManageAllocationsJob,
 ) {
 
   @PostMapping(value = ["/create-scheduled-instances"])
@@ -47,15 +47,15 @@ class JobTriggerController(
     return "Create attendance records triggered"
   }
 
-  @PostMapping(value = ["/deallocate-offenders"])
+  @PostMapping(value = ["/manage-allocations"])
   @Operation(
-    summary = "Trigger the job to deallocate offenders when end dates are reached",
+    summary = "Trigger the job to manage allocations",
     description = "Can only be accessed from within the ingress. Requests from elsewhere will result in a 401 response code.",
   )
   @ResponseBody
   @ResponseStatus(HttpStatus.CREATED)
-  fun triggerDeallocateOffendersJob(): String {
-    offenderDeallocationJob.execute()
-    return "Deallocate offenders when end dates are reached triggered"
+  fun triggerManageAllocationsJob(): String {
+    manageAllocationsJob.execute()
+    return "Manage allocations triggered"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -13,7 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Allo
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
-class OffenderDeallocationJobIntegrationTest : IntegrationTestBase() {
+class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var allocationRepository: AllocationRepository
@@ -26,7 +26,7 @@ class OffenderDeallocationJobIntegrationTest : IntegrationTestBase() {
     assertThat(activeAllocations).hasSize(3)
     activeAllocations.forEach { it.assertIsActive() }
 
-    webTestClient.deallocateOffenders()
+    webTestClient.manageAllocations()
 
     val deallocatedAllocations = allocationRepository.findAll()
 
@@ -42,7 +42,7 @@ class OffenderDeallocationJobIntegrationTest : IntegrationTestBase() {
     assertThat(activeAllocations).hasSize(3)
     activeAllocations.forEach { it.assertIsActive() }
 
-    webTestClient.deallocateOffenders()
+    webTestClient.manageAllocations()
 
     val allocations = allocationRepository.findAll()
 
@@ -68,9 +68,9 @@ class OffenderDeallocationJobIntegrationTest : IntegrationTestBase() {
 
   private fun List<Allocation>.prisoner(number: String) = first { it.prisonerNumber == number }
 
-  private fun WebTestClient.deallocateOffenders() {
+  private fun WebTestClient.manageAllocations() {
     post()
-      .uri("/job/deallocate-offenders")
+      .uri("/job/manage-allocations")
       .accept(MediaType.TEXT_PLAIN)
       .exchange()
       .expectStatus().isCreated

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -5,9 +5,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.OffenderDeallocationService
 
-class OffenderDeallocationJobTest {
+class ManageAllocationsJobTest {
   private val offenderDeallocationService: OffenderDeallocationService = mock()
-  private val job = OffenderDeallocationJob(offenderDeallocationService)
+  private val job = ManageAllocationsJob(offenderDeallocationService)
 
   @Test
   fun `attendance records creation triggered for today`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerControllerTest.kt
@@ -10,7 +10,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.CreateAttendanceRecordsJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.CreateScheduledInstancesJob
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.OffenderDeallocationJob
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.ManageAllocationsJob
 
 @WebMvcTest(controllers = [JobTriggerController::class])
 @ContextConfiguration(classes = [JobTriggerController::class])
@@ -23,9 +23,9 @@ class JobTriggerControllerTest : ControllerTestBase<JobTriggerController>() {
   private lateinit var createAttendanceRecordsJob: CreateAttendanceRecordsJob
 
   @MockBean
-  private lateinit var offenderDeallocationJob: OffenderDeallocationJob
+  private lateinit var manageAllocationsJob: ManageAllocationsJob
 
-  override fun controller() = JobTriggerController(createScheduledInstancesJob, createAttendanceRecordsJob, offenderDeallocationJob)
+  override fun controller() = JobTriggerController(createScheduledInstancesJob, createAttendanceRecordsJob, manageAllocationsJob)
 
   @Test
   fun `201 response when create activity sessions job triggered`() {
@@ -50,14 +50,14 @@ class JobTriggerControllerTest : ControllerTestBase<JobTriggerController>() {
   }
 
   @Test
-  fun `201 response when deallocate offenders job triggered`() {
-    val response = mockMvc.triggerJob("deallocate-offenders")
+  fun `201 response when manage allocations job triggered`() {
+    val response = mockMvc.triggerJob("manage-allocations")
       .andExpect { status { isCreated() } }
       .andReturn().response
 
-    assertThat(response.contentAsString).isEqualTo("Deallocate offenders when end dates are reached triggered")
+    assertThat(response.contentAsString).isEqualTo("Manage allocations triggered")
 
-    verify(offenderDeallocationJob).execute()
+    verify(manageAllocationsJob).execute()
   }
 
   private fun MockMvc.triggerJob(jobName: String) = post("/job/$jobName")


### PR DESCRIPTION
There are some extra tasks around changing the status of allocations that we can piggy back off the existing deallocation job hence the renaming to be managing allocations.

This helps prevent conflicts with regards to CRON timings as well.  All changes to the allocations will capture in job.