### PR TITLE
SAA-773 - Do not overwrite status of suspended prisoners on cancel/uncancel

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -83,7 +83,7 @@ data class Attendance(
 
   fun cancel(reason: AttendanceReason) = mark(
     principalName = scheduledInstance.cancelledBy,
-    reason = reason,
+    reason = if (this.attendanceReason?.code != AttendanceReasonEnum.SUSPENDED) reason else this.attendanceReason,
     newStatus = AttendanceStatus.COMPLETED,
     newComment = scheduledInstance.cancelledReason,
     newIssuePayment = true,
@@ -94,7 +94,7 @@ data class Attendance(
 
   fun uncancel() = mark(
     principalName = null,
-    reason = null,
+    reason = if (this.attendanceReason?.code != AttendanceReasonEnum.SUSPENDED) null else this.attendanceReason,
     newStatus = AttendanceStatus.WAITING,
     newComment = null,
     newIssuePayment = null,
@@ -130,7 +130,7 @@ data class Attendance(
     }
 
     if (newStatus == AttendanceStatus.WAITING) {
-      attendanceReason = null
+      attendanceReason = if (this.attendanceReason?.code != AttendanceReasonEnum.SUSPENDED) null else attendanceReason
       comment = null
       issuePayment = null
       incentiveLevelWarningIssued = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
@@ -42,6 +42,30 @@ class AttendanceTest {
   }
 
   @Test
+  fun `uncancel does not alter the attendance reason of a suspended prisoner`() {
+    val attendance = Attendance(
+      scheduledInstance = mock(),
+      prisonerNumber = "P000111",
+      attendanceReason = attendanceReasons()["SUSPENDED"]!!,
+      status = AttendanceStatus.COMPLETED,
+      comment = "Some Comment",
+      recordedBy = "Old User",
+      recordedTime = LocalDateTime.now(),
+    )
+
+    attendance.uncancel()
+
+    with(attendance) {
+      assertThat(attendanceReason).isEqualTo(attendanceReasons()["SUSPENDED"])
+      assertThat(status()).isEqualTo(AttendanceStatus.WAITING)
+      assertThat(comment).isNull()
+      assertThat(recordedBy).isNull()
+      assertThat(recordedTime).isNull()
+      assertThat(otherAbsenceReason).isNull()
+    }
+  }
+
+  @Test
   fun `can cancel attendance`() {
     val attendanceReason = attendanceReasons()["CANCELLED"]!!
     val canceledInstance =
@@ -52,6 +76,25 @@ class AttendanceTest {
     assertThat(attendanceWithCanceledInstance.status()).isEqualTo(AttendanceStatus.COMPLETED)
     assertThat(attendanceWithCanceledInstance.issuePayment).isEqualTo(true)
     assertThat(attendanceWithCanceledInstance.attendanceReason).isEqualTo(attendanceReason)
+    assertThat(attendanceWithCanceledInstance.comment).isEqualTo("Staff unavailable")
+    assertThat(attendanceWithCanceledInstance.recordedTime).isCloseTo(
+      LocalDateTime.now(),
+      Assertions.within(1, ChronoUnit.SECONDS),
+    )
+    assertThat(attendanceWithCanceledInstance.recordedBy).isEqualTo("USER1")
+  }
+
+  @Test
+  fun `cancel does not alter the attendance reason of a suspended prisoner`() {
+    val attendanceReason = attendanceReasons()["CANCELLED"]!!
+    val canceledInstance =
+      instance.copy(cancelledBy = "USER1", cancelledTime = today, cancelledReason = "Staff unavailable")
+    val attendanceWithCanceledInstance = attendance.copy(attendanceReason = attendanceReasons()["SUSPENDED"], scheduledInstance = canceledInstance)
+
+    attendanceWithCanceledInstance.cancel(attendanceReason)
+    assertThat(attendanceWithCanceledInstance.status()).isEqualTo(AttendanceStatus.COMPLETED)
+    assertThat(attendanceWithCanceledInstance.issuePayment).isEqualTo(true)
+    assertThat(attendanceWithCanceledInstance.attendanceReason).isEqualTo(attendanceReasons()["SUSPENDED"])
     assertThat(attendanceWithCanceledInstance.comment).isEqualTo("Staff unavailable")
     assertThat(attendanceWithCanceledInstance.recordedTime).isCloseTo(
       LocalDateTime.now(),


### PR DESCRIPTION
Alongside the unit tests I have also performed the following manual test

- Create an activity via the UI with a start date of today
- Allocate three prisoners to that activity
- Set the status of one of the prisoners to SUSPENDED.
- Generate the attendance records using swagger (one of them now has an attendance reason of 7 - SUSPENDED)
- Cancel the session. The attendance records for the unsuspended prisoners have their reason set to 8 - WAITING. The attendance record for the suspended prisoner still has its attendance reason set to 7 and the prisoner attendance and pay is recorded as **SUSPENDED NO PAY**
- Uncancel the session. The attendance records for the unsuspended prisoners have their reason set to null. The attendance record for the suspended prisoner still has its attendance reason set to 7

<img width="1295" alt="image" src="https://github.com/ministryofjustice/hmpps-activities-management-api/assets/10604405/2ddf5eec-00f0-44c9-8103-d6cce1265ce4">
