### PR TITLE
SAA0-689 POST endpoint to acknowledge events after reviewing them

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventReview.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/EventReview.kt
@@ -28,7 +28,7 @@ data class EventReview(
 
   val eventData: String? = null,
 
-  val acknowledgedTime: LocalDateTime? = null,
+  var acknowledgedTime: LocalDateTime? = null,
 
-  val acknowledgedBy: String? = null,
+  var acknowledgedBy: String? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/EventAcknowledgeRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/EventAcknowledgeRequest.kt
@@ -1,0 +1,9 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Request to acknowledge change events")
+data class EventAcknowledgeRequest(
+  @Schema(description = "The list of IDs to acknowledge", example = "[3,5,6]")
+  val eventReviewIds: List<Long>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/EventReviewSearchResults.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/EventReviewSearchResults.kt
@@ -11,6 +11,9 @@ data class EventReviewSearchResults(
   @Schema(description = "The current page number", example = "1")
   val pageNumber: Int,
 
+  @Schema(description = "The total number of elements", example = "20")
+  val totalElements: Long,
+
   @Schema(description = "The total number of pages", example = "5")
   val totalPages: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/EventReviewController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/EventReviewController.kt
@@ -11,18 +11,23 @@ import jakarta.validation.constraints.PastOrPresent
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.PositiveOrZero
 import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.EventAcknowledgeRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.EventReviewSearchRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.EventReviewSearchResults
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.EventReviewService
+import java.security.Principal
 import java.time.LocalDate
+import org.springframework.web.bind.annotation.RequestBody
 
 @RestController
 @RequestMapping("/event-review", produces = [MediaType.APPLICATION_JSON_VALUE])
@@ -110,4 +115,57 @@ class EventReviewController(private val eventReviewService: EventReviewService) 
       paginatedResults.totalPages,
     )
   }
+
+  @PostMapping(
+    value = ["/prison/{prison}/acknowledge"],
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @ResponseBody
+  @Operation(
+    summary = "Acknowledge a list of change of circumstance events in the prison.",
+    description = "Used to indicate that a subset of change events have been acknowledged.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "204",
+        description = "The event IDS were acknowledged.",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid request body",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Requested resource not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun acknowledgeEvents(
+    principal: Principal,
+
+    @PathVariable("prison", required = true)
+    @Parameter(description = "The prison code e.g. MDI")
+    @NotEmpty(message = "Prison code must be supplied")
+    prisonCode: String,
+
+    @Parameter(description = "The prisoner allocation request details", required = true)
+    @RequestBody
+    eventReviewAcknowledgeRequest: EventAcknowledgeRequest,
+  ): ResponseEntity<Any> =
+    eventReviewService.acknowledgeEvents(prisonCode, eventReviewAcknowledgeRequest, principal.name)
+      .let { ResponseEntity.noContent().build() }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/EventReviewController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/EventReviewController.kt
@@ -103,6 +103,11 @@ class EventReviewController(private val eventReviewService: EventReviewService) 
       acknowledgedEvents = includeAcknowledged,
     )
     val paginatedResults = eventReviewService.getFilteredEvents(page, size, sortDirection, filters)
-    return EventReviewSearchResults(paginatedResults.content, paginatedResults.number, paginatedResults.totalPages)
+    return EventReviewSearchResults(
+      paginatedResults.content,
+      paginatedResults.number,
+      paginatedResults.totalElements,
+      paginatedResults.totalPages,
+    )
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventReviewService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventReviewService.kt
@@ -6,10 +6,12 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.EventAcknowledgeRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.EventReviewSearchRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventReviewRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventReviewSearchSpecification
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transform
+import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.EventReview as ModelEventReview
 
 @Service
@@ -55,6 +57,15 @@ class EventReviewService(
       pageable,
       results.totalElements,
     )
+  }
+
+  fun acknowledgeEvents(prisonCode: String, req: EventAcknowledgeRequest, name: String) {
+    val updatedEvents = eventReviewRepository.findAllById(req.eventReviewIds)
+    updatedEvents.map {
+      it.acknowledgedBy = name
+      it.acknowledgedTime = LocalDateTime.now()
+    }
+    eventReviewRepository.saveAll(updatedEvents)
   }
 
   private fun createSort(sortDirection: String, sortField: String = "eventTime"): Sort? {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/EventReviewIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/EventReviewIntegrationTest.kt
@@ -29,6 +29,7 @@ class EventReviewIntegrationTest : IntegrationTestBase() {
       assertThat(content.last().eventReviewId).isEqualTo(10)
       assertThat(content.first().eventTime).isBefore(content.last().eventTime)
       assertThat(totalPages).isEqualTo(2)
+      assertThat(totalElements).isEqualTo(12)
     }
 
     // Should not include any acknowledged events
@@ -51,6 +52,7 @@ class EventReviewIntegrationTest : IntegrationTestBase() {
     with(result!!) {
       assertThat(content.size).isEqualTo(2)
       assertThat(totalPages).isEqualTo(6)
+      assertThat(totalElements).isEqualTo(12)
     }
 
     result = webTestClient.getEvents(page = 0, size = 5)
@@ -64,6 +66,7 @@ class EventReviewIntegrationTest : IntegrationTestBase() {
     with(result!!) {
       assertThat(content.size).isEqualTo(5)
       assertThat(totalPages).isEqualTo(3)
+      assertThat(totalElements).isEqualTo(12)
     }
 
     result = webTestClient.getEvents(page = 0, size = 12)
@@ -77,6 +80,7 @@ class EventReviewIntegrationTest : IntegrationTestBase() {
     with(result!!) {
       assertThat(content.size).isEqualTo(12)
       assertThat(totalPages).isEqualTo(1)
+      assertThat(totalElements).isEqualTo(12)
     }
   }
 
@@ -94,6 +98,7 @@ class EventReviewIntegrationTest : IntegrationTestBase() {
     with(result!!) {
       assertThat(content.size).isEqualTo(13)
       assertThat(totalPages).isEqualTo(1)
+      assertThat(totalElements).isEqualTo(13)
     }
   }
 
@@ -111,6 +116,7 @@ class EventReviewIntegrationTest : IntegrationTestBase() {
     with(result!!) {
       assertThat(content.size).isEqualTo(5)
       assertThat(totalPages).isEqualTo(1)
+      assertThat(totalElements).isEqualTo(5)
     }
   }
 
@@ -129,6 +135,7 @@ class EventReviewIntegrationTest : IntegrationTestBase() {
       assertThat(content.first().eventReviewId).isEqualTo(12)
       assertThat(content.last().eventReviewId).isEqualTo(1)
       assertThat(totalPages).isEqualTo(1)
+      assertThat(totalElements).isEqualTo(12)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/EventReviewControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/EventReviewControllerTest.kt
@@ -50,7 +50,7 @@ class EventReviewControllerTest : ControllerTestBase<EventReviewController>() {
 
     assertThat(result.contentAsString).isEqualTo(
       mapper.writeValueAsString(
-        EventReviewSearchResults(response.content, response.number, response.totalPages),
+        EventReviewSearchResults(response.content, response.number, response.totalElements, response.totalPages),
       ),
     )
 
@@ -81,7 +81,7 @@ class EventReviewControllerTest : ControllerTestBase<EventReviewController>() {
 
     assertThat(result.contentAsString).isEqualTo(
       mapper.writeValueAsString(
-        EventReviewSearchResults(response.content, response.number, response.totalPages),
+        EventReviewSearchResults(response.content, response.number, response.totalElements, response.totalPages),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventReviewServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/EventReviewServiceTest.kt
@@ -6,11 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.domain.Specification
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventReview
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.EventAcknowledgeRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.EventReviewSearchRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventReviewRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventReviewSearchSpecification
@@ -57,5 +59,23 @@ class EventReviewServiceTest {
       assertThat(it.bookingId).isEqualTo(1)
       assertThat(it.eventData).isEqualTo("XYZ")
     }
+  }
+
+  @Test
+  fun `acknowledges events`() {
+    val prisonCode = "MDI"
+    val eventReviewIds = mutableListOf<Long>(1, 2, 3)
+    val request = EventAcknowledgeRequest(eventReviewIds)
+    val results = listOf(
+      EventReview(1, "service", "x.y.z", LocalDateTime.now(), prisonCode, "G1234FF", 1, "XYZ"),
+      EventReview(2, "service", "x.y.z", LocalDateTime.now(), prisonCode, "G1234FF", 1, "XYZ"),
+      EventReview(3, "service", "x.y.z", LocalDateTime.now(), prisonCode, "G1234FF", 1, "XYZ"),
+    )
+
+    whenever(eventReviewRepository.findAllById(eventReviewIds)).thenReturn(results)
+
+    eventReviewService.acknowledgeEvents(prisonCode, request, "PRINCIPAL")
+
+    verify(eventReviewRepository).saveAll(results)
   }
 }


### PR DESCRIPTION
Allows the UI to post the IDs (multiple) of the events that have been reviewed and acknowledged.