### PR TITLE
SAA-643 missing query param necessary to determine a prisoners release details when calling prison-api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -26,12 +26,13 @@ inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>(
 @Service
 class PrisonApiClient(private val prisonApiWebClient: WebClient) {
 
-  fun getPrisonerDetails(prisonerNumber: String, fullInfo: Boolean = true): Mono<InmateDetail> {
+  fun getPrisonerDetails(prisonerNumber: String, fullInfo: Boolean = true, extraInfo: Boolean? = null): Mono<InmateDetail> {
     return prisonApiWebClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
           .path("/api/bookings/offenderNo/{prisonerNumber}")
           .queryParam("fullInfo", fullInfo)
+          .maybeQueryParam("extraInfo", extraInfo)
           .build(prisonerNumber)
       }
       .retrieve()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -125,7 +125,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/clear-local-audit.sql",
   )
   fun `204 (no content) response when successfully allocate prisoner to an activity schedule`() {
-    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", false)
+    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", fullInfo = false)
 
     repository.findById(1).orElseThrow().also { assertThat(it.allocations()).isEmpty() }
 
@@ -176,7 +176,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/seed-activity-id-7.sql",
   )
   fun `400 (bad request) response when attempt to allocate already allocated prisoner`() {
-    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", false)
+    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", fullInfo = false)
 
     repository.findById(1).orElseThrow().also { assertThat(it.allocations()).isEmpty() }
 
@@ -202,7 +202,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/seed-activity-id-7.sql",
   )
   fun `403 (forbidden) response when user doesnt have correct role to allocate prisoner`() {
-    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", false)
+    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", fullInfo = false)
 
     repository.findById(1).orElseThrow().also { assertThat(it.allocations()).isEmpty() }
 
@@ -238,7 +238,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
   fun `the allocation should be persisted even if the subsequent event notification fails`() {
     whenever(eventsPublisher.send(any())).thenThrow(RuntimeException("Publishing failure"))
 
-    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", false)
+    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", fullInfo = false)
 
     repository.findById(1).orElseThrow().also { assertThat(it.allocations()).isEmpty() }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -109,7 +109,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
   )
   @Test
   fun `permanent release of prisoner from remand`() {
-    prisonApiMockServer.stubGetPrisonerDetails(prisonerNumber = "A11111A", jsonFileSuffix = "-released-from-remand")
+    prisonApiMockServer.stubGetPrisonerDetails(prisonerNumber = "A11111A", fullInfo = true, extraInfo = true, jsonFileSuffix = "-released-from-remand")
 
     repository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "A11111A").onEach {
       assertThat(it.status(PrisonerStatus.ACTIVE))
@@ -131,7 +131,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
   )
   @Test
   fun `permanent release of prisoner from custodial sentence`() {
-    prisonApiMockServer.stubGetPrisonerDetails(prisonerNumber = "A11111A", jsonFileSuffix = "-released-from-custodial-sentence")
+    prisonApiMockServer.stubGetPrisonerDetails(prisonerNumber = "A11111A", fullInfo = true, extraInfo = true, jsonFileSuffix = "-released-from-custodial-sentence")
 
     repository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "A11111A").onEach {
       assertThat(it.status(PrisonerStatus.ACTIVE))
@@ -153,7 +153,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
   )
   @Test
   fun `permanent release of prisoner due to death in prison`() {
-    prisonApiMockServer.stubGetPrisonerDetails(prisonerNumber = "A11111A", jsonFileSuffix = "-released-on-death-in-prison")
+    prisonApiMockServer.stubGetPrisonerDetails(prisonerNumber = "A11111A", fullInfo = true, extraInfo = true, jsonFileSuffix = "-released-on-death-in-prison")
 
     repository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "A11111A").onEach {
       assertThat(it.status(PrisonerStatus.ACTIVE))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -165,9 +165,9 @@ class PrisonApiMockServer : WireMockServer(8999) {
     )
   }
 
-  fun stubGetPrisonerDetails(prisonerNumber: String, fullInfo: Boolean = true, jsonFileSuffix: String = "") {
+  fun stubGetPrisonerDetails(prisonerNumber: String, fullInfo: Boolean = true, extraInfo: Boolean? = null, jsonFileSuffix: String = "") {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/offenderNo/$prisonerNumber?fullInfo=$fullInfo"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/offenderNo/$prisonerNumber?fullInfo=$fullInfo${extraInfo?.let { "&extraInfo=$it" } ?: ""}"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
@@ -102,7 +102,11 @@ class OffenderReleasedEventHandlerTest {
     }
 
     whenever(prisoner.legalStatus).doReturn(InmateDetail.LegalStatus.DEAD)
-    whenever(prisonApiClient.getPrisonerDetails("123456")).doReturn(Mono.just(prisoner))
+    whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = true, extraInfo = true)).doReturn(
+      Mono.just(
+        prisoner,
+      ),
+    )
     whenever(repository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456")).doReturn(
       previouslyActiveAllocations,
     )
@@ -141,7 +145,11 @@ class OffenderReleasedEventHandlerTest {
       on { sentenceDetail } doReturn sentenceCalcDatesNoReleaseDateForRemand
     }
 
-    whenever(prisonApiClient.getPrisonerDetails("123456")).doReturn(Mono.just(prisoner))
+    whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = true, extraInfo = true)).doReturn(
+      Mono.just(
+        prisoner,
+      ),
+    )
     whenever(repository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456")).doReturn(
       previouslyActiveAllocations,
     )
@@ -181,7 +189,11 @@ class OffenderReleasedEventHandlerTest {
       on { sentenceDetail } doReturn sentenceCalcDatesReleaseDateTodayForCustodialSentence
     }
 
-    whenever(prisonApiClient.getPrisonerDetails("123456")).doReturn(Mono.just(prisoner))
+    whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = true, extraInfo = true)).doReturn(
+      Mono.just(
+        prisoner,
+      ),
+    )
     whenever(repository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456")).doReturn(
       previouslyActiveAllocations,
     )
@@ -213,7 +225,11 @@ class OffenderReleasedEventHandlerTest {
 
     val allocations = listOf(previouslyEndedAllocation, previouslySuspendedAllocation, previouslyActiveAllocation)
 
-    whenever(prisonApiClient.getPrisonerDetails("123456")).doReturn(Mono.just(prisoner))
+    whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = true, extraInfo = true)).doReturn(
+      Mono.just(
+        prisoner,
+      ),
+    )
     whenever(repository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456")).doReturn(allocations)
 
     val successful = handler.handle(offenderReleasedEvent(moorlandPrisonCode, "123456"))


### PR DESCRIPTION
Missing the extraInfo query param when calling prison-api which is needed to determine the prisoners release status.

![image](https://user-images.githubusercontent.com/60104344/235660981-c0713d08-ff3f-482d-bc4a-685be2734cca.png)
