### PR TITLE
SAA-654: Record other absence reason

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -87,6 +87,7 @@ data class Attendance(
     newIssuePayment = true,
     newIncentiveLevelWarningIssued = null,
     newCaseNoteId = null,
+    newOtherAbsenceReason = null,
   )
 
   fun uncancel() = mark(
@@ -97,6 +98,7 @@ data class Attendance(
     newIssuePayment = null,
     newIncentiveLevelWarningIssued = null,
     newCaseNoteId = null,
+    newOtherAbsenceReason = null,
   )
 
   fun mark(
@@ -107,6 +109,7 @@ data class Attendance(
     newIssuePayment: Boolean?,
     newIncentiveLevelWarningIssued: Boolean?,
     newCaseNoteId: String?,
+    newOtherAbsenceReason: String?,
   ): Attendance {
     if (status != AttendanceStatus.WAITING) {
       this.addHistory(
@@ -138,6 +141,7 @@ data class Attendance(
       issuePayment = newIssuePayment
       incentiveLevelWarningIssued = newIncentiveLevelWarningIssued
       caseNoteId = newCaseNoteId?.toLong()
+      otherAbsenceReason = newOtherAbsenceReason
     }
     status = newStatus
     recordedBy = principalName
@@ -174,6 +178,7 @@ data class Attendance(
     pieces = this.pieces,
     issuePayment = this.issuePayment,
     incentiveLevelWarningIssued = this.incentiveLevelWarningIssued,
+    otherAbsenceReason = this.otherAbsenceReason,
     caseNoteText = this.caseNoteId ?.let { caseNotesApiClient.getCaseNote(this.prisonerNumber, this.caseNoteId)?.text },
     attendanceHistory = this.attendanceHistory
       .sortedWith(compareBy { it.recordedTime })

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -122,7 +122,7 @@ data class Attendance(
           issuePayment = issuePayment,
           caseNoteId = caseNoteId,
           incentiveLevelWarningIssued = incentiveLevelWarningIssued,
-          otherAbsenceReason = otherAbsenceReason,
+          otherAbsenceReason = if (AttendanceReasonEnum.OTHER == reason?.code) otherAbsenceReason else null,
         ),
       )
     }
@@ -141,7 +141,7 @@ data class Attendance(
       issuePayment = newIssuePayment
       incentiveLevelWarningIssued = newIncentiveLevelWarningIssued
       caseNoteId = newCaseNoteId?.toLong()
-      otherAbsenceReason = newOtherAbsenceReason
+      otherAbsenceReason = if (AttendanceReasonEnum.OTHER == reason?.code) newOtherAbsenceReason else null
     }
     status = newStatus
     recordedBy = principalName

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
@@ -66,6 +66,7 @@ class AttendancesService(
         attendanceUpdatesById[it.attendanceId]!!.issuePayment,
         attendanceUpdatesById[it.attendanceId]!!.incentiveLevelWarningIssued,
         caseNoteDetails?.caseNoteId,
+        attendanceUpdatesById[it.attendanceId]!!.otherAbsenceReason,
       )
     }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -336,6 +336,7 @@ fun transform(attendanceHistory: EntityAttendanceHistory): ModelAttendanceHistor
     recordedBy = attendanceHistory.recordedBy,
     issuePayment = attendanceHistory.issuePayment,
     incentiveLevelWarningIssued = attendanceHistory.incentiveLevelWarningIssued,
+    otherAbsenceReason = attendanceHistory.otherAbsenceReason,
   )
 
 fun EntityPrisonPayBand.toModelPrisonPayBand() =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
@@ -49,6 +49,7 @@ class AttendanceTest {
       assertThat(comment).isNull()
       assertThat(recordedBy).isNull()
       assertThat(recordedTime).isNull()
+      assertThat(otherAbsenceReason).isNull()
     }
   }
 


### PR DESCRIPTION
## Overview

Enables `otherAbsenceReason` field to be set when marking attendance