### PR TITLE
SAA-839 work to improve resilience of our jobs and record their success or failure in the DB should we need to recover/re-run.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Job.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Job.kt
@@ -18,11 +18,12 @@ data class Job(
 
   @Enumerated(EnumType.STRING)
   val jobType: JobType,
+
+  val startedAt: LocalDateTime,
 ) {
-  var startedAt: LocalDateTime = LocalDateTime.now()
-    private set
 
   var endedAt: LocalDateTime? = null
+    private set
 
   var successful: Boolean = false
     private set
@@ -36,14 +37,28 @@ data class Job(
     successful = true
   }
 
+  fun failed() = this.apply {
+    if (endedAt != null) {
+      throw IllegalStateException("Job is already ended.")
+    }
+
+    endedAt = LocalDateTime.now()
+    successful = false
+  }
+
   companion object {
-    fun start(jobType: JobType) = Job(jobType = jobType)
+    fun successful(jobType: JobType, start: LocalDateTime) = Job(jobType = jobType, startedAt = start).succeeded()
+
+    fun failed(jobType: JobType, start: LocalDateTime) = Job(jobType = jobType, startedAt = start).failed()
   }
 }
 
 enum class JobType {
-  ALLOCATION,
-  ATTENDANCE,
-  DEALLOCATION,
+  ALLOCATE,
+  ATTENDANCE_CREATE,
+  ATTENDANCE_EXPIRE,
+  DEALLOCATE_ENDING,
+  DEALLOCATE_EXPIRING,
+  SCHEDULES,
   ;
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Job.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Job.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "job")
+data class Job(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val jobId: Long = 0,
+
+  @Enumerated(EnumType.STRING)
+  val jobType: JobType,
+) {
+  var startedAt: LocalDateTime = LocalDateTime.now()
+    private set
+
+  var endedAt: LocalDateTime? = null
+
+  var successful: Boolean = false
+    private set
+
+  fun succeeded() = this.apply {
+    if (endedAt != null) {
+      throw IllegalStateException("Job is already ended.")
+    }
+
+    endedAt = LocalDateTime.now()
+    successful = true
+  }
+
+  companion object {
+    fun start(jobType: JobType) = Job(jobType = jobType)
+  }
+}
+
+enum class JobType {
+  ALLOCATION,
+  ATTENDANCE,
+  DEALLOCATION,
+  ;
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
@@ -9,25 +9,25 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageA
 @Component
 class ManageAllocationsJob(
   private val service: ManageAllocationsService,
-  private val safeJobRunner: SafeJobRunner,
+  private val jobRunner: SafeJobRunner,
 ) {
 
   @Async("asyncExecutor")
   fun execute(withActivate: Boolean = false, withDeallocate: Boolean = false) {
     if (withActivate) {
-      safeJobRunner.runSafe(
-        JobDefinition(JobType.ALLOCATION) {
+      jobRunner.runSafe(
+        JobDefinition(JobType.ALLOCATE) {
           service.allocations(AllocationOperation.STARTING_TODAY)
         },
       )
     }
 
     if (withDeallocate) {
-      safeJobRunner.runSafe(
-        JobDefinition(jobType = JobType.DEALLOCATION) {
+      jobRunner.runSafe(
+        JobDefinition(jobType = JobType.DEALLOCATE_ENDING) {
           service.allocations(AllocationOperation.DEALLOCATE_ENDING)
         },
-        JobDefinition(jobType = JobType.DEALLOCATION) {
+        JobDefinition(jobType = JobType.DEALLOCATE_EXPIRING) {
           service.allocations(AllocationOperation.DEALLOCATE_EXPIRING)
         },
       )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJob.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AttendanceOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAttendancesService
 
@@ -12,12 +13,24 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageA
  * more this will likely change the behaviour of this job.
  */
 @Component
-class ManageAttendanceRecordsJob(private val attendancesService: ManageAttendancesService) {
+class ManageAttendanceRecordsJob(
+  private val attendancesService: ManageAttendancesService,
+  private val jobRunner: SafeJobRunner,
+) {
   @Async("asyncExecutor")
   fun execute(withExpiry: Boolean) {
-    attendancesService.attendances(AttendanceOperation.CREATE)
+    jobRunner.runSafe(
+      JobDefinition(
+        JobType.ATTENDANCE_CREATE,
+      ) { attendancesService.attendances(AttendanceOperation.CREATE) },
+    )
+
     if (withExpiry) {
-      attendancesService.attendances(AttendanceOperation.EXPIRE)
+      jobRunner.runSafe(
+        JobDefinition(
+          JobType.ATTENDANCE_EXPIRE,
+        ) { attendancesService.attendances(AttendanceOperation.EXPIRE) },
+      )
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
@@ -1,0 +1,33 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
+
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Job
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+
+@Component
+class SafeJobRunner(private val jobRepository: JobRepository) {
+
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun runSafe(vararg jobDefinitions: JobDefinition) {
+    jobDefinitions.forEach(this::runSafe)
+  }
+
+  fun runSafe(jobDefinition: JobDefinition) {
+    val job = Job.start(jobDefinition.jobType)
+
+    runCatching {
+      jobDefinition.block()
+    }
+      .onSuccess { job.succeeded() }
+      .onFailure { log.error("Failed to run ${jobDefinition.jobType} job", it) }
+
+    jobRepository.saveAndFlush(job)
+  }
+}
+
+data class JobDefinition(val jobType: JobType, val block: () -> Unit)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/JobRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/JobRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Job
+
+@Repository
+interface JobRepository : JpaRepository<Job, Long>

--- a/src/main/resources/migrations/common/V2023.06.13__add_job.sql
+++ b/src/main/resources/migrations/common/V2023.06.13__add_job.sql
@@ -1,0 +1,10 @@
+CREATE TABLE job (
+  job_id     bigserial    NOT NULL CONSTRAINT job_pk PRIMARY KEY,
+  job_type   varchar(100) NOT NULL,
+  started_at timestamp    NOT NULL,
+  successful boolean      NOT NULL,
+  ended_at   timestamp
+);
+
+CREATE INDEX idx_job_type ON job (job_type);
+CREATE INDEX idx_started_at ON job (started_at);

--- a/src/main/resources/migrations/common/V2023.06.13__add_job.sql
+++ b/src/main/resources/migrations/common/V2023.06.13__add_job.sql
@@ -2,8 +2,8 @@ CREATE TABLE job (
   job_id     bigserial    NOT NULL CONSTRAINT job_pk PRIMARY KEY,
   job_type   varchar(100) NOT NULL,
   started_at timestamp    NOT NULL,
-  successful boolean      NOT NULL,
-  ended_at   timestamp
+  ended_at   timestamp    NOT NULL,
+  successful boolean      NOT NULL
 );
 
 CREATE INDEX idx_job_type ON job (job_type);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/JobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/JobTest.kt
@@ -9,24 +9,38 @@ import java.time.temporal.ChronoUnit
 
 class JobTest {
 
+  private val start = LocalDateTime.MIN
+
   @Test
-  fun `can successful job`() {
-    val job = Job.start(JobType.ATTENDANCE)
+  fun `successful job`() {
+    val job = Job.successful(JobType.ATTENDANCE_CREATE, start)
 
-    assertThat(job.jobType).isEqualTo(JobType.ATTENDANCE)
-    assertThat(job.startedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
-    assertThat(job.endedAt).isNull()
-
-    job.succeeded()
-
+    assertThat(job.jobType).isEqualTo(JobType.ATTENDANCE_CREATE)
+    assertThat(job.startedAt).isEqualTo(start)
     assertThat(job.endedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
     assertThat(job.successful).isTrue
   }
 
   @Test
-  fun `cannot end already ended job`() {
-    val job = Job.start(JobType.ATTENDANCE).succeeded()
+  fun `failed job`() {
+    val job = Job.failed(JobType.ATTENDANCE_CREATE, start)
 
-    assertThatThrownBy { job.succeeded() }.isInstanceOf(IllegalStateException::class.java).hasMessage("Job is already ended.")
+    assertThat(job.jobType).isEqualTo(JobType.ATTENDANCE_CREATE)
+    assertThat(job.startedAt).isEqualTo(start)
+    assertThat(job.endedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
+    assertThat(job.successful).isFalse
+  }
+
+  @Test
+  fun `job cannot be changed once successful or failed`() {
+    with(Job.successful(JobType.ATTENDANCE_CREATE, LocalDateTime.now())) {
+      assertThatThrownBy { succeeded() }.isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Job is already ended.")
+    }
+
+    with(Job.failed(JobType.ATTENDANCE_CREATE, LocalDateTime.now())) {
+      assertThatThrownBy { failed() }.isInstanceOf(IllegalStateException::class.java)
+        .hasMessage("Job is already ended.")
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/JobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/JobTest.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class JobTest {
+
+  @Test
+  fun `can successful job`() {
+    val job = Job.start(JobType.ATTENDANCE)
+
+    assertThat(job.jobType).isEqualTo(JobType.ATTENDANCE)
+    assertThat(job.startedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
+    assertThat(job.endedAt).isNull()
+
+    job.succeeded()
+
+    assertThat(job.endedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
+    assertThat(job.successful).isTrue
+  }
+
+  @Test
+  fun `cannot end already ended job`() {
+    val job = Job.start(JobType.ATTENDANCE).succeeded()
+
+    assertThatThrownBy { job.succeeded() }.isInstanceOf(IllegalStateException::class.java).hasMessage("Job is already ended.")
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -1,39 +1,57 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAllocationsService
 
 class ManageAllocationsJobTest {
-  private val offenderDeallocationService: ManageAllocationsService = mock()
+  private val deallocationService: ManageAllocationsService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = SafeJobRunner(jobRepository)
-  private val job = ManageAllocationsJob(offenderDeallocationService, safeJobRunner)
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val job = ManageAllocationsJob(deallocationService, safeJobRunner)
+  private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 
   @Test
   fun `activate allocation operation triggered`() {
     job.execute(withActivate = true)
 
-    verify(offenderDeallocationService).allocations(AllocationOperation.STARTING_TODAY)
+    verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
+    verify(safeJobRunner).runSafe(jobDefinitionCaptor.capture())
+
+    assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.ALLOCATE)
   }
 
   @Test
   fun `deallocate allocation operation triggered`() {
     job.execute(withDeallocate = true)
 
-    verify(offenderDeallocationService).allocations(AllocationOperation.DEALLOCATE_ENDING)
-    verify(offenderDeallocationService).allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    verify(deallocationService).allocations(AllocationOperation.DEALLOCATE_ENDING)
+    verify(deallocationService).allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    verify(safeJobRunner, times(2)).runSafe(jobDefinitionCaptor.capture())
+
+    assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.DEALLOCATE_ENDING)
+    assertThat(jobDefinitionCaptor.secondValue.jobType).isEqualTo(JobType.DEALLOCATE_EXPIRING)
   }
 
   @Test
   fun `activate and deallocate allocation operations triggered`() {
     job.execute(withActivate = true, withDeallocate = true)
 
-    verify(offenderDeallocationService).allocations(AllocationOperation.STARTING_TODAY)
-    verify(offenderDeallocationService).allocations(AllocationOperation.DEALLOCATE_ENDING)
-    verify(offenderDeallocationService).allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
+    verify(deallocationService).allocations(AllocationOperation.DEALLOCATE_ENDING)
+    verify(deallocationService).allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    verify(safeJobRunner, times(3)).runSafe(jobDefinitionCaptor.capture())
+
+    assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.ALLOCATE)
+    assertThat(jobDefinitionCaptor.secondValue.jobType).isEqualTo(JobType.DEALLOCATE_ENDING)
+    assertThat(jobDefinitionCaptor.thirdValue.jobType).isEqualTo(JobType.DEALLOCATE_EXPIRING)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -3,12 +3,15 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAllocationsService
 
 class ManageAllocationsJobTest {
   private val offenderDeallocationService: ManageAllocationsService = mock()
-  private val job = ManageAllocationsJob(offenderDeallocationService)
+  private val jobRepository: JobRepository = mock()
+  private val safeJobRunner = SafeJobRunner(jobRepository)
+  private val job = ManageAllocationsJob(offenderDeallocationService, safeJobRunner)
 
   @Test
   fun `activate allocation operation triggered`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
@@ -1,27 +1,45 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AttendanceOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAttendancesService
 
 class ManageAttendanceRecordsJobTest {
   private val attendancesService: ManageAttendancesService = mock()
-  private val job = ManageAttendanceRecordsJob(attendancesService)
+  private val jobRepository: JobRepository = mock()
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val job = ManageAttendanceRecordsJob(attendancesService, safeJobRunner)
+  private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 
   @Test
   fun `attendance operations triggered - without expiry`() {
     job.execute(withExpiry = false)
+
     verify(attendancesService).attendances(AttendanceOperation.CREATE)
     verify(attendancesService, never()).attendances(AttendanceOperation.EXPIRE)
+    verify(safeJobRunner).runSafe(jobDefinitionCaptor.capture())
+
+    assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.ATTENDANCE_CREATE)
   }
 
   @Test
   fun `attendance operations triggered - with expiry`() {
     job.execute(withExpiry = true)
+
     verify(attendancesService).attendances(AttendanceOperation.CREATE)
     verify(attendancesService).attendances(AttendanceOperation.EXPIRE)
+    verify(safeJobRunner, times(2)).runSafe(jobDefinitionCaptor.capture())
+
+    assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.ATTENDANCE_CREATE)
+    assertThat(jobDefinitionCaptor.secondValue.jobType).isEqualTo(JobType.ATTENDANCE_EXPIRE)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunnerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunnerTest.kt
@@ -21,7 +21,7 @@ class SafeJobRunnerTest {
 
   @Test
   fun `runs safe job without error`() {
-    runner.runSafe(JobDefinition(JobType.ATTENDANCE) {})
+    runner.runSafe(JobDefinition(JobType.ATTENDANCE_CREATE) {})
 
     verify(jobRepository).saveAndFlush(jobEntityCaptor.capture())
 
@@ -34,8 +34,8 @@ class SafeJobRunnerTest {
   @Test
   fun `runs safe multiple jobs without error`() {
     runner.runSafe(
-      JobDefinition(JobType.ATTENDANCE) {},
-      JobDefinition(JobType.DEALLOCATION) {},
+      JobDefinition(JobType.ATTENDANCE_CREATE) {},
+      JobDefinition(JobType.DEALLOCATE_ENDING) {},
     )
 
     verify(jobRepository, times(2)).saveAndFlush(jobEntityCaptor.capture())
@@ -53,12 +53,12 @@ class SafeJobRunnerTest {
 
   @Test
   fun `runs safe job with error`() {
-    runner.runSafe(JobDefinition(JobType.ATTENDANCE) { throw RuntimeException("it failed") })
+    runner.runSafe(JobDefinition(JobType.ATTENDANCE_CREATE) { throw RuntimeException("it failed") })
 
     verify(jobRepository).saveAndFlush(jobEntityCaptor.capture())
 
     with(jobEntityCaptor.firstValue) {
-      assertThat(endedAt).isNull()
+      assertThat(endedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
       assertThat(successful).isFalse
     }
   }
@@ -66,14 +66,14 @@ class SafeJobRunnerTest {
   @Test
   fun `runs safe multiple jobs with error on first job`() {
     runner.runSafe(
-      JobDefinition(JobType.ATTENDANCE) { throw RuntimeException("first job failed") },
-      JobDefinition(JobType.DEALLOCATION) {},
+      JobDefinition(JobType.ATTENDANCE_CREATE) { throw RuntimeException("first job failed") },
+      JobDefinition(JobType.DEALLOCATE_ENDING) {},
     )
 
     verify(jobRepository, times(2)).saveAndFlush(jobEntityCaptor.capture())
 
     with(jobEntityCaptor.firstValue) {
-      assertThat(endedAt).isNull()
+      assertThat(endedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
       assertThat(successful).isFalse
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunnerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunnerTest.kt
@@ -1,0 +1,85 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.within
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Job
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
+
+class SafeJobRunnerTest {
+
+  private val jobRepository: JobRepository = mock()
+  private val runner = SafeJobRunner(jobRepository)
+  private val jobEntityCaptor = argumentCaptor<Job>()
+
+  @Test
+  fun `runs safe job without error`() {
+    runner.runSafe(JobDefinition(JobType.ATTENDANCE) {})
+
+    verify(jobRepository).saveAndFlush(jobEntityCaptor.capture())
+
+    with(jobEntityCaptor.firstValue) {
+      assertThat(endedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
+      assertThat(successful).isTrue
+    }
+  }
+
+  @Test
+  fun `runs safe multiple jobs without error`() {
+    runner.runSafe(
+      JobDefinition(JobType.ATTENDANCE) {},
+      JobDefinition(JobType.DEALLOCATION) {},
+    )
+
+    verify(jobRepository, times(2)).saveAndFlush(jobEntityCaptor.capture())
+
+    with(jobEntityCaptor.firstValue) {
+      assertThat(endedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
+      assertThat(successful).isTrue()
+    }
+
+    with(jobEntityCaptor.secondValue) {
+      assertThat(endedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
+      assertThat(successful).isTrue()
+    }
+  }
+
+  @Test
+  fun `runs safe job with error`() {
+    runner.runSafe(JobDefinition(JobType.ATTENDANCE) { throw RuntimeException("it failed") })
+
+    verify(jobRepository).saveAndFlush(jobEntityCaptor.capture())
+
+    with(jobEntityCaptor.firstValue) {
+      assertThat(endedAt).isNull()
+      assertThat(successful).isFalse
+    }
+  }
+
+  @Test
+  fun `runs safe multiple jobs with error on first job`() {
+    runner.runSafe(
+      JobDefinition(JobType.ATTENDANCE) { throw RuntimeException("first job failed") },
+      JobDefinition(JobType.DEALLOCATION) {},
+    )
+
+    verify(jobRepository, times(2)).saveAndFlush(jobEntityCaptor.capture())
+
+    with(jobEntityCaptor.firstValue) {
+      assertThat(endedAt).isNull()
+      assertThat(successful).isFalse
+    }
+
+    with(jobEntityCaptor.secondValue) {
+      assertThat(endedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
+      assertThat(successful).isTrue()
+    }
+  }
+}


### PR DESCRIPTION
These changes do not guarantee jobs from failing but it does mean any jobs that run in the same call will get the opportunity to run should a previous one fail.  It also records the success/failure of the job in the DB.

This can be expanded on - thoughts are to provide some information to the Job entity that gets created with some details of the job outcome.