### PR TITLE
SAA-606: Override the Education class to fix nullable fields.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -7,11 +7,11 @@ import org.springframework.web.reactive.function.client.awaitBody
 import org.springframework.web.util.UriBuilder
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.CourtHearings
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Education
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.InmateDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.LocationGroup
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderAdjudicationHearing
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/Education.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/Education.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.AddressDto
+import java.time.LocalDate
+
+// Overridden because some fields are required to be nullable despite the required=true option.
+
+data class Education(
+  @get:JsonProperty("bookingId", required = true) val bookingId: Long? = null,
+  @get:JsonProperty("startDate", required = true) val startDate: LocalDate? = null,
+  @get:JsonProperty("endDate", required = true) val endDate: LocalDate? = null,
+  @get:JsonProperty("studyArea", required = true) val studyArea: String? = null,
+  @get:JsonProperty("educationLevel", required = true) val educationLevel: String? = null,
+  @get:JsonProperty("numberOfYears", required = true) val numberOfYears: Int? = null,
+  @get:JsonProperty("graduationYear", required = true) val graduationYear: String? = null,
+  @get:JsonProperty("comment", required = true) val comment: String? = null,
+  @get:JsonProperty("school", required = true) val school: String? = null,
+  @get:JsonProperty("isSpecialEducation", required = true) val isSpecialEducation: Boolean? = null,
+  @get:JsonProperty("schedule", required = true) val schedule: String? = null,
+  @get:JsonProperty("addresses", required = true) val addresses: List<AddressDto>? = emptyList(),
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/ActivityCandidate.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/ActivityCandidate.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response
 
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Education
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import java.time.LocalDate
 


### PR DESCRIPTION
Small fix for generated prison API types being different to expected nullable fields for Education.