### PR TITLE
SAA-701 exposing the suspension details on allocations as currently not visible when pull back allocations.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -190,7 +190,7 @@ data class ActivitySchedule(
   fun allocatePrisoner(
     prisonerNumber: PrisonerNumber,
     payBand: PrisonPayBand,
-    bookingId: Long?,
+    bookingId: Long,
     startDate: LocalDate = LocalDate.now(),
     endDate: LocalDate? = null,
     allocatedBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -30,7 +30,7 @@ data class Allocation(
 
   val prisonerNumber: String,
 
-  val bookingId: Long? = null,
+  val bookingId: Long,
 
   @OneToOne
   @JoinColumn(name = "prison_pay_band_id")
@@ -98,6 +98,13 @@ data class Allocation(
       scheduleId = activitySchedule.activityScheduleId,
       scheduleDescription = activitySchedule.description,
       isUnemployment = activitySchedule.activity.isUnemployment(),
+      deallocatedBy = deallocatedBy,
+      deallocatedReason = deallocatedReason,
+      deallocatedTime = deallocatedTime,
+      suspendedBy = suspendedBy,
+      suspendedReason = suspendedReason,
+      suspendedTime = suspendedTime,
+      status = prisonerStatus,
     )
 
   fun autoSuspend(dateTime: LocalDateTime, reason: String) =
@@ -122,7 +129,10 @@ data class Allocation(
 
   fun reactivateAutoSuspensions() =
     this.apply {
-      failWithMessageIfAllocationsIsNot("You can only reactivate auto-suspended allocations", PrisonerStatus.AUTO_SUSPENDED)
+      failWithMessageIfAllocationsIsNot(
+        "You can only reactivate auto-suspended allocations",
+        PrisonerStatus.AUTO_SUSPENDED,
+      )
 
       prisonerStatus = PrisonerStatus.ACTIVE
       suspendedTime = null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -15,7 +16,7 @@ data class Allocation(
   val prisonerNumber: String,
 
   @Schema(description = "The offender booking id", example = "10001")
-  val bookingId: Long?,
+  val bookingId: Long,
 
   val activitySummary: String,
 
@@ -44,13 +45,35 @@ data class Allocation(
   @Schema(description = "The person who allocated the prisoner to the activity", example = "Mr Blogs")
   val allocatedBy: String? = null,
 
-  @Schema(description = "The date and time the prisoner was deallocated from the activity", example = "2022-09-02T09:00:00")
+  @Schema(
+    description = "The date and time the prisoner was deallocated from the activity",
+    example = "2022-09-02T09:00:00",
+  )
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
   val deallocatedTime: LocalDateTime? = null,
 
   @Schema(description = "The person who deallocated the prisoner from the activity", example = "Mrs Blogs")
   val deallocatedBy: String? = null,
 
-  @Schema(description = "The descriptive reason why this prisoner was deallocated from the activity", example = "Not attending regularly")
+  @Schema(
+    description = "The descriptive reason why this prisoner was deallocated from the activity",
+    example = "Not attending regularly",
+  )
   val deallocatedReason: String? = null,
+
+  @Schema(description = "The date and time the allocation was suspended", example = "2022-09-02T09:00:00")
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  val suspendedTime: LocalDateTime? = null,
+
+  @Schema(description = "The person who suspended the prisoner from the activity", example = "Mrs Blogs")
+  val suspendedBy: String? = null,
+
+  @Schema(
+    description = "The descriptive reason why this prisoner was suspended from the activity",
+    example = "Temporarily released from prison",
+  )
+  val suspendedReason: String? = null,
+
+  @Schema(description = "The status of the allocation", example = "ACTIVE")
+  val status: PrisonerStatus,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -104,7 +104,7 @@ class ActivityScheduleService(
 
     schedule.allocatePrisoner(
       prisonerNumber = prisonerNumber,
-      bookingId = prisonerDetails.bookingId,
+      bookingId = prisonerDetails.bookingId ?: throw IllegalStateException("Active prisoner $prisonerNumber does not have a booking id."),
       payBand = payBand,
       allocatedBy = allocatedBy,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
@@ -45,7 +45,7 @@ class AppointmentService(
             appointmentType = AppointmentType.INDIVIDUAL,
             prisonCode = request.prisonCode,
             prisonerNumbers = listOf(it.prisonerNumber),
-            prisonerBookings = prisonerBookings.filter { entry -> entry.key == it.prisonerNumber },
+            prisonerBookings = prisonerBookings.filterKeys { k -> k == it.prisonerNumber },
             categoryCode = request.categoryCode,
             appointmentDescription = request.appointmentDescription,
             internalLocationId = request.internalLocationId,

--- a/src/main/resources/migrations/common/V2023.05.11__booking_id_mandatory_on_allocation.sql
+++ b/src/main/resources/migrations/common/V2023.05.11__booking_id_mandatory_on_allocation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE allocation ALTER COLUMN booking_id SET NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandOne
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandThree
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandTwo
@@ -39,6 +40,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
           allocatedBy = "MR BLOGS",
+          status = PrisonerStatus.ACTIVE,
         ),
         Allocation(
           id = 4,
@@ -53,6 +55,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
           allocatedBy = "MR BLOGS",
+          status = PrisonerStatus.ACTIVE,
         ),
       )
     }
@@ -72,20 +75,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
           allocatedBy = "MRS BLOGS",
-        ),
-        Allocation(
-          id = 5,
-          prisonerNumber = "A22222A",
-          bookingId = 10002,
-          activitySummary = "Retirement",
-          scheduleId = 2,
-          scheduleDescription = "Retirement PM",
-          prisonPayBand = testPentonvillePayBandThree,
-          isUnemployment = true,
-          startDate = LocalDate.of(2022, 10, 10),
-          endDate = null,
-          allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
-          allocatedBy = "MRS BLOGS",
+          status = PrisonerStatus.ACTIVE,
         ),
       )
     }
@@ -117,6 +107,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
           allocatedBy = "MR BLOGS",
+          status = PrisonerStatus.ACTIVE,
         ),
         Allocation(
           id = 4,
@@ -131,6 +122,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
           allocatedBy = "MR BLOGS",
+          status = PrisonerStatus.ACTIVE,
         ),
       )
     }
@@ -150,6 +142,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
           allocatedBy = "MRS BLOGS",
+          status = PrisonerStatus.ACTIVE,
         ),
         Allocation(
           id = 5,
@@ -164,6 +157,10 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           endDate = null,
           allocatedTime = LocalDateTime.of(2022, 10, 10, 10, 0),
           allocatedBy = "MRS BLOGS",
+          status = PrisonerStatus.AUTO_SUSPENDED,
+          suspendedBy = "SYSTEM",
+          suspendedTime = LocalDateTime.of(2022, 10, 11, 10, 0),
+          suspendedReason = "Temporary absence",
         ),
       )
     }
@@ -183,6 +180,10 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           endDate = LocalDate.of(2022, 10, 11),
           allocatedTime = LocalDateTime.of(2022, 10, 10, 9, 0),
           allocatedBy = "MRS BLOGS",
+          status = PrisonerStatus.ENDED,
+          deallocatedBy = "SYSTEM",
+          deallocatedReason = "Allocation end date reached",
+          deallocatedTime = LocalDateTime.of(2022, 10, 11, 9, 0),
         ),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCategoryReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
@@ -134,6 +135,7 @@ class TransformFunctionsTest {
               activitySummary = "Maths",
               scheduleId = 1,
               scheduleDescription = "schedule description",
+              status = PrisonerStatus.ACTIVE,
             ),
           ),
           description = "schedule description",

--- a/src/test/resources/test_data/seed-activity-id-6.sql
+++ b/src/test/resources/test_data/seed-activity-id-6.sql
@@ -23,10 +23,10 @@ insert into allocation(allocation_id, activity_schedule_id, prisoner_number, boo
 values (2, 1, 'A22222A', 10002, 2, '2022-10-10', null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (3, 1, 'A33333A', 10003, 2, '2022-10-10', '2022-10-11', '2022-10-10 09:00:00', 'MRS BLOGS', '2022-10-11 09:00:00', 'SYSTEM', 'Allocation end data reached', null, null, null, 'ENDED');
+values (3, 1, 'A33333A', 10003, 2, '2022-10-10', '2022-10-11', '2022-10-10 09:00:00', 'MRS BLOGS', '2022-10-11 09:00:00', 'SYSTEM', 'Allocation end date reached', null, null, null, 'ENDED');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (4, 2, 'A11111A', 10001, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (5, 2, 'A22222A', 10002, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (5, 2, 'A22222A', 10002, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MRS BLOGS', null, null, null, '2022-10-11 10:00:00', 'SYSTEM', 'Temporary absence', 'AUTO_SUSPENDED');


### PR DESCRIPTION
This is part one of two PR's.  Will most likely need to regenerate the types for the UI.

Ready to be reviewed but please do not merge.