### PR TITLE
SAA-529 refactoring handlers so they return an Outcome instead of a boolean.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEventsService.kt
@@ -17,24 +17,16 @@ class InboundEventsService(
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun process(inboundEvent: InboundEvent) {
-    when (inboundEvent) {
-      is OffenderReceivedEvent -> {
-        if (!receivedEventHandler.handle(inboundEvent)) {
-          interestingEventHandler.handle(inboundEvent)
-        }
-      }
-      is OffenderReleasedEvent -> {
-        if (!releasedEventHandler.handle(inboundEvent)) {
-          interestingEventHandler.handle(inboundEvent)
-        }
-      }
-      is IncentivesInsertedEvent -> interestingEventHandler.handle(inboundEvent)
-      is IncentivesUpdatedEvent -> interestingEventHandler.handle(inboundEvent)
-      is IncentivesDeletedEvent -> interestingEventHandler.handle(inboundEvent)
-      is CellMoveEvent -> interestingEventHandler.handle(inboundEvent)
-      is NonAssociationsChangedEvent -> interestingEventHandler.handle(inboundEvent)
-      else -> log.warn("Unsupported event ${inboundEvent.javaClass.name}")
+  fun process(event: InboundEvent) {
+    when (event) {
+      is OffenderReceivedEvent -> receivedEventHandler.handle(event).onFailure { interestingEventHandler.handle(event) }
+      is OffenderReleasedEvent -> releasedEventHandler.handle(event).onFailure { interestingEventHandler.handle(event) }
+      is IncentivesInsertedEvent -> interestingEventHandler.handle(event)
+      is IncentivesUpdatedEvent -> interestingEventHandler.handle(event)
+      is IncentivesDeletedEvent -> interestingEventHandler.handle(event)
+      is CellMoveEvent -> interestingEventHandler.handle(event)
+      is NonAssociationsChangedEvent -> interestingEventHandler.handle(event)
+      else -> log.warn("Unsupported event ${event.javaClass.name}")
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/EventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/EventHandler.kt
@@ -1,9 +1,33 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.handlers
 
-interface EventHandler<T> {
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.InboundEvent
+
+interface EventHandler<T : InboundEvent> {
 
   /**
    * Returns true if the event was handled successfully and false if it was not handled successfully.
    */
-  fun handle(event: T): Boolean
+  fun handle(event: T): Outcome
+}
+
+class Outcome(private val success: Boolean) {
+
+  companion object {
+    fun success() = Outcome(true)
+    fun failed() = Outcome(false)
+  }
+
+  fun isSuccess() = success
+
+  fun onSuccess(block: () -> Unit) {
+    if (success) {
+      block()
+    }
+  }
+
+  fun onFailure(block: () -> Unit) {
+    if (!success) {
+      block()
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
@@ -31,7 +31,7 @@ class InterestingEventHandler(
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  override fun handle(event: InboundEvent): Boolean {
+  override fun handle(event: InboundEvent): Outcome {
     log.info("Checking for interesting event: $event")
 
     prisonApiClient.getPrisonerDetails(event.prisonerNumber(), fullInfo = false).block()?.let { prisoner ->
@@ -48,7 +48,7 @@ class InterestingEventHandler(
             ),
           )
           log.info("Saved interesting event ID ${saved.eventReviewId} - ${event.eventType()} - for ${prisoner.offenderNo}")
-          return true
+          return Outcome.success()
         } else {
           log.info("${prisoner.offenderNo} has no active allocations at ${prisoner.agencyId}")
         }
@@ -56,7 +56,7 @@ class InterestingEventHandler(
         log.info("${prisoner.agencyId} is not a rolled out prison")
       }
     }
-    return false
+    return Outcome.failed()
   }
 
   private fun getEventMessage(event: InboundEvent, prisoner: InmateDetail) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandler.kt
@@ -21,7 +21,7 @@ class OffenderReceivedEventHandler(
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  override fun handle(event: OffenderReceivedEvent): Boolean {
+  override fun handle(event: OffenderReceivedEvent): Outcome {
     log.info("Handling offender received event $event")
 
     if (rolloutPrisonRepository.prisonIsRolledOut(event.prisonCode())) {
@@ -38,13 +38,13 @@ class OffenderReceivedEventHandler(
           log.info("Prisoner is not active in prison ${event.prisonCode()}")
         }
 
-        return true
+        return Outcome.success()
       }
     }
 
     log.info("Ignoring received event for ${event.prisonCode()} - not rolled out.")
 
-    return true
+    return Outcome.success()
   }
 
   private fun RolloutPrisonRepository.prisonIsRolledOut(prisonCode: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandler.kt
@@ -24,31 +24,31 @@ class OffenderReleasedEventHandler(
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
-  override fun handle(event: OffenderReleasedEvent): Boolean {
+  override fun handle(event: OffenderReleasedEvent): Outcome {
     log.info("Handling offender released event $event")
 
     if (rolloutPrisonRepository.findByCode(event.prisonCode())?.isActivitiesRolledOut() == true) {
       return when {
         event.isTemporary() -> {
           suspendOffenderAllocations(event)
-          true
+          Outcome.success()
         }
 
         event.isPermanent() -> {
           deallocateOffenderAllocations(event)
-          true
+          Outcome.success()
         }
 
         else -> {
           log.warn("Failed to handle event $event")
-          false
+          Outcome.failed()
         }
       }
     } else {
       log.info("Ignoring released event for ${event.prisonCode()} - not rolled out.")
     }
 
-    return true
+    return Outcome.success()
   }
 
   private fun suspendOffenderAllocations(event: OffenderReleasedEvent) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEventsServiceTest.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlan
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.handlers.InterestingEventHandler
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.handlers.OffenderReceivedEventHandler
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.handlers.OffenderReleasedEventHandler
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.handlers.Outcome
 
 class InboundEventsServiceTest {
   private val receivedEventHandler: OffenderReceivedEventHandler = mock()
@@ -22,9 +23,9 @@ class InboundEventsServiceTest {
   @BeforeEach
   fun setupMocks() {
     reset(receivedEventHandler, releasedEventHandler, interestingEventHandler)
-    whenever(releasedEventHandler.handle(any())).thenReturn(true)
-    whenever(receivedEventHandler.handle(any())).thenReturn(true)
-    whenever(interestingEventHandler.handle(any())).thenReturn(true)
+    whenever(releasedEventHandler.handle(any())).thenReturn(Outcome.success())
+    whenever(receivedEventHandler.handle(any())).thenReturn(Outcome.success())
+    whenever(interestingEventHandler.handle(any())).thenReturn(Outcome.success())
   }
 
   @Test
@@ -43,7 +44,7 @@ class InboundEventsServiceTest {
 
   @Test
   fun `inbound released event failure is handled as an interesting event`() {
-    whenever(releasedEventHandler.handle(any())).thenReturn(false)
+    whenever(releasedEventHandler.handle(any())).thenReturn(Outcome.failed())
     val inboundEvent = offenderReleasedEvent(moorlandPrisonCode, "123456")
     service.process(inboundEvent)
     verify(releasedEventHandler).handle(inboundEvent)
@@ -52,7 +53,7 @@ class InboundEventsServiceTest {
 
   @Test
   fun `inbound received event failure is handled as an interesting event`() {
-    whenever(receivedEventHandler.handle(any())).thenReturn(false)
+    whenever(receivedEventHandler.handle(any())).thenReturn(Outcome.failed())
     val inboundEvent = offenderReceivedFromTemporaryAbsence(moorlandPrisonCode, "123456")
     service.process(inboundEvent)
     verify(receivedEventHandler).handle(inboundEvent)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
@@ -66,9 +66,9 @@ class InterestingEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
       .doReturn(activeAllocations)
 
-    val result = handler.handle(inboundEvent)
+    val outcome = handler.handle(inboundEvent)
 
-    assertThat(result).isTrue
+    assertThat(outcome.isSuccess()).isTrue
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
     verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
     verify(eventReviewRepository).saveAndFlush(any<EventReview>())
@@ -81,9 +81,9 @@ class InterestingEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
       .doReturn(activeAllocations)
 
-    val result = handler.handle(inboundEvent)
+    val outcome = handler.handle(inboundEvent)
 
-    assertThat(result).isTrue
+    assertThat(outcome.isSuccess()).isTrue
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
     verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
     verify(eventReviewRepository).saveAndFlush(any<EventReview>())
@@ -96,9 +96,9 @@ class InterestingEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
       .doReturn(activeAllocations)
 
-    val result = handler.handle(inboundEvent)
+    val outcome = handler.handle(inboundEvent)
 
-    assertThat(result).isTrue
+    assertThat(outcome.isSuccess()).isTrue
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
     verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
     verify(eventReviewRepository).saveAndFlush(any<EventReview>())
@@ -111,9 +111,9 @@ class InterestingEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
       .doReturn(activeAllocations)
 
-    val result = handler.handle(inboundEvent)
+    val outcome = handler.handle(inboundEvent)
 
-    assertThat(result).isTrue
+    assertThat(outcome.isSuccess()).isTrue
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
     verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
     verify(eventReviewRepository).saveAndFlush(any<EventReview>())
@@ -131,9 +131,9 @@ class InterestingEventHandlerTest {
         )
     }
 
-    val result = handler.handle(inboundEvent)
+    val outcome = handler.handle(inboundEvent)
 
-    assertThat(result).isFalse
+    assertThat(outcome.isSuccess()).isFalse
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
     verifyNoInteractions(allocationRepository)
     verifyNoInteractions(eventReviewRepository)
@@ -145,9 +145,9 @@ class InterestingEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
       .doReturn(emptyList())
 
-    val result = handler.handle(inboundEvent)
+    val outcome = handler.handle(inboundEvent)
 
-    assertThat(result).isFalse
+    assertThat(outcome.isSuccess()).isFalse
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
     verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
     verifyNoInteractions(eventReviewRepository)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandlerTest.kt
@@ -59,9 +59,9 @@ class OffenderReceivedEventHandlerTest {
         )
     }
 
-    val result = handler.handle(inboundEvent)
+    val outcome = handler.handle(inboundEvent)
 
-    assertThat(result).isTrue
+    assertThat(outcome.isSuccess()).isTrue
     verify(rolloutPrisonRepository).findByCode(moorlandPrisonCode)
     verifyNoInteractions(allocationRepository)
   }
@@ -93,9 +93,9 @@ class OffenderReceivedEventHandlerTest {
       on { findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456") } doReturn allocations
     }
 
-    val successful = handler.handle(offenderReceivedFromTemporaryAbsence(moorlandPrisonCode, "123456"))
+    val outcome = handler.handle(offenderReceivedFromTemporaryAbsence(moorlandPrisonCode, "123456"))
 
-    assertThat(successful).isTrue
+    assertThat(outcome.isSuccess()).isTrue
     assertThat(autoSuspendedOne.status(PrisonerStatus.ACTIVE)).isTrue
     assertThat(autoSuspendedTwo.status(PrisonerStatus.ACTIVE)).isTrue
     assertThat(userSuspended.status(PrisonerStatus.SUSPENDED)).isTrue

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
@@ -66,9 +66,9 @@ class OffenderReleasedEventHandlerTest {
         )
     }
 
-    val result = handler.handle(inboundEvent)
+    val outcome = handler.handle(inboundEvent)
 
-    assertThat(result).isTrue
+    assertThat(outcome.isSuccess()).isTrue
     verify(rolloutPrisonRepository).findByCode(moorlandPrisonCode)
     verifyNoInteractions(allocationRepository)
   }
@@ -79,9 +79,9 @@ class OffenderReleasedEventHandlerTest {
     val inboundEvent = offenderReleasedEvent(moorlandPrisonCode, "123456")
     rolloutPrisonRepository.stub { on { findByCode(moorlandPrisonCode) } doReturn null }
 
-    val result = handler.handle(inboundEvent)
+    val outcome = handler.handle(inboundEvent)
 
-    assertThat(result).isTrue
+    assertThat(outcome.isSuccess()).isTrue
     verify(rolloutPrisonRepository).findByCode(moorlandPrisonCode)
     verifyNoInteractions(allocationRepository)
   }
@@ -102,9 +102,9 @@ class OffenderReleasedEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456"))
       .doReturn(previouslyActiveAllocations)
 
-    val successful = handler.handle(offenderTemporaryReleasedEvent(moorlandPrisonCode, "123456"))
+    val outcome = handler.handle(offenderTemporaryReleasedEvent(moorlandPrisonCode, "123456"))
 
-    assertThat(successful).isTrue
+    assertThat(outcome.isSuccess()).isTrue
 
     previouslyActiveAllocations.forEach {
       assertThat(it.status(PrisonerStatus.AUTO_SUSPENDED)).isTrue
@@ -127,9 +127,9 @@ class OffenderReleasedEventHandlerTest {
 
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456")).doReturn(allocations)
 
-    val successful = handler.handle(offenderTemporaryReleasedEvent(moorlandPrisonCode, "123456"))
+    val outcome = handler.handle(offenderTemporaryReleasedEvent(moorlandPrisonCode, "123456"))
 
-    assertThat(successful).isTrue
+    assertThat(outcome.isSuccess()).isTrue
     assertThat(allocations[0].status(PrisonerStatus.AUTO_SUSPENDED)).isTrue
     assertThat(allocations[1].status(PrisonerStatus.ENDED)).isTrue
     assertThat(allocations[2].status(PrisonerStatus.AUTO_SUSPENDED)).isTrue
@@ -156,9 +156,9 @@ class OffenderReleasedEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456"))
       .doReturn(previouslyActiveAllocations)
 
-    val successful = handler.handle(offenderReleasedEvent(moorlandPrisonCode, "123456"))
+    val outcome = handler.handle(offenderReleasedEvent(moorlandPrisonCode, "123456"))
 
-    assertThat(successful).isTrue
+    assertThat(outcome.isSuccess()).isTrue
 
     previouslyActiveAllocations.forEach {
       assertThat(it.status(PrisonerStatus.ENDED)).isTrue
@@ -196,9 +196,9 @@ class OffenderReleasedEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456"))
       .doReturn(previouslyActiveAllocations)
 
-    val successful = handler.handle(offenderReleasedEvent(moorlandPrisonCode, "123456"))
+    val outcome = handler.handle(offenderReleasedEvent(moorlandPrisonCode, "123456"))
 
-    assertThat(successful).isTrue
+    assertThat(outcome.isSuccess()).isTrue
 
     previouslyActiveAllocations.forEach {
       assertThat(it.status(PrisonerStatus.ENDED)).isTrue
@@ -237,9 +237,9 @@ class OffenderReleasedEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456"))
       .doReturn(previouslyActiveAllocations)
 
-    val successful = handler.handle(offenderReleasedEvent(moorlandPrisonCode, "123456"))
+    val outcome = handler.handle(offenderReleasedEvent(moorlandPrisonCode, "123456"))
 
-    assertThat(successful).isTrue
+    assertThat(outcome.isSuccess()).isTrue
 
     previouslyActiveAllocations.forEach {
       assertThat(it.status(PrisonerStatus.ENDED)).isTrue
@@ -270,9 +270,9 @@ class OffenderReleasedEventHandlerTest {
     whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(moorlandPrisonCode, "123456"))
       .doReturn(allocations)
 
-    val successful = handler.handle(offenderReleasedEvent(moorlandPrisonCode, "123456"))
+    val outcome = handler.handle(offenderReleasedEvent(moorlandPrisonCode, "123456"))
 
-    assertThat(successful).isTrue
+    assertThat(outcome.isSuccess()).isTrue
 
     with(previouslyEndedAllocation) {
       assertThat(status(PrisonerStatus.ENDED)).isTrue
@@ -294,7 +294,7 @@ class OffenderReleasedEventHandlerTest {
       ),
     )
 
-    val successful = handler.handle(
+    val outcome = handler.handle(
       OffenderReleasedEvent(
         ReleaseInformation(
           nomsNumber = "12345",
@@ -304,7 +304,7 @@ class OffenderReleasedEventHandlerTest {
       ),
     )
 
-    assertThat(successful).isFalse
+    assertThat(outcome.isSuccess()).isFalse
     assertThat(allocation.status(PrisonerStatus.ACTIVE)).isTrue
     verifyNoInteractions(allocationRepository)
   }


### PR DESCRIPTION
This change allows for a more fluent api approach when an event handler is called/used.