### PR TITLE
SAA-654: Bug fix + test

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -122,7 +122,7 @@ data class Attendance(
           issuePayment = issuePayment,
           caseNoteId = caseNoteId,
           incentiveLevelWarningIssued = incentiveLevelWarningIssued,
-          otherAbsenceReason = if (AttendanceReasonEnum.OTHER == reason?.code) otherAbsenceReason else null,
+          otherAbsenceReason = if (AttendanceReasonEnum.OTHER == attendanceReason?.code) otherAbsenceReason else null,
         ),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
@@ -21,20 +21,7 @@ class AttendanceTest {
     val attendance = Attendance(
       scheduledInstance = mock(),
       prisonerNumber = "P000111",
-      attendanceReason = AttendanceReason(
-        1,
-        AttendanceReasonEnum.ATTENDED,
-        "Some Desc",
-        false,
-        true,
-        true,
-        false,
-        false,
-        false,
-        true,
-        1,
-        "some note",
-      ),
+      attendanceReason = attendanceReasons()["ATTENDED"]!!,
       status = AttendanceStatus.COMPLETED,
       comment = "Some Comment",
       recordedBy = "Old User",
@@ -66,5 +53,36 @@ class AttendanceTest {
     assertThat(attendanceWithCanceledInstance.comment).isEqualTo("Staff unavailable")
     assertThat(attendanceWithCanceledInstance.recordedTime).isCloseTo(LocalDateTime.now(), Assertions.within(1, ChronoUnit.SECONDS))
     assertThat(attendanceWithCanceledInstance.recordedBy).isEqualTo("USER1")
+  }
+
+  @Test
+  fun `marking attendance records history`() {
+    val attendanceReason = attendanceReasons()["OTHER"]!!
+    val otherAttendance = attendance.copy(
+      status = AttendanceStatus.COMPLETED,
+      attendanceReason = attendanceReason,
+      otherAbsenceReason = "Other reason",
+      comment = "Some comment",
+      issuePayment = true,
+    )
+
+    otherAttendance.mark(
+      principalName = "New user",
+      reason = null,
+      newStatus = AttendanceStatus.WAITING,
+      newComment = null,
+      newIssuePayment = null,
+      newIncentiveLevelWarningIssued = null,
+      newCaseNoteId = null,
+      newOtherAbsenceReason = null,
+    )
+
+    with(otherAttendance.history().last()) {
+      assertThat(this.attendanceReason).isEqualTo(attendanceReason)
+      assertThat(this.comment).isEqualTo("Some comment")
+      assertThat(this.recordedBy).isEqualTo("Joe Bloggs")
+      assertThat(this.issuePayment).isEqualTo(true)
+      assertThat(this.otherAbsenceReason).isEqualTo("Other reason")
+    }
   }
 }


### PR DESCRIPTION
## Overview

Fixes bug causing `otherAbsenceReason` to be recorded as null in attendance history