### PR TITLE
SAA-609: App insights logging fix for preprod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -10,7 +10,7 @@ generic-service:
     PRISON_API_URL: https://api-preprod.prison.service.justice.gov.uk
     PRISONER_SEARCH_API_URL: https://prisoner-offender-search-preprod.prison.service.justice.gov.uk
     CASE_NOTES_API_URL: https://preprod.offender-case-notes.service.justice.gov.uk
-    APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.json
+    APPLICATIONINSIGHTS_CONFIGURATION_FILE: applicationinsights.dev.json
     SCHEDULE_AHEAD_DAYS: 14
     FEATURE_EVENTS_SNS_ENABLED: true
     FEATURE_AUDIT_SERVICE_HMPPS_ENABLED: true


### PR DESCRIPTION
Preprod API pods failing to start with an AppInsights configuration error.

Logs indicate it may be to do with sampling that was configured for prod and preprod, so reverting to no sampling for preprod (like it is in dev).

This may not work, but it won't harm. The other possibility is that our spring profiles are not set correctly when running in preprod.