### PR TITLE
SAA-763 planned allocation deallocations should be considered when the deallocation job runs.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -19,7 +19,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Allo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonRegimeRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import java.time.LocalDate
-import java.time.LocalDateTime
 
 @Service
 class ManageAllocationsService(
@@ -36,17 +35,15 @@ class ManageAllocationsService(
   }
 
   fun allocations(operation: AllocationOperation) {
-    LocalDateTime.now().let { now ->
-      when (operation) {
-        AllocationOperation.DEALLOCATE_ENDING -> {
-          log.info("Ending allocations due to end today.")
-          allocationsDueToEnd().allocations(now, DeallocationReason.ENDED)
-        }
+    when (operation) {
+      AllocationOperation.DEALLOCATE_ENDING -> {
+        log.info("Ending allocations due to end today.")
+        allocationsDueToEnd().allocations(DeallocationReason.ENDED)
+      }
 
-        AllocationOperation.DEALLOCATE_EXPIRING -> {
-          log.info("Expiring allocations due to expire today.")
-          allocationsDueToExpire().allocations(now, DeallocationReason.EXPIRED)
-        }
+      AllocationOperation.DEALLOCATE_EXPIRING -> {
+        log.info("Expiring allocations due to expire today.")
+        allocationsDueToExpire().allocations(DeallocationReason.EXPIRED)
       }
     }
   }
@@ -115,11 +112,11 @@ class ManageAllocationsService(
       false
     }
 
-  private fun Map<ActivitySchedule, List<Allocation>>.allocations(dateTime: LocalDateTime, reason: DeallocationReason) {
+  private fun Map<ActivitySchedule, List<Allocation>>.allocations(reason: DeallocationReason) {
     this.keys.forEach { schedule ->
       continueToRunOnFailure(
         block = {
-          getOrDefault(schedule, emptyList()).map { allocation -> allocation.deallocateNow(dateTime, reason) }
+          getOrDefault(schedule, emptyList()).map { allocation -> allocation.deallocateNow(reason) }
             .let {
               if (it.isNotEmpty()) {
                 activityScheduleRepository.saveAndFlush(schedule)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
@@ -55,9 +55,7 @@ class ActivitiesChangedEventHandler(
       }
 
   private fun List<Allocation>.deallocateAndSaveAffectedAllocations(reason: DeallocationReason) =
-    LocalDateTime.now().let { now ->
-      this.filterNot { it.status(PrisonerStatus.ENDED) }.map { it.deallocateNow(now, reason) }
-    }.saveAffectedAllocations()
+    this.filterNot { it.status(PrisonerStatus.ENDED) }.map { it.deallocateNow(reason) }.saveAffectedAllocations()
 
   private fun List<Allocation>.saveAffectedAllocations() =
     allocationRepository.saveAllAndFlush(this).toList()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandler.kt
@@ -86,9 +86,7 @@ class OffenderReleasedEventHandler(
     }.saveAffectedAllocations()
 
   private fun List<Allocation>.deallocateAndSaveAffectedAllocations(reason: DeallocationReason) =
-    LocalDateTime.now().let { now ->
-      this.filterNot { it.status(PrisonerStatus.ENDED) }.map { it.deallocateNow(now, reason) }
-    }.saveAffectedAllocations()
+    this.filterNot { it.status(PrisonerStatus.ENDED) }.map { it.deallocateNow(reason) }.saveAffectedAllocations()
 
   private fun List<Allocation>.saveAffectedAllocations() =
     allocationRepository.saveAllAndFlush(this).toList()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
@@ -8,6 +9,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocat
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonPayBand
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation as EntityAllocation
 
 class AllocationTest : ModelTest() {
@@ -108,7 +110,7 @@ class AllocationTest : ModelTest() {
     val now = LocalDateTime.now()
 
     val allocation = allocation().also {
-      it.deallocateNow(now, DeallocationReason.ENDED)
+      it.deallocateNow(DeallocationReason.ENDED)
       assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.ENDED)
     }
 
@@ -116,7 +118,7 @@ class AllocationTest : ModelTest() {
       assertOnCommonModalTransformation(this, allocation)
       assertThat(deallocatedBy).isEqualTo("Activities Management Service")
       assertThat(deallocatedReason).isEqualTo(DeallocationReason.ENDED.toModel())
-      assertThat(deallocatedTime).isEqualTo(now)
+      assertThat(deallocatedTime).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
       assertThat(suspendedBy).isNull()
       assertThat(suspendedReason).isNull()
       assertThat(suspendedTime).isNull()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
@@ -21,7 +21,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Acti
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonPayBandRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelAllocations
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.util.Optional
 
 class ActivityScheduleServiceTest {
@@ -48,7 +47,7 @@ class ActivityScheduleServiceTest {
   @Test
   fun `ended allocations for a given schedule are not returned`() {
     val schedule = schedule().apply {
-      allocations().first().apply { deallocateNow(LocalDateTime.now(), DeallocationReason.ENDED) }
+      allocations().first().apply { deallocateNow(DeallocationReason.ENDED) }
     }
 
     whenever(repository.findById(1)).thenReturn(Optional.of(schedule))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CapacityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CapacityServiceTest.kt
@@ -14,7 +14,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
-import java.time.LocalDateTime
 import java.util.Optional
 
 class CapacityServiceTest {
@@ -43,7 +42,7 @@ class CapacityServiceTest {
 
   @Test
   fun `getActivityCategoryCapacityAndAllocated excludes deallocations from summary for known category ID`() {
-    val activity = activityEntity().also { it.schedules().first().allocations().first().deallocateNow(LocalDateTime.now(), DeallocationReason.ENDED) }
+    val activity = activityEntity().also { it.schedules().first().allocations().first().deallocateNow(DeallocationReason.ENDED) }
 
     whenever(activityCategoryRepository.findById(1)).thenReturn(Optional.of(activityCategory()))
     whenever(activityRepository.getAllByPrisonCodeAndActivityCategory("MDI", activityCategory()))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
@@ -88,7 +88,7 @@ class ManageAttendancesServiceTest {
   @Test
   fun `attendance record is not created when allocation has ended`() {
     instance.activitySchedule.activity.attendanceRequired = true
-    allocation.deallocateNow(today.atStartOfDay(), DeallocationReason.ENDED)
+    allocation.deallocateNow(DeallocationReason.ENDED)
 
     whenever(scheduledInstanceRepository.findAllBySessionDate(today)).thenReturn(listOf(instance))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
@@ -91,7 +91,7 @@ class ActivitiesChangedEventHandlerTest {
     val allocations = listOf(
       allocation().copy(allocationId = 1, prisonerNumber = "123456"),
       allocation().copy(allocationId = 2, prisonerNumber = "123456")
-        .also { it.deallocateNow(LocalDateTime.now(), DeallocationReason.ENDED) },
+        .also { it.deallocateNow(DeallocationReason.ENDED) },
       allocation().copy(allocationId = 3, prisonerNumber = "123456"),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandlerTest.kt
@@ -77,7 +77,7 @@ class OffenderReceivedEventHandlerTest {
       allocation().copy(allocationId = 2, prisonerNumber = "123456").autoSuspend(now, "Auto Reason")
     val userSuspended =
       allocation().copy(allocationId = 3, prisonerNumber = "123456").userSuspend(now, "User reason", "username")
-    val ended = allocation().copy(allocationId = 3, prisonerNumber = "123456").deallocateNow(now, DeallocationReason.ENDED)
+    val ended = allocation().copy(allocationId = 3, prisonerNumber = "123456").deallocateNow(DeallocationReason.ENDED)
 
     val allocations = listOf(autoSuspendedOne, autoSuspendedTwo, userSuspended, ended)
 


### PR DESCRIPTION
Updates to ensure deallocation job factors in planned deallocations in the job which deallocates and ends allocations that have an end date (or planned end date).