### PR TITLE
SAA-677: Fix for nullable fields in events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEvents.kt
@@ -83,7 +83,7 @@ data class IncentivesDeletedEvent(val additionalInformation: IncentivesInformati
   override fun eventType() = InboundEventType.INCENTIVES_DELETED.eventType
 }
 
-data class IncentivesInformation(val nomsNumber: String, val reason: String, val prisonId: String)
+data class IncentivesInformation(val nomsNumber: String, val reason: String?, val prisonId: String?)
 
 // ------------ Cell move events ------------------------------------------------------------------
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/EventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/EventsFactory.kt
@@ -54,3 +54,12 @@ fun cellMoveEvent(prisonerNumber: String = "XXXXXX") =
       livingUnitId = 234L,
     ),
   )
+
+fun iepReviewInsertedEvent(prisonerNumber: String = "XXXXXX", prisonId: String? = null, reason: String? = null) =
+  IncentivesInsertedEvent(
+    IncentivesInformation(
+      nomsNumber = prisonerNumber,
+      prisonId = prisonId,
+      reason = reason,
+    ),
+  )


### PR DESCRIPTION
On Incentives review events the `reason` and `prisonId` fields are sometimes not filled in, and are null.
This was causing an exception when creating the intermediate object for incentives review events.