### PR TITLE
SAA-820 changes to allow allocation management operations to be run and different times.

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-activiate-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-activiate-cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: activate-allocations
+spec:
+  schedule: "0 2 * * *" # 2am every day
+  concurrencyPolicy: Replace
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 43200
+  successfulJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: Never
+          activeDeadlineSeconds: 3600
+          containers:
+          - name: activate-allocations-job
+            image: ghcr.io/ministryofjustice/hmpps-devops-tools
+            args:
+              - /bin/sh
+              - -c
+              - curl --fail -X POST http://hmpps-activities-management-api/job/manage-allocations -H "Content-Type: application/json" -d '["STARTING_TODAY"]'

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-cronjob.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: deallocate-offenders
+  name: deallocate-allocations
 spec:
   schedule: "0 22 * * *" # 10pm every day
   concurrencyPolicy: Replace
@@ -16,9 +16,9 @@ spec:
           restartPolicy: Never
           activeDeadlineSeconds: 3600
           containers:
-          - name: deallocate-offenders-job
+          - name: deallocate-allocations-job
             image: ghcr.io/ministryofjustice/hmpps-devops-tools
             args:
               - /bin/sh
               - -c
-              - curl --fail -X POST http://hmpps-activities-management-api/job/manage-allocations
+              - curl --fail -X POST http://hmpps-activities-management-api/job/manage-allocations -H "Content-Type: application/json" -d '["DEALLOCATE_ENDING","DEALLOCATE_EXPIRING"]'

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -152,7 +152,11 @@ data class Allocation(
     )
 
   fun activate() =
-    this.apply { prisonerStatus = PrisonerStatus.ACTIVE }
+    this.apply {
+      failWithMessageIfAllocationsIsNot("You can only activate pending allocations", PrisonerStatus.PENDING)
+
+      prisonerStatus = PrisonerStatus.ACTIVE
+    }
 
   fun autoSuspend(dateTime: LocalDateTime, reason: String) =
     this.apply {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
+import org.slf4j.LoggerFactory
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
@@ -7,11 +8,21 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageA
 
 @Component
 class ManageAllocationsJob(private val service: ManageAllocationsService) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
 
+  /**
+   * The order in which the operations are supplied determines the order of execution of the operation.
+   */
   @Async("asyncExecutor")
-  fun execute() {
-    service.allocations(AllocationOperation.STARTING_TODAY)
-    service.allocations(AllocationOperation.DEALLOCATE_ENDING)
-    service.allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+  fun execute(operations: List<AllocationOperation>) {
+    if (operations.isEmpty()) {
+      log.warn("No allocation operations specified")
+    } else {
+      log.info("The following allocation operations will be performed in sequence: $operations")
+    }
+
+    operations.distinct().forEach(service::allocations)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerController.kt
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.Parameter
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.CreateScheduledInstancesJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.ManageAllocationsJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.ManageAttendanceRecordsJob
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 
 // These endpoints are secured in the ingress rather than the app so that they can be called from
 // within the namespace without requiring authentication
@@ -56,12 +58,25 @@ class JobTriggerController(
   @PostMapping(value = ["/manage-allocations"])
   @Operation(
     summary = "Trigger the job to manage allocations",
-    description = "Can only be accessed from within the ingress. Requests from elsewhere will result in a 401 response code.",
+    description = """
+        One or more operations to trigger for managing allocations. Duplicates are ignored.
+        
+        The order in which the operations are supplied determines the order in which the operations are executed.
+        
+        Can only be accessed from within the ingress. Requests from elsewhere will result in a 401 response code.
+    """,
   )
   @ResponseBody
   @ResponseStatus(HttpStatus.CREATED)
-  fun triggerManageAllocationsJob(): String {
-    manageAllocationsJob.execute()
-    return "Manage allocations triggered"
+  fun triggerManageAllocationsJob(
+    @RequestBody
+    @Parameter(
+      description = "The operation (or operations) to trigger",
+      required = true,
+    )
+    operations: List<AllocationOperation>,
+  ): String {
+    manageAllocationsJob.execute(operations.distinct())
+    return "Manage allocations triggered operations ${operations.distinct()}"
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -82,7 +82,7 @@ class ManageAllocationsService(
     rolloutPrisonRepository.findAll().filter { it.isActivitiesRolledOut() }
 
   private fun List<Allocation>.activatePending() =
-    filter { allocation -> allocation.prisonerStatus == PrisonerStatus.PENDING }
+    filter { it.status(PrisonerStatus.PENDING) }
       .forEach {
         it.activate()
         allocationRepository.saveAndFlush(it)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -232,4 +232,26 @@ class AllocationTest {
     }.isInstanceOf(IllegalStateException::class.java)
       .hasMessage("Allocation with ID '1' is already deallocated.")
   }
+
+  @Test
+  fun `activate pending allocation`() {
+    val allocation = allocation()
+      .apply { prisonerStatus = PrisonerStatus.PENDING }
+      .also { assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.PENDING) }
+
+    allocation.activate()
+
+    assertThat(allocation.prisonerStatus).isEqualTo(PrisonerStatus.ACTIVE)
+  }
+
+  @Test
+  fun `can only activate pending allocation`() {
+    val allocation = allocation()
+      .also { assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.ACTIVE) }
+
+    assertThatThrownBy {
+      allocation.activate()
+    }.isInstanceOf(IllegalStateException::class.java)
+      .hasMessage("You can only activate pending allocations")
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocati
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSearchPrisonerFixture
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -29,9 +30,9 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
     val activeAllocations = allocationRepository.findAll()
 
     assertThat(activeAllocations).hasSize(3)
-    activeAllocations.forEach { it.assertIsActive() }
+    activeAllocations.forEach { it.assertIs(PrisonerStatus.ACTIVE) }
 
-    webTestClient.manageAllocations()
+    webTestClient.manageAllocations(listOf(AllocationOperation.DEALLOCATE_ENDING))
 
     val deallocatedAllocations = allocationRepository.findAll()
 
@@ -43,20 +44,20 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
   @Test
   fun `deallocate offenders for activity with no end date`() {
     val allocations = allocationRepository.findAll().also {
-      it.prisoner("A11111A").assertIsActive()
-      it.prisoner("A22222A").assertIsActive()
-      it.prisoner("A33333A").assertIsActive()
+      it.prisoner("A11111A").assertIs(PrisonerStatus.ACTIVE)
+      it.prisoner("A22222A").assertIs(PrisonerStatus.ACTIVE)
+      it.prisoner("A33333A").assertIs(PrisonerStatus.ACTIVE)
     }
 
     assertThat(allocations).hasSize(3)
 
-    webTestClient.manageAllocations()
+    webTestClient.manageAllocations(listOf(AllocationOperation.DEALLOCATE_ENDING))
 
     allocationRepository.findAll().let {
       assertThat(it).hasSize(3)
-      it.prisoner("A11111A").assertIsActive()
+      it.prisoner("A11111A").assertIs(PrisonerStatus.ACTIVE)
       it.prisoner("A22222A").assertIsDeallocated(DeallocationReason.ENDED)
-      it.prisoner("A33333A").assertIsActive()
+      it.prisoner("A33333A").assertIs(PrisonerStatus.ACTIVE)
     }
   }
 
@@ -78,16 +79,27 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
 
     assertThat(allocations).hasSize(1)
 
-    webTestClient.manageAllocations()
+    webTestClient.manageAllocations(listOf(AllocationOperation.DEALLOCATE_EXPIRING))
 
     allocationRepository.findAll().prisoner("A11111A").assertIsDeallocated(DeallocationReason.EXPIRED)
   }
 
-  private fun Allocation.assertIsActive() {
-    assertThat(prisonerStatus).isEqualTo(PrisonerStatus.ACTIVE)
-    assertThat(deallocatedBy).isNull()
-    assertThat(deallocatedReason).isNull()
-    assertThat(deallocatedTime).isNull()
+  @Sql("classpath:test_data/seed-allocations-pending.sql")
+  @Test
+  fun `pending allocation is activated`() {
+    val allocations = allocationRepository.findAll().also {
+      it.prisoner("A11111A").assertIs(PrisonerStatus.PENDING)
+    }
+
+    assertThat(allocations).hasSize(1)
+
+    webTestClient.manageAllocations(listOf(AllocationOperation.STARTING_TODAY))
+
+    allocationRepository.findAll().prisoner("A11111A").assertIs(PrisonerStatus.ACTIVE)
+  }
+
+  private fun Allocation.assertIs(status: PrisonerStatus) {
+    assertThat(this.prisonerStatus).isEqualTo(status)
   }
 
   private fun Allocation.assertIsAutoSuspended() {
@@ -103,10 +115,12 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
 
   private fun List<Allocation>.prisoner(number: String) = first { it.prisonerNumber == number }
 
-  private fun WebTestClient.manageAllocations() {
+  private fun WebTestClient.manageAllocations(operations: List<AllocationOperation>) {
     post()
       .uri("/job/manage-allocations")
       .accept(MediaType.TEXT_PLAIN)
+      .contentType(MediaType.APPLICATION_JSON)
+      .bodyValue(mapper.writeValueAsString(operations))
       .exchange()
       .expectStatus().isCreated
     Thread.sleep(1000)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
@@ -11,9 +12,40 @@ class ManageAllocationsJobTest {
   private val job = ManageAllocationsJob(offenderDeallocationService)
 
   @Test
-  fun `attendance records creation triggered for today`() {
-    job.execute()
+  fun `single allocation operation triggered`() {
+    job.execute(listOf(AllocationOperation.DEALLOCATE_ENDING))
 
     verify(offenderDeallocationService).allocations(AllocationOperation.DEALLOCATE_ENDING)
+  }
+
+  @Test
+  fun `all allocation operations triggered in order`() {
+    job.execute(
+      listOf(
+        AllocationOperation.STARTING_TODAY,
+        AllocationOperation.DEALLOCATE_ENDING,
+        AllocationOperation.DEALLOCATE_EXPIRING,
+      ),
+    )
+
+    offenderDeallocationService.inOrder {
+      verify(offenderDeallocationService).allocations(AllocationOperation.STARTING_TODAY)
+      verify(offenderDeallocationService).allocations(AllocationOperation.DEALLOCATE_ENDING)
+      verify(offenderDeallocationService).allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    }
+
+    job.execute(
+      listOf(
+        AllocationOperation.DEALLOCATE_ENDING,
+        AllocationOperation.DEALLOCATE_EXPIRING,
+        AllocationOperation.STARTING_TODAY,
+      ),
+    )
+
+    offenderDeallocationService.inOrder {
+      verify(offenderDeallocationService).allocations(AllocationOperation.DEALLOCATE_ENDING)
+      verify(offenderDeallocationService).allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+      verify(offenderDeallocationService).allocations(AllocationOperation.STARTING_TODAY)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerControllerTest.kt
@@ -5,12 +5,14 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.post
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.CreateScheduledInstancesJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.ManageAllocationsJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.ManageAttendanceRecordsJob
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 
 @WebMvcTest(controllers = [JobTriggerController::class])
 @ContextConfiguration(classes = [JobTriggerController::class])
@@ -62,15 +64,41 @@ class JobTriggerControllerTest : ControllerTestBase<JobTriggerController>() {
   }
 
   @Test
-  fun `201 response when manage allocations job triggered`() {
-    val response = mockMvc.triggerJob("manage-allocations")
+  fun `201 response when manage allocations job triggered for single operation`() {
+    val response = mockMvc.triggerJob("manage-allocations", listOf(AllocationOperation.STARTING_TODAY))
       .andExpect { status { isCreated() } }
       .andReturn().response
 
-    assertThat(response.contentAsString).isEqualTo("Manage allocations triggered")
+    assertThat(response.contentAsString).isEqualTo("Manage allocations triggered operations ${setOf(AllocationOperation.STARTING_TODAY)}")
 
-    verify(manageAllocationsJob).execute()
+    verify(manageAllocationsJob).execute(listOf(AllocationOperation.STARTING_TODAY))
   }
 
-  private fun MockMvc.triggerJob(jobName: String) = post("/job/$jobName")
+  @Test
+  fun `201 response when manage allocations job triggered for multiple operations`() {
+    val response = mockMvc.triggerJob("manage-allocations", listOf(AllocationOperation.STARTING_TODAY, AllocationOperation.DEALLOCATE_ENDING))
+      .andExpect { status { isCreated() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).isEqualTo("Manage allocations triggered operations ${setOf(AllocationOperation.STARTING_TODAY, AllocationOperation.DEALLOCATE_ENDING)}")
+
+    verify(manageAllocationsJob).execute(listOf(AllocationOperation.STARTING_TODAY, AllocationOperation.DEALLOCATE_ENDING))
+  }
+
+  @Test
+  fun `201 response when manage allocations job triggered for duplicate operations`() {
+    val response = mockMvc.triggerJob("manage-allocations", listOf(AllocationOperation.DEALLOCATE_EXPIRING, AllocationOperation.DEALLOCATE_EXPIRING))
+      .andDo { println() }
+      .andExpect { status { isCreated() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).isEqualTo("Manage allocations triggered operations ${setOf(AllocationOperation.DEALLOCATE_EXPIRING)}")
+
+    verify(manageAllocationsJob).execute(listOf(AllocationOperation.DEALLOCATE_EXPIRING))
+  }
+
+  private fun MockMvc.triggerJob(jobName: String, mayBeBody: Any? = null) = post("/job/$jobName") {
+    contentType = MediaType.APPLICATION_JSON
+    content = mayBeBody?.let(mapper::writeValueAsString)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
@@ -240,10 +240,10 @@ class ManageAllocationsServiceTest {
     val schedule = mock<ActivitySchedule>()
     val activity = mock<Activity>()
     val pendingAllocation: Allocation = mock {
-      on { prisonerStatus } doReturn PrisonerStatus.PENDING
+      on { status(PrisonerStatus.PENDING) } doReturn true
     }
     val activeAllocation: Allocation = mock {
-      on { prisonerStatus } doReturn PrisonerStatus.ACTIVE
+      on { status(PrisonerStatus.ACTIVE) } doReturn true
     }
 
     whenever(activity.schedules()).thenReturn(listOf(schedule))
@@ -258,9 +258,6 @@ class ManageAllocationsServiceTest {
     verify(pendingAllocation).activate()
     verify(allocationRepository).saveAndFlush(pendingAllocation)
     verifyNoMoreInteractions(allocationRepository)
-
-    verify(activeAllocation).prisonerStatus
-    verifyNoMoreInteractions(activeAllocation)
   }
 
   private fun Allocation.verifyIsActive() {

--- a/src/test/resources/test_data/seed-allocations-pending.sql
+++ b/src/test/resources/test_data/seed-allocations-pending.sql
@@ -1,0 +1,20 @@
+--
+-- Test data for activity pending allocation activation.
+--
+INSERT INTO prison_regime (prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
+VALUES('PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
+
+insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description)
+values (1, 1, '1', 'Reading Measure 1.0');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date, null);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (1, 1, 'A11111A', 10001, 1, current_date, null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'PENDING');


### PR DESCRIPTION
Previously the timing for activating pending allocations for today would have been performed at 10pm.

Now they will be activated at 2am in time for other jobs to do what is needed for the day e.g. create attendance records for active allocations.