### PR TITLE
SAA-780 the reason codes presented to the UI need to be restricted to a subset of codes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![codecov](https://codecov.io/github/ministryofjustice/hmpps-activities-management-api/branch/main/graph/badge.svg?token=DYVHRRP1B1)](https://codecov.io/github/ministryofjustice/hmpps-activities-management-api)
 [![CircleCI](https://dl.circleci.com/status-badge/img/gh/ministryofjustice/hmpps-activities-management-api/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/ministryofjustice/hmpps-activities-management-api/tree/main)
+[![API docs](https://img.shields.io/badge/API_docs-view-85EA2D.svg?logo=swagger)](https://activities-api-dev.prison.service.justice.gov.uk/swagger-ui/index.html?configUrl=/v3/api-docs/swagger-config)
 
 # hmpps-activities-management-api
 

--- a/generate-prison-api-types.sh
+++ b/generate-prison-api-types.sh
@@ -1,1 +1,0 @@
-openapi-generator generate -i https://api-dev.prison.service.justice.gov.uk/v3/api-docs -g kotlin-spring

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -201,25 +201,26 @@ enum class PrisonerStatus {
   ACTIVE, SUSPENDED, AUTO_SUSPENDED, ENDED
 }
 
-enum class DeallocationReason(val description: String) {
+enum class DeallocationReason(val description: String, val displayed: Boolean = false) {
   DIED("Deceased"),
   ENDED("Allocation end date reached"),
   EXPIRED("Expired"),
-  OTHER("Other"),
-  PERSONAL("Personal reason"),
-  PROBLEM("Problem understanding material"),
+  OTHER("Other", true),
+  PERSONAL("Personal reason", true),
+  PROBLEM("Problem understanding material", true),
   RELEASED("Released from prison"),
-  REMOVED("Removed"),
-  SECURITY("Security"),
+  REMOVED("Removed", true),
+  SECURITY("Security", true),
   TEMPORARY_ABSENCE("Temporary absence"),
-  UNACCEPTABLE_ATTENDANCE("Unacceptable attendance"),
-  UNACCEPTABLE_BEHAVIOUR("Unacceptable behaviour"),
-  WITHDRAWN("Withdrawn"),
+  UNACCEPTABLE_ATTENDANCE("Unacceptable attendance", true),
+  UNACCEPTABLE_BEHAVIOUR("Unacceptable behaviour", true),
+  WITHDRAWN("Withdrawn", true),
   ;
 
   fun toModel() = ModelDeallocationReason(name, description)
 
   companion object {
-    fun toModelDeallocationReasons() = DeallocationReason.values().map(DeallocationReason::toModel)
+    fun toModelDeallocationReasons() =
+      DeallocationReason.values().filter(DeallocationReason::displayed).map(DeallocationReason::toModel)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/PrisonerDeallocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/PrisonerDeallocationRequest.kt
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import java.time.LocalDate
 
 @Schema(
@@ -24,9 +23,13 @@ data class PrisonerDeallocationRequest(
   @field:NotEmpty(message = "One or more prisoner numbers for the deallocation request must be supplied.")
   val prisonerNumbers: List<String>?,
 
-  @Schema(description = "The reason code for the deallocation", example = "RELEASED")
-  @field:NotNull(message = "The reason code for the deallocation request must supplied.")
-  val reasonCode: DeallocationReason?,
+  @Schema(
+    description = "The reason code for the deallocation",
+    example = "RELEASED",
+    allowableValues = ["OTHER", "PERSONAL", "PROBLEM", "REMOVED", "SECURITY", "UNACCEPTABLE_ATTENDANCE", "UNACCEPTABLE_BEHAVIOUR", "WITHDRAWN"],
+  )
+  @field:NotEmpty(message = "The reason code for the deallocation request must supplied.")
+  val reasonCode: String?,
 
   @Schema(
     description =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toPrisonerNumber
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ScheduledInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
@@ -129,10 +130,15 @@ class ActivityScheduleService(
 
     repository.findOrThrowNotFound(scheduleId).run {
       request.prisonerNumbers!!.distinct().forEach {
-        deallocatePrisonerOn(it, request.endDate!!, request.reasonCode!!, deallocatedBy)
+        deallocatePrisonerOn(it, request.endDate!!, request.reasonCode.toDeallocationReason(), deallocatedBy)
         log.info("Planned deallocation of prisoner $it from activity schedule id ${this.activityScheduleId}")
       }
       repository.saveAndFlush(this)
     }
   }
+
+  private fun String?.toDeallocationReason() =
+    DeallocationReason.values()
+      .filter(DeallocationReason::displayed)
+      .firstOrNull { it.name == this } ?: throw IllegalArgumentException("Invalid deallocation reason specified '$this'")
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -39,6 +39,7 @@ import java.time.temporal.ChronoUnit
 @TestPropertySource(
   properties = [
     "feature.event.activities.prisoner.allocated=true",
+    "feature.event.activities.activity-schedule.amended=true",
     "feature.audit.service.hmpps.enabled=true",
     "feature.audit.service.local.enabled=true",
     "feature.event.activities.prisoner.allocation-amended=true",
@@ -318,7 +319,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
       1,
       PrisonerDeallocationRequest(
         prisonerNumbers = listOf("G4793VF"),
-        reasonCode = DeallocationReason.RELEASED,
+        reasonCode = DeallocationReason.WITHDRAWN.name,
         endDate = TimeSource.tomorrow(),
       ),
     ).expectStatus().isNoContent
@@ -326,7 +327,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
     repository.findById(1).orElseThrow().also {
       with(it.allocations().first().plannedDeallocation!!) {
         assertThat(plannedBy).isEqualTo("test-client")
-        assertThat(plannedReason).isEqualTo(DeallocationReason.RELEASED)
+        assertThat(plannedReason).isEqualTo(DeallocationReason.WITHDRAWN)
         assertThat(plannedDate).isEqualTo(TimeSource.tomorrow())
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
@@ -107,8 +107,6 @@ class AllocationTest : ModelTest() {
 
   @Test
   fun `check deallocated allocation transformation`() {
-    val now = LocalDateTime.now()
-
     val allocation = allocation().also {
       it.deallocateNow(DeallocationReason.ENDED)
       assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.ENDED)
@@ -123,6 +121,20 @@ class AllocationTest : ModelTest() {
       assertThat(suspendedReason).isNull()
       assertThat(suspendedTime).isNull()
     }
+  }
+
+  @Test
+  fun `check displayable deallocation reasons`() {
+    assertThat(DeallocationReason.toModelDeallocationReasons()).containsExactlyInAnyOrder(
+      DeallocationReason.OTHER.toModel(),
+      DeallocationReason.PERSONAL.toModel(),
+      DeallocationReason.PROBLEM.toModel(),
+      DeallocationReason.REMOVED.toModel(),
+      DeallocationReason.SECURITY.toModel(),
+      DeallocationReason.UNACCEPTABLE_ATTENDANCE.toModel(),
+      DeallocationReason.UNACCEPTABLE_BEHAVIOUR.toModel(),
+      DeallocationReason.WITHDRAWN.toModel(),
+    )
   }
 
   private fun assertOnCommonModalTransformation(model: Allocation, entity: EntityAllocation) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleControllerTest.kt
@@ -182,7 +182,7 @@ class ActivityScheduleControllerTest : ControllerTestBase<ActivityScheduleContro
   fun `204 response when deallocate offender from a schedule`() {
     val request = PrisonerDeallocationRequest(
       prisonerNumbers = listOf("654321"),
-      reasonCode = DeallocationReason.RELEASED,
+      reasonCode = DeallocationReason.RELEASED.name,
       endDate = TimeSource.tomorrow(),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationControllerTest.kt
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationsService
 
@@ -47,6 +48,28 @@ class AllocationControllerTest : ControllerTestBase<AllocationController>() {
     mockMvc.getAllocationById(1)
       .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
       .andExpect { status { isNotFound() } }
+  }
+
+  @Test
+  fun `200 response when get deallocation reasons`() {
+    val response = mockMvc.get("/allocations/deallocation-reasons")
+      .andExpect { status { isOk() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).contains(DeallocationReason.OTHER.name)
+    assertThat(response.contentAsString).contains(DeallocationReason.PERSONAL.name)
+    assertThat(response.contentAsString).contains(DeallocationReason.PROBLEM.name)
+    assertThat(response.contentAsString).contains(DeallocationReason.REMOVED.name)
+    assertThat(response.contentAsString).contains(DeallocationReason.SECURITY.name)
+    assertThat(response.contentAsString).contains(DeallocationReason.UNACCEPTABLE_ATTENDANCE.name)
+    assertThat(response.contentAsString).contains(DeallocationReason.UNACCEPTABLE_BEHAVIOUR.name)
+    assertThat(response.contentAsString).contains(DeallocationReason.WITHDRAWN.name)
+
+    assertThat(response.contentAsString).doesNotContain(DeallocationReason.DIED.name)
+    assertThat(response.contentAsString).doesNotContain(DeallocationReason.ENDED.name)
+    assertThat(response.contentAsString).doesNotContain(DeallocationReason.EXPIRED.name)
+    assertThat(response.contentAsString).doesNotContain(DeallocationReason.RELEASED.name)
+    assertThat(response.contentAsString).doesNotContain(DeallocationReason.TEMPORARY_ABSENCE.name)
   }
 
   private fun MockMvc.getAllocationById(id: Long) = get("/allocations/id/{allocationId}", id)


### PR DESCRIPTION
Some of the deallocation reason codes are only applicable to the API e.g. when jobs run.