### PR TITLE
SAA-606: Update secret name for hmpps domain events SNS topic values.

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/values.yaml
+++ b/helm_deploy/hmpps-activities-management-api/values.yaml
@@ -71,7 +71,7 @@ generic-service:
       DB_NAME: "database_name"
       DB_USER: "database_username"
       DB_PASS: "database_password"
-    activities-domain-events-sqs-topic-instance-output:
+    hmpps-domain-events-topic:
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ACCESS_KEY_ID: "access_key_id"
       HMPPS_SQS_TOPICS_DOMAINEVENTS_SECRET_ACCESS_KEY: "secret_access_key"
       HMPPS_SQS_TOPICS_DOMAINEVENTS_ARN: "topic_arn"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateScheduledInstancesJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateScheduledInstancesJob.kt
@@ -26,11 +26,11 @@ class CreateScheduledInstancesJob(
 
   /*
   * This job finds all prisons that are active in the rollout table, and for each one, finds
-  * the activities and schedules that are active at that prison between today SCHEDULE_AHEAD_DAYS days
+  * the activities and schedules that are active at that prison between today and SCHEDULE_AHEAD_DAYS days
   * into the future. This value is set as an environment variable in the helm configuration.
   *
   * For each day between the two dates it looks at the list of activities in a prison, their schedules and
-  * slots, and determine which ones need a scheduled instance creating for them. It will avoid duplicating
+  * slots, and determines which ones need a scheduled instance creating for them. It will avoid duplicating
   * instances for the same day - so safe to re-run for the same period (or overlapping periods). Will need
   * some thought here to pick up changes made to scheduled instances that already exist? These will need to
   * be amended in-situ by the user action of changing a schedule or slot (i.e. not the responsibility of this job).

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
@@ -95,17 +95,11 @@ class AttendancesService(
     activitySchedule.allocations().filterNot { it.status(PrisonerStatus.ENDED) }.forEach { f(it) }
   }
 
-  // TODO not applying pay rates.
   private fun createAttendanceRecordIfNoPreExistingRecord(
     instance: ScheduledInstance,
     allocation: Allocation,
   ) {
-    if (attendanceRepository.existsAttendanceByScheduledInstanceAndPrisonerNumber(
-        instance,
-        allocation.prisonerNumber,
-      )
-    ) {
-      log.info("Attendance record already exists for allocation ${allocation.allocationId} and scheduled instance ${instance.scheduledInstanceId}")
+    if (attendanceRepository.existsAttendanceByScheduledInstanceAndPrisonerNumber(instance, allocation.prisonerNumber)) {
       return
     }
 


### PR DESCRIPTION
This is to align our service with others who subscribe or generate events on the HMPPS domain events SNS topic.
A change went into Cloud Platform to automate the generation of consistently named secrets - our service is in this list - so this change makes our API service use the consistent secret name.

A further cloud platform PR will be raised to remove the old secret being created.