### PR TITLE
SAA-669: Activity candidate suitability

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -11,6 +11,8 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.LocationGroup
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderAdjudicationHearing
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetail
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetails
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
@@ -18,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import java.time.LocalDate
+import java.time.LocalDateTime
 import java.util.Optional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.ScheduledEvent as PrisonApiScheduledEvent
 
@@ -328,5 +331,24 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
           (!excludeInFlightCertifications || it.endDate?.isBefore(LocalDate.now()) == true)
       }
       .distinctBy { it.educationLevel + it.studyArea + it.bookingId }
+  }
+
+  fun getOffenderNonAssociations(
+    prisonerNumber: String,
+    excludeExpired: Boolean = true,
+  ): List<OffenderNonAssociationDetail>? {
+    val nonAssociationDetails = prisonApiWebClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/offenders/{offenderNo}/non-association-details")
+          .build(prisonerNumber)
+      }
+      .retrieve()
+      .bodyToMono(typeReference<OffenderNonAssociationDetails>())
+      .block()
+
+    return nonAssociationDetails?.nonAssociations?.filter {
+      !excludeExpired || LocalDateTime.parse(it.expiryDate).isAfter(LocalDateTime.now())
+    }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -348,7 +348,7 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .block()
 
     return nonAssociationDetails?.nonAssociations?.filter {
-      !excludeExpired || LocalDateTime.parse(it.expiryDate).isAfter(LocalDateTime.now())
+      !excludeExpired || it.expiryDate == null || LocalDateTime.parse(it.expiryDate).isAfter(LocalDateTime.now())
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -101,7 +101,7 @@ data class Activity(
 
   fun activityPay() = activityPay.toList()
 
-  fun activityPayForBand(payBand: PrisonPayBand) = activityPay().find { it.payBand == payBand }!!
+  fun activityPayForBand(payBand: PrisonPayBand) = activityPay().find { it.payBand == payBand }
 
   fun activityMinimumEducationLevel() = activityMinimumEducationLevel.toList()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPay.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPay.kt
@@ -9,6 +9,8 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.hibernate.Hibernate
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonPayBand
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPay as ModelActivityPay
 
 @Entity
 @Table(name = "activity_pay")
@@ -49,4 +51,14 @@ data class ActivityPay(
   override fun toString(): String {
     return this::class.simpleName + "(activityPayId = $activityPayId )"
   }
+
+  fun toModel() = ModelActivityPay(
+    id = activityPayId,
+    incentiveNomisCode = incentiveNomisCode,
+    incentiveLevel = incentiveLevel,
+    prisonPayBand = payBand.toModelPrisonPayBand(),
+    rate = rate,
+    pieceRate = pieceRate,
+    pieceRateItems = pieceRateItems,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -114,7 +114,11 @@ data class ActivitySchedule(
 
   fun slots() = slots.toList()
 
-  fun allocations() = allocations.toList()
+  fun allocations(excludeEnded: Boolean = false): List<Allocation> =
+    allocations.toList().filter { !excludeEnded || !it.status(PrisonerStatus.ENDED) }
+
+  fun activityPayForBand(payBand: PrisonPayBand) =
+    activity.activityPay().firstOrNull { it.payBand == payBand }
 
   companion object {
     fun valueOf(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -136,12 +136,14 @@ data class Allocation(
 
   fun status(vararg status: PrisonerStatus) = status.any { it == prisonerStatus }
 
+  fun allocationPay() = activitySchedule.activityPayForBand(payBand)
+
   fun toModel() =
     ModelAllocation(
       id = allocationId,
       prisonerNumber = prisonerNumber,
       bookingId = bookingId,
-      payRate = activitySchedule.activity.activityPayForBand(payBand)?.toModel(),
+      payRate = allocationPay()?.toModel(),
       startDate = startDate,
       endDate = plannedDeallocation?.plannedDate ?: endDate,
       allocatedTime = allocatedTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -141,7 +141,7 @@ data class Allocation(
       id = allocationId,
       prisonerNumber = prisonerNumber,
       bookingId = bookingId,
-      prisonPayBand = payBand.toModel(),
+      payRate = activitySchedule.activity.activityPayForBand(payBand)?.toModel(),
       startDate = startDate,
       endDate = plannedDeallocation?.plannedDate ?: endDate,
       allocatedTime = allocatedTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
@@ -107,7 +107,7 @@ data class ScheduledInstance(
     if (attendances.isNotEmpty()) f(attendances)
   }
 
-  fun rateFor(band: PrisonPayBand) = activitySchedule.activity.activityPayForBand(band).rate
+  fun rateFor(band: PrisonPayBand) = activitySchedule.activity.activityPayForBand(band)!!.rate
 }
 
 fun List<ScheduledInstance>.toModel() = map { it.toModel() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
@@ -106,8 +106,6 @@ data class ScheduledInstance(
     comment = cancelComment
     if (attendances.isNotEmpty()) f(attendances)
   }
-
-  fun rateFor(band: PrisonPayBand) = activitySchedule.activity.activityPayForBand(band)!!.rate
 }
 
 fun List<ScheduledInstance>.toModel() = map { it.toModel() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
@@ -27,8 +27,8 @@ data class Allocation(
   @Schema(description = "Indicates whether this allocation is to an activity within the 'Not in work' category")
   val isUnemployment: Boolean = false,
 
-  @Schema(description = "Where a prison uses pay bands to differentiate earnings, this is the pay band given to this prisoner")
-  val prisonPayBand: PrisonPayBand,
+  @Schema(description = "The activity pay assigned to this allocation")
+  val payRate: ActivityPay? = null,
 
   @Schema(description = "The date when the prisoner will start the activity", example = "2022-09-10")
   @JsonFormat(pattern = "yyyy-MM-dd")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/AllocationSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/AllocationSuitability.kt
@@ -1,0 +1,26 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.EducationSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.IncentiveLevelSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.NonAssociationSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.ReleaseDateSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.WRASuitability
+
+@Schema(description = "Cross references prisoners details with activity requirements")
+data class AllocationSuitability(
+  @Schema(description = "The prisoner's workplace risk assessment suitability")
+  val workplaceRiskAssessment: WRASuitability? = null,
+
+  @Schema(description = "The prisoner's incentive level suitability")
+  val incentiveLevel: IncentiveLevelSuitability? = null,
+
+  @Schema(description = "The prisoner's education suitability")
+  val education: EducationSuitability? = null,
+
+  @Schema(description = "The prisoner's release date suitability")
+  val releaseDate: ReleaseDateSuitability? = null,
+
+  @Schema(description = "The prisoner's non-association suitability")
+  val nonAssociation:  NonAssociationSuitability? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/AllocationSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/AllocationSuitability.kt
@@ -22,5 +22,5 @@ data class AllocationSuitability(
   val releaseDate: ReleaseDateSuitability? = null,
 
   @Schema(description = "The prisoner's non-association suitability")
-  val nonAssociation:  NonAssociationSuitability? = null,
+  val nonAssociation: NonAssociationSuitability? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/EducationSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/EducationSuitability.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
+
+@Schema(description = "Prisoner workplace education suitability")
+data class EducationSuitability(
+  @Schema(description = "The prisoner's suitability", example = "True")
+  val suitable: Boolean,
+  @Schema(description = "The prisoner's education levels")
+  val education: List<Education>?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/EducationSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/EducationSuitability.kt
@@ -8,5 +8,5 @@ data class EducationSuitability(
   @Schema(description = "The prisoner's suitability", example = "True")
   val suitable: Boolean,
   @Schema(description = "The prisoner's education levels")
-  val education: List<Education>?,
+  val education: List<Education>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/IncentiveLevelSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/IncentiveLevelSuitability.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability
+
+import io.swagger.v3.oas.annotations.media.Schema
+@Schema(description = "Prisoner's incentive level suitability")
+data class IncentiveLevelSuitability(
+  @Schema(description = "The prisoner's suitability", example = "True")
+  val suitable: Boolean,
+  @Schema(description = "The prisoner's current incentive level", example = "standard")
+  val incentiveLevel: String?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/NonAssociationSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/NonAssociationSuitability.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability
+
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetail
+
+@Schema(description = "Prisoner workplace risk assessment suitability")
+data class NonAssociationSuitability(
+  @Schema(description = "The prisoner's suitability", example = "True")
+  val suitable: Boolean,
+  @Schema(description = "The prisoner's non-associations")
+  val nonAssociations: List<OffenderNonAssociationDetail>?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/NonAssociationSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/NonAssociationSuitability.kt
@@ -8,5 +8,5 @@ data class NonAssociationSuitability(
   @Schema(description = "The prisoner's suitability", example = "True")
   val suitable: Boolean,
   @Schema(description = "The prisoner's non-associations")
-  val nonAssociations: List<OffenderNonAssociationDetail>?,
+  val nonAssociations: List<OffenderNonAssociationDetail>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/ReleaseDateSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/ReleaseDateSuitability.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDate
 
@@ -8,5 +9,6 @@ data class ReleaseDateSuitability(
   @Schema(description = "The prisoner's suitability", example = "True")
   val suitable: Boolean,
   @Schema(description = "The prisoner's earliest release date", example = "medium")
+  @JsonFormat(pattern = "yyyy-MM-dd")
   val earliestReleaseDate: LocalDate?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/ReleaseDateSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/ReleaseDateSuitability.kt
@@ -1,0 +1,12 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability
+
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+
+@Schema(description = "Prisoner release date suitability")
+data class ReleaseDateSuitability(
+  @Schema(description = "The prisoner's suitability", example = "True")
+  val suitable: Boolean,
+  @Schema(description = "The prisoner's earliest release date", example = "medium")
+  val earliestReleaseDate: LocalDate?,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/WRASuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/WRASuitability.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability
+
+import io.swagger.v3.oas.annotations.media.Schema
+@Schema(description = "Prisoner workplace risk assessment suitability")
+data class WRASuitability(
+  @Schema(description = "The prisoner's suitability", example = "True")
+  val suitable: Boolean,
+  @Schema(description = "The prisoner's WRA level", example = "medium")
+  val riskLevel: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
@@ -313,6 +313,69 @@ class ActivityScheduleController(
     )
   }
 
+  @GetMapping(value = ["/{scheduleId}/suitability"])
+  @Operation(
+    summary = "Gets the suitability details of a candidate for an activity",
+    description = "Returns candidate suitability details considering factors such as, workplace risk assessment," +
+      " incentive level, education levels, earliest release date and non-associations" +
+      " Requires any one of the following roles ['ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN'].",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Candidate suitability details.",
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Bad request",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The activity schedule for this ID was not found.",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN')")
+  fun allocationSuitability(
+    @PathVariable("scheduleId") scheduleId: Long,
+    @RequestParam(value = "prisonerNumber", required = true)
+    @Parameter(description = "Prisoner number (required). Format A9999AA.")
+    prisonerNumber: String,
+  ) = candidatesService.candidateSuitability(scheduleId, prisonerNumber)
+
   @ResponseStatus(HttpStatus.NO_CONTENT)
   @PutMapping(value = ["/{scheduleId}/deallocate"])
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
@@ -33,6 +33,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocatio
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.PrisonerAllocationRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.PrisonerDeallocationRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCandidate
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.AllocationSuitability
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ActivityScheduleService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.CandidatesService
 import java.security.Principal
@@ -325,6 +326,12 @@ class ActivityScheduleController(
       ApiResponse(
         responseCode = "200",
         description = "Candidate suitability details.",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = AllocationSuitability::class)),
+          ),
+        ],
       ),
       ApiResponse(
         responseCode = "400",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -416,14 +416,14 @@ class ActivityService(
     checkEducationLevels(minimumEducationLevel)
 
     activity.activityMinimumEducationLevel().filter {
-      minimumEducationLevel.any { newEducation ->
-        it.studyAreaCode != newEducation.studyAreaCode || it.educationLevelCode != newEducation.educationLevelCode
+      minimumEducationLevel.none { newEducation ->
+        it.studyAreaCode == newEducation.studyAreaCode && it.educationLevelCode == newEducation.educationLevelCode
       }
     }.forEach { activity.removeMinimumEducationLevel(it) }
 
     minimumEducationLevel.filter {
-      activity.activityMinimumEducationLevel().any { activityEducation ->
-        it.studyAreaCode != activityEducation.studyAreaCode || it.educationLevelCode != activityEducation.educationLevelCode
+      activity.activityMinimumEducationLevel().none { activityEducation ->
+        it.studyAreaCode == activityEducation.studyAreaCode && it.educationLevelCode == activityEducation.educationLevelCode
       }
     }.forEach {
       activity.addMinimumEducationLevel(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesService.kt
@@ -1,19 +1,59 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetail
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.CurrentIncentive
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.PrisonerAlert
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityMinimumEducationLevel
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityPay
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivityCandidate
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.AllocationSuitability
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.EducationSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.IncentiveLevelSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.NonAssociationSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.ReleaseDateSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.WRASuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
+import java.time.LocalDate
 
 @Service
 class CandidatesService(
   private val prisonApiClient: PrisonApiClient,
   private val prisonerSearchApiClient: PrisonerSearchApiClient,
   private val activityScheduleService: ActivityScheduleService,
+  private val activityScheduleRepository: ActivityScheduleRepository,
   private val allocationsService: AllocationsService,
 ) {
+
+  fun candidateSuitability(scheduleId: Long, prisonerNumber: String): AllocationSuitability {
+    val schedule = activityScheduleRepository.findOrThrowNotFound(scheduleId)
+
+    val prisonerNumbers = schedule.allocations().map { it.prisonerNumber }.toMutableList()
+    prisonerNumbers.add(prisonerNumber)
+
+    val prisonerDetails = prisonerSearchApiClient.findByPrisonerNumbers(prisonerNumbers).block()!!
+      .associateBy { it.prisonerNumber }
+    val candidateDetails = prisonerDetails[prisonerNumber]
+      ?: throw EntityNotFoundException("Prisoner '$prisonerNumber' not found")
+
+    val prisonerEducation = this.prisonApiClient.getEducationLevels(listOf(prisonerNumber))
+    val prisonerNonAssociations = this.prisonApiClient.getOffenderNonAssociations(prisonerNumber)
+
+    return AllocationSuitability(
+      workplaceRiskAssessment = wraSuitability(schedule.activity.riskLevel, candidateDetails.alerts),
+      incentiveLevel = incentiveLevelSuitability(schedule.activity.activityPay(), candidateDetails.currentIncentive),
+      education = educationSuitability(schedule.activity.activityMinimumEducationLevel(), prisonerEducation),
+      releaseDate = releaseDateSuitability(schedule.startDate, candidateDetails),
+      nonAssociation = nonAssociationSuitability(prisonerDetails.values.toList(), prisonerNonAssociations),
+    )
+  }
 
   fun getActivityCandidates(
     scheduleId: Long,
@@ -110,4 +150,80 @@ class CandidatesService(
       prisoner.prisonerNumber.lowercase().contains(searchStringLower) ||
       "${prisoner.firstName} ${prisoner.lastName}".lowercase().contains(searchStringLower)
   }
+
+  private fun wraSuitability(
+    activityRiskLevel: String,
+    prisonerAlerts: List<PrisonerAlert>?,
+  ): WRASuitability {
+    val prisonerRiskCodes = prisonerAlerts
+      ?.filter{ it.active }
+      ?.filter { arrayOf("RLO", "RME", "RHI").contains(it.alertCode) }
+      ?.map { it.alertCode }
+
+    val prisonerHighestRiskLevel = when {
+      prisonerRiskCodes?.contains("RHI") == true -> "high"
+      prisonerRiskCodes?.contains("RME") == true -> "medium"
+      prisonerRiskCodes?.contains("RLO") == true -> "low"
+      else -> "none"
+    }
+
+    val suitable = when (activityRiskLevel) {
+      "low" -> "low" == prisonerHighestRiskLevel
+      "medium" -> listOf("low", "medium").contains(prisonerHighestRiskLevel)
+      else -> true
+    }
+
+    return WRASuitability(
+      suitable,
+      prisonerHighestRiskLevel,
+    )
+  }
+
+  private fun incentiveLevelSuitability(
+    activityPay: List<ActivityPay>,
+    prisonerIncentiveLevel: CurrentIncentive?,
+  ) = IncentiveLevelSuitability(
+    suitable = activityPay.any{ it.incentiveNomisCode == prisonerIncentiveLevel?.level?.code },
+    incentiveLevel = prisonerIncentiveLevel?.level?.description,
+  )
+
+  private fun educationSuitability(
+    activityEducations: List<ActivityMinimumEducationLevel>,
+    prisonerEducations: List<Education>?,
+  ): EducationSuitability {
+    val suitable = activityEducations.all { activityEducation ->
+      prisonerEducations?.any {
+        it.educationLevel == activityEducation.educationLevelCode && it.studyArea == activityEducation.studyAreaCode
+      } ?: false
+    }
+
+    return EducationSuitability(
+      suitable = suitable,
+      education = prisonerEducations,
+    )
+  }
+
+  private fun nonAssociationSuitability(
+    allocatedPrisoners: List<Prisoner>,
+    nonAssociations: List<OffenderNonAssociationDetail>?,
+  ): NonAssociationSuitability {
+    val allocatedPrisonerNumbers = allocatedPrisoners.map { it.prisonerNumber }
+
+    val allocationNonAssociations = nonAssociations?.filter {
+      allocatedPrisonerNumbers.contains(it.offenderNonAssociation.offenderNo)
+    }
+
+    return NonAssociationSuitability(
+      allocationNonAssociations.isNullOrEmpty(),
+      allocationNonAssociations,
+    )
+  }
+
+  private fun releaseDateSuitability(
+    activityStartDate: LocalDate,
+    prisonerDetail: Prisoner,
+  ) = ReleaseDateSuitability(
+    suitable = prisonerDetail.releaseDate?.isAfter(activityStartDate) ?: false,
+    earliestReleaseDate = prisonerDetail.releaseDate,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
@@ -67,7 +67,7 @@ class ManageAttendancesService(
           scheduledInstance = instance,
           prisonerNumber = allocation.prisonerNumber,
           attendanceReason = attendanceReasonRepository.findByCode(AttendanceReasonEnum.SUSPENDED),
-          payAmount = instance.rateFor(allocation.payBand),
+          payAmount = allocation.allocationPay()?.rate,
           issuePayment = false,
           status = AttendanceStatus.COMPLETED,
           recordedTime = LocalDateTime.now(),
@@ -76,7 +76,7 @@ class ManageAttendancesService(
         instance.cancelled -> Attendance(
           scheduledInstance = instance,
           prisonerNumber = allocation.prisonerNumber,
-          payAmount = instance.rateFor(allocation.payBand),
+          payAmount = allocation.allocationPay()?.rate,
           issuePayment = true,
           status = AttendanceStatus.COMPLETED,
           attendanceReason = attendanceReasonRepository.findByCode(AttendanceReasonEnum.CANCELLED),
@@ -86,7 +86,7 @@ class ManageAttendancesService(
         else -> Attendance(
           scheduledInstance = instance,
           prisonerNumber = allocation.prisonerNumber,
-          payAmount = instance.rateFor(allocation.payBand),
+          payAmount = allocation.allocationPay()?.rate,
         )
       }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPayTest.kt
@@ -1,0 +1,49 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonPayBand as PrisonPayBandModel
+
+class ActivityPayTest {
+  @Test
+  fun `entity is converted to model`() {
+    val activity = activityEntity()
+    val activityPayEntity = ActivityPay(
+      1,
+      activity,
+      incentiveNomisCode = "STD",
+      incentiveLevel = "Standard",
+      payBand = PrisonPayBand(
+        prisonPayBandId = 1,
+        displaySequence = 1,
+        nomisPayBand = 1,
+        payBandAlias = "Low",
+        payBandDescription = "Pay band 1",
+        prisonCode = "MDI",
+      ),
+      rate = 100,
+      pieceRate = 150,
+      pieceRateItems = 1,
+    )
+
+    with(activityPayEntity.toModel()) {
+      assertThat(id).isEqualTo(1)
+      assertThat(incentiveNomisCode).isEqualTo("STD")
+      assertThat(incentiveLevel).isEqualTo("Standard")
+      assertThat(prisonPayBand).isEqualTo(
+        PrisonPayBandModel(
+          id = 1,
+          displaySequence = 1,
+          nomisPayBand = 1,
+          alias = "Low",
+          description = "Pay band 1",
+          prisonCode = "MDI",
+        ),
+      )
+      assertThat(rate).isEqualTo(100)
+      assertThat(pieceRate).isEqualTo(150)
+      assertThat(pieceRateItems).isEqualTo(1)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -47,7 +47,7 @@ class ActivityScheduleTest {
         prisonCode = "123",
         summary = "Maths",
         description = "Maths basic",
-        riskLevel = "High",
+        riskLevel = "high",
         minimumIncentiveNomisCode = "BAS",
         minimumIncentiveLevel = "Basic",
         minimumEducationLevel = listOf(
@@ -114,7 +114,7 @@ class ActivityScheduleTest {
           prisonCode = "123",
           summary = "Maths",
           description = "Maths basic",
-          riskLevel = "High",
+          riskLevel = "high",
           minimumIncentiveNomisCode = "BAS",
           minimumIncentiveLevel = "Basic",
           minimumEducationLevel = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
@@ -66,7 +66,7 @@ class ActivityTest {
       prisonCode = "123",
       summary = "Maths",
       description = "Maths basic",
-      riskLevel = "High",
+      riskLevel = "high",
       minimumIncentiveNomisCode = "BAS",
       minimumIncentiveLevel = "Basic",
       category = ActivityCategory(
@@ -96,7 +96,7 @@ class ActivityTest {
         prisonCode = "123",
         summary = "Maths",
         description = "Maths basic",
-        riskLevel = "High",
+        riskLevel = "high",
         minimumIncentiveNomisCode = "BAS",
         minimumIncentiveLevel = "Basic",
         minimumEducationLevel = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -54,6 +54,7 @@ internal fun activityEntity(
   noPayBands: Boolean = false,
   noMinimumEducationLevels: Boolean = false,
   inCell: Boolean = false,
+  riskLevel: String = "high",
 ) =
   Activity(
     activityId = activityId,
@@ -62,7 +63,7 @@ internal fun activityEntity(
     activityTier = tier,
     summary = summary,
     description = description,
-    riskLevel = "High",
+    riskLevel = riskLevel,
     minimumIncentiveNomisCode = "BAS",
     minimumIncentiveLevel = "Basic",
     startDate = startDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -20,9 +20,9 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.read
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.educationCategory
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandOne
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandThree
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandTwo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand1
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand2
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand3
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityMinimumEducationLevel
@@ -370,15 +370,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
       assertThat(description).isEqualTo("Maths Level 1")
       assertThat(category).isEqualTo(educationCategory)
       assertThat(tier).isEqualTo(ActivityTier(1, "T1", "Tier 1"))
-      assertThat(pay).hasSize(1)
-      pay.map {
-        assertThat(it.incentiveNomisCode).isEqualTo("BAS")
-        assertThat(it.incentiveLevel).isEqualTo("Basic")
-        assertThat(it.prisonPayBand).isEqualTo(testPentonvillePayBandOne)
-        assertThat(it.rate).isEqualTo(125)
-        assertThat(it.pieceRate).isEqualTo(150)
-        assertThat(it.pieceRateItems).isEqualTo(1)
-      }
+      assertThat(pay).isEqualTo(listOf(testActivityPayRateBand1, testActivityPayRateBand2, testActivityPayRateBand3))
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(createdBy).isEqualTo("SEED USER")
@@ -398,7 +390,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsMorning.allocatedPrisoner("A11111A")) {
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandOne)
+      assertThat(payRate).isEqualTo(testActivityPayRateBand1)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -406,7 +398,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsMorning.allocatedPrisoner("A22222A")) {
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandTwo)
+      assertThat(payRate).isEqualTo(testActivityPayRateBand2)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")
@@ -424,7 +416,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsAfternoon.allocatedPrisoner("A11111A")) {
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandThree)
+      assertThat(payRate).isEqualTo(testActivityPayRateBand3)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -432,7 +424,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(mathsAfternoon.allocatedPrisoner("A22222A")) {
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandThree)
+      assertThat(payRate).isEqualTo(testActivityPayRateBand3)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")
@@ -451,14 +443,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
       assertThat(description).isEqualTo("English Level 2")
       assertThat(category).isEqualTo(educationCategory)
       assertThat(tier).isEqualTo(ActivityTier(2, "T2", "Tier 2"))
-      pay.map {
-        assertThat(it.incentiveNomisCode).isEqualTo("BAS")
-        assertThat(it.incentiveLevel).isEqualTo("Basic")
-        assertThat(it.prisonPayBand).isEqualTo(testPentonvillePayBandOne)
-        assertThat(it.rate).isEqualTo(75)
-        assertThat(it.pieceRate).isEqualTo(0)
-        assertThat(it.pieceRateItems).isEqualTo(0)
-      }
+      assertThat(pay).isEqualTo(listOf(testActivityPayRateBand1, testActivityPayRateBand2, testActivityPayRateBand3))
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(createdBy).isEqualTo("SEED USER")
@@ -478,7 +463,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishMorning.allocatedPrisoner("B11111B")) {
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandOne)
+      assertThat(payRate).isEqualTo(testActivityPayRateBand1)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -486,7 +471,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishMorning.allocatedPrisoner("B22222B")) {
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandTwo)
+      assertThat(payRate).isEqualTo(testActivityPayRateBand2)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")
@@ -505,7 +490,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishAfternoon.allocatedPrisoner("B11111B")) {
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandThree)
+      assertThat(payRate).isEqualTo(testActivityPayRateBand3)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
@@ -513,7 +498,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     }
 
     with(englishAfternoon.allocatedPrisoner("B22222B")) {
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandThree)
+      assertThat(payRate).isEqualTo(testActivityPayRateBand3)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 21))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -5,8 +5,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandOne
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandTwo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand1
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand2
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -20,16 +20,16 @@ class AllocationIntegrationTest : IntegrationTestBase() {
   fun `get allocation by id`() {
     with(webTestClient.getAllocationBy(1)!!) {
       assertThat(prisonerNumber).isEqualTo("A11111A")
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandOne)
-      assertThat(startDate).isEqualTo(java.time.LocalDate.of(2022, 10, 10))
+      assertThat(payRate).isEqualTo(testActivityPayRateBand1)
+      assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MR BLOGS")
-      assertThat(allocatedTime).isEqualTo(java.time.LocalDateTime.of(2022, 10, 10, 9, 0))
+      assertThat(allocatedTime).isEqualTo(LocalDateTime.of(2022, 10, 10, 9, 0))
     }
 
     with(webTestClient.getAllocationBy(2)!!) {
       assertThat(prisonerNumber).isEqualTo("A22222A")
-      assertThat(prisonPayBand).isEqualTo(testPentonvillePayBandTwo)
+      assertThat(payRate).isEqualTo(testActivityPayRateBand2)
       assertThat(startDate).isEqualTo(LocalDate.of(2022, 10, 10))
       assertThat(endDate).isNull()
       assertThat(allocatedBy).isEqualTo("MRS BLOGS")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonerAllocationIntegrationTest.kt
@@ -7,9 +7,9 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandOne
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandThree
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandTwo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand1
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand2
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand3
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
 import java.time.LocalDate
@@ -35,7 +35,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           activitySummary = "Retirement",
           scheduleId = 1,
           scheduleDescription = "Retirement AM",
-          prisonPayBand = testPentonvillePayBandOne,
+          payRate = testActivityPayRateBand1,
           isUnemployment = true,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
@@ -50,7 +50,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           activitySummary = "Retirement",
           scheduleId = 2,
           scheduleDescription = "Retirement PM",
-          prisonPayBand = testPentonvillePayBandThree,
+          payRate = testActivityPayRateBand3,
           isUnemployment = true,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
@@ -70,7 +70,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           activitySummary = "Retirement",
           scheduleId = 1,
           scheduleDescription = "Retirement AM",
-          prisonPayBand = testPentonvillePayBandTwo,
+          payRate = testActivityPayRateBand2,
           isUnemployment = true,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
@@ -102,7 +102,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           activitySummary = "Retirement",
           scheduleId = 1,
           scheduleDescription = "Retirement AM",
-          prisonPayBand = testPentonvillePayBandOne,
+          payRate = testActivityPayRateBand1,
           isUnemployment = true,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
@@ -117,7 +117,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           activitySummary = "Retirement",
           scheduleId = 2,
           scheduleDescription = "Retirement PM",
-          prisonPayBand = testPentonvillePayBandThree,
+          payRate = testActivityPayRateBand3,
           isUnemployment = true,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
@@ -137,7 +137,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           activitySummary = "Retirement",
           scheduleId = 1,
           scheduleDescription = "Retirement AM",
-          prisonPayBand = testPentonvillePayBandTwo,
+          payRate = testActivityPayRateBand2,
           isUnemployment = true,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
@@ -152,7 +152,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           activitySummary = "Retirement",
           scheduleId = 2,
           scheduleDescription = "Retirement PM",
-          prisonPayBand = testPentonvillePayBandThree,
+          payRate = testActivityPayRateBand3,
           isUnemployment = true,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = null,
@@ -175,7 +175,7 @@ class PrisonerAllocationIntegrationTest : IntegrationTestBase() {
           activitySummary = "Retirement",
           scheduleId = 1,
           scheduleDescription = "Retirement AM",
-          prisonPayBand = testPentonvillePayBandTwo,
+          payRate = testActivityPayRateBand2,
           isUnemployment = true,
           startDate = LocalDate.of(2022, 10, 10),
           endDate = LocalDate.of(2022, 10, 11),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/testdata/IntegrationTestPayRates.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/testdata/IntegrationTestPayRates.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata
+
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPay
+
+val testActivityPayRateBand1 = ActivityPay(1, "BAS", "Basic", testPentonvillePayBandOne, 125, 150, 1)
+val testActivityPayRateBand2 = ActivityPay(2, "BAS", "Basic", testPentonvillePayBandTwo, 225, 250, 1)
+val testActivityPayRateBand3 = ActivityPay(3, "BAS", "Basic", testPentonvillePayBandThree, 325, 350, 1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -297,6 +297,18 @@ class PrisonApiMockServer : WireMockServer(8999) {
     )
   }
 
+  fun stubGetStudyArea(domain: String, studyAreaCode: String, jsonResponseFile: String) {
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/api/reference-domains/domains/$domain/codes/$studyAreaCode"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBodyFile(jsonResponseFile)
+            .withStatus(200),
+        ),
+    )
+  }
+
   fun stubGetLocation(locationId: Long, location: Location) {
     stubFor(
       WireMock.get(WireMock.urlEqualTo("/api/locations/$locationId"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -297,18 +297,6 @@ class PrisonApiMockServer : WireMockServer(8999) {
     )
   }
 
-  fun stubGetStudyArea(domain: String, studyAreaCode: String, jsonResponseFile: String) {
-    stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/reference-domains/domains/$domain/codes/$studyAreaCode"))
-        .willReturn(
-          WireMock.aResponse()
-            .withHeader("Content-Type", "application/json")
-            .withBodyFile(jsonResponseFile)
-            .withStatus(200),
-        ),
-    )
-  }
-
   fun stubGetLocation(locationId: Long, location: Location) {
     stubFor(
       WireMock.get(WireMock.urlEqualTo("/api/locations/$locationId"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonPayBand
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.lowPayBand
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -34,7 +34,22 @@ class AllocationTest : ModelTest() {
       deallocatedTime = originalDeallocatedTime,
       activitySummary = "Blah",
       bookingId = 123,
-      prisonPayBand = PrisonPayBand(1, 1, "Alias", "Desc", 1, "PVI"),
+      payRate = ActivityPay(
+        id = 1,
+        incentiveNomisCode = "BAS",
+        incentiveLevel = "Basic",
+        rate = 30,
+        pieceRate = 40,
+        pieceRateItems = 50,
+        prisonPayBand = PrisonPayBand(
+          id = lowPayBand.prisonPayBandId,
+          displaySequence = lowPayBand.displaySequence,
+          alias = lowPayBand.payBandAlias,
+          description = lowPayBand.payBandDescription,
+          prisonCode = lowPayBand.prisonCode,
+          nomisPayBand = lowPayBand.nomisPayBand,
+        ),
+      ),
       prisonerNumber = "1234",
       scheduleDescription = "Blah blah",
       scheduleId = 123,
@@ -147,11 +162,11 @@ class AllocationTest : ModelTest() {
       assertThat(scheduleId).isEqualTo(entity.activitySchedule.activityScheduleId)
       assertThat(scheduleDescription).isEqualTo(entity.activitySchedule.description)
       assertThat(isUnemployment).isEqualTo(entity.activitySchedule.activity.isUnemployment())
-      assertThat(prisonPayBand).isEqualTo(entity.payBand.toModelPrisonPayBand())
       assertThat(startDate).isEqualTo(entity.startDate)
       assertThat(endDate).isEqualTo(entity.endDate)
       assertThat(allocatedTime).isEqualTo(entity.allocatedTime)
       assertThat(allocatedBy).isEqualTo(entity.allocatedBy)
+      assertThat(payRate).isEqualTo(entity.activitySchedule.activity.activityPayForBand(entity.payBand)?.toModel())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
@@ -166,7 +166,7 @@ class AllocationTest : ModelTest() {
       assertThat(endDate).isEqualTo(entity.endDate)
       assertThat(allocatedTime).isEqualTo(entity.allocatedTime)
       assertThat(allocatedBy).isEqualTo(entity.allocatedBy)
-      assertThat(payRate).isEqualTo(entity.activitySchedule.activity.activityPayForBand(entity.payBand)?.toModel())
+      assertThat(payRate).isEqualTo(entity.allocationPay()?.toModel())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
@@ -595,6 +595,15 @@ class ActivityServiceTest {
       allocatedBy = "FRED",
     )
 
+    beforeActivityEntity.addPay(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBand = lowPayBand,
+      rate = 30,
+      pieceRate = 40,
+      pieceRateItems = 50,
+    )
+
     whenever(activityRepository.findById(1)).thenReturn(Optional.of(beforeActivityEntity))
 
     val afterActivityEntity: ActivityEntity = mapper.read("activity/updated-activity-entity-1.json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
@@ -53,14 +53,11 @@ class CandidatesServiceTest {
 
     fun candidateSuitabilitySetup(activity: Activity, candidate: Prisoner) {
       val schedule = activity.schedules().first()
-      val allocatedPrisoners = schedule.allocations().map {
-        PrisonerSearchPrisonerFixture.instance(prisonerNumber = it.prisonerNumber)
-      }.toMutableList()
-      allocatedPrisoners.add(candidate)
 
       whenever(activityScheduleRepository.findById(1)).thenReturn(Optional.of(schedule))
-      whenever(prisonerSearchApiClient.findByPrisonerNumbers(allocatedPrisoners.map { it.prisonerNumber }))
-        .thenReturn(Mono.just((allocatedPrisoners)))
+      whenever(prisonerSearchApiClient.findByPrisonerNumbers(listOf(candidate.prisonerNumber))).thenReturn(
+        Mono.just(listOf(candidate)),
+      )
       whenever(prisonApiClient.getEducationLevels(listOf(candidate.prisonerNumber))).thenReturn(
         listOf(candidateEducation),
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
@@ -1,0 +1,455 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import jakarta.persistence.EntityNotFoundException
+import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import reactor.core.publisher.Mono
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetail
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.CurrentIncentive
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.IncentiveLevel
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.PrisonerAlert
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toIsoDateTime
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.EducationSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.IncentiveLevelSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.NonAssociationSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.ReleaseDateSuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.WRASuitability
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.util.*
+
+class CandidatesServiceTest {
+  private val prisonApiClient: PrisonApiClient = mock()
+  private val prisonerSearchApiClient: PrisonerSearchApiClient = mock()
+  private val activityScheduleRepository: ActivityScheduleRepository = mock()
+  private val allocationsService: AllocationsService = mock()
+
+  private val service = CandidatesService(
+    prisonApiClient,
+    prisonerSearchApiClient,
+    activityScheduleRepository,
+    allocationsService,
+  )
+
+  @Nested
+  inner class CandidateSuitability {
+    private val candidateEducation = Education(
+      bookingId = 1,
+      studyArea = "English Language",
+      educationLevel = "Reading Measure 1.0",
+    )
+
+    fun candidateSuitabilitySetup(activity: Activity, candidate: Prisoner) {
+      val schedule = activity.schedules().first()
+      val allocatedPrisoners = schedule.allocations().map {
+        PrisonerSearchPrisonerFixture.instance(prisonerNumber = it.prisonerNumber)
+      }.toMutableList()
+      allocatedPrisoners.add(candidate)
+
+      whenever(activityScheduleRepository.findById(1)).thenReturn(Optional.of(schedule))
+      whenever(prisonerSearchApiClient.findByPrisonerNumbers(allocatedPrisoners.map { it.prisonerNumber }))
+        .thenReturn(Mono.just((allocatedPrisoners)))
+      whenever(prisonApiClient.getEducationLevels(listOf(candidate.prisonerNumber))).thenReturn(
+        listOf(candidateEducation),
+      )
+      whenever(prisonApiClient.getOffenderNonAssociations(candidate.prisonerNumber)).thenReturn(emptyList())
+    }
+
+    @Test
+    fun `fails if schedule not found`() {
+      Assertions.assertThatThrownBy {
+        service.candidateSuitability(1, "A1234AA")
+      }.isInstanceOf(EntityNotFoundException::class.java)
+    }
+
+    @Test
+    fun `wraSuitability - suitable`() {
+      val activity = activityEntity(
+        riskLevel = "high",
+      )
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+        alerts = listOf(
+          PrisonerAlert(
+            alertType = "R",
+            alertCode = "RHI",
+            active = true,
+            expired = false,
+          ),
+        ),
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.workplaceRiskAssessment).isEqualTo(
+        WRASuitability(
+          suitable = true,
+          riskLevel = "high",
+        ),
+      )
+    }
+
+    @Test
+    fun `wraSuitability - not suitable`() {
+      val activity = activityEntity(
+        riskLevel = "medium",
+      )
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+        alerts = listOf(
+          PrisonerAlert(
+            alertType = "R",
+            alertCode = "RHI",
+            active = true,
+            expired = false,
+          ),
+        ),
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.workplaceRiskAssessment).isEqualTo(
+        WRASuitability(
+          suitable = false,
+          riskLevel = "high",
+        ),
+      )
+    }
+
+    @Test
+    fun `wraSuitability - not suitable (no WRA & medium activity risk level)`() {
+      val activity = activityEntity(
+        riskLevel = "medium",
+      )
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.workplaceRiskAssessment).isEqualTo(
+        WRASuitability(
+          suitable = false,
+          riskLevel = "none",
+        ),
+      )
+    }
+
+    @Test
+    fun `wraSuitability - not suitable (no WRA & high activity risk level)`() {
+      val activity = activityEntity(
+        riskLevel = "high",
+      )
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.workplaceRiskAssessment).isEqualTo(
+        WRASuitability(
+          suitable = true,
+          riskLevel = "none",
+        ),
+      )
+    }
+
+    @Test
+    fun `incentiveLevelSuitability - suitable`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.incentiveLevel).isEqualTo(
+        IncentiveLevelSuitability(
+          suitable = true,
+          incentiveLevel = "Basic",
+        ),
+      )
+    }
+
+    @Test
+    fun `incentiveLevelSuitability - not suitable`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+        currentIncentive = CurrentIncentive(
+          level = IncentiveLevel("Standard", "STD"),
+          dateTime = "2020-07-20T10:36:53",
+          nextReviewDate = LocalDate.of(2021, 7, 20),
+        ),
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.incentiveLevel).isEqualTo(
+        IncentiveLevelSuitability(
+          suitable = false,
+          incentiveLevel = "Standard",
+        ),
+      )
+    }
+
+    @Test
+    fun `educationSuitability - suitable`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.education).isEqualTo(
+        EducationSuitability(
+          suitable = true,
+          education = listOf(candidateEducation),
+        ),
+      )
+    }
+
+    @Test
+    fun `educationSuitability - not suitable`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+
+      val candidateEducation = candidateEducation.copy(educationLevel = "Reading Measure 2.0")
+
+      whenever(prisonApiClient.getEducationLevels(listOf(candidate.prisonerNumber))).thenReturn(
+        listOf(candidateEducation),
+      )
+
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.education).isEqualTo(
+        EducationSuitability(
+          suitable = false,
+          education = listOf(candidateEducation),
+        ),
+      )
+    }
+
+    @Test
+    fun `releaseDate - suitable`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+        releaseDate = LocalDate.now().plusYears(1),
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.releaseDate).isEqualTo(
+        ReleaseDateSuitability(
+          suitable = true,
+          earliestReleaseDate = LocalDate.now().plusYears(1),
+        ),
+      )
+    }
+
+    @Test
+    fun `releaseDate - not suitable`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+        releaseDate = LocalDate.now().minusDays(1),
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.releaseDate).isEqualTo(
+        ReleaseDateSuitability(
+          suitable = false,
+          earliestReleaseDate = LocalDate.now().minusDays(1),
+        ),
+      )
+    }
+
+    @Test
+    fun `releaseDate - not suitable (no release date)`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.releaseDate).isEqualTo(
+        ReleaseDateSuitability(
+          suitable = false,
+          earliestReleaseDate = null,
+        ),
+      )
+    }
+
+    @Test
+    fun `nonAssociation - suitable (no non-associations)`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.nonAssociation).isEqualTo(
+        NonAssociationSuitability(
+          suitable = true,
+          nonAssociations = emptyList(),
+        ),
+      )
+    }
+
+    @Test
+    fun `nonAssociation - suitable (no conflicting non-associations)`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+
+      whenever(prisonApiClient.getOffenderNonAssociations(candidate.prisonerNumber)).thenReturn(
+        listOf(
+          OffenderNonAssociationDetail(
+            reasonCode = "VIC",
+            reasonDescription = "Victim",
+            typeCode = "WING",
+            typeDescription = "Do Not Locate on Same Wing",
+            effectiveDate = LocalDateTime.now().toIsoDateTime(),
+            offenderNonAssociation = OffenderNonAssociation(
+              offenderNo = "A1234ZY",
+              firstName = "Joseph",
+              lastName = "Bloggs",
+              reasonCode = "PER",
+              reasonDescription = "Perpetrator",
+              agencyDescription = "Pentonville (PVI)",
+              assignedLivingUnitDescription = "PVI-1-2-4",
+              assignedLivingUnitId = 1234,
+            ),
+          ),
+        ),
+      )
+
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.nonAssociation).isEqualTo(
+        NonAssociationSuitability(
+          suitable = true,
+          nonAssociations = emptyList(),
+        ),
+      )
+    }
+
+    @Test
+    fun `nonAssociation - not suitable`() {
+      val activity = activityEntity()
+      val candidate = PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+      )
+
+      candidateSuitabilitySetup(activity, candidate)
+
+      val offenderNonAssociation = OffenderNonAssociationDetail(
+        reasonCode = "VIC",
+        reasonDescription = "Victim",
+        typeCode = "WING",
+        typeDescription = "Do Not Locate on Same Wing",
+        effectiveDate = LocalDateTime.now().toIsoDateTime(),
+        offenderNonAssociation = OffenderNonAssociation(
+          offenderNo = "A1234AA",
+          firstName = "Joseph",
+          lastName = "Bloggs",
+          reasonCode = "PER",
+          reasonDescription = "Perpetrator",
+          agencyDescription = "Pentonville (PVI)",
+          assignedLivingUnitDescription = "PVI-1-2-4",
+          assignedLivingUnitId = 1234,
+        ),
+      )
+
+      whenever(prisonApiClient.getOffenderNonAssociations(candidate.prisonerNumber)).thenReturn(
+        listOf(offenderNonAssociation),
+      )
+
+      val suitability = service.candidateSuitability(
+        activity.schedules().first().activityScheduleId,
+        candidate.prisonerNumber,
+      )
+
+      assertThat(suitability.nonAssociation).isEqualTo(
+        NonAssociationSuitability(
+          suitable = false,
+          nonAssociations = listOf(offenderNonAssociation),
+        ),
+      )
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSearchPrisonerFixture.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSearchPrisonerFixture.kt
@@ -4,6 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.CurrentIncentive
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.IncentiveLevel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.PrisonerAlert
 import java.time.LocalDate
 
 object PrisonerSearchPrisonerFixture {
@@ -34,6 +35,7 @@ object PrisonerSearchPrisonerFixture {
     ),
     lastMovementType: MovementType? = null,
     releaseDate: LocalDate? = null,
+    alerts: List<PrisonerAlert> = emptyList(),
   ) =
     Prisoner(
       prisonerNumber = prisonerNumber,
@@ -58,5 +60,6 @@ object PrisonerSearchPrisonerFixture {
       currentIncentive = currentIncentive,
       lastMovementTypeCode = lastMovementType?.nomisShortCode,
       releaseDate = releaseDate,
+      alerts = alerts,
     )
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -20,12 +20,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.lowPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rolloutPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userDetail
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPay
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentCategorySummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentLocationSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonerSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RolloutPrisonPlan
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ScheduledEvent
@@ -137,13 +137,14 @@ class TransformFunctionsTest {
               id = 0,
               prisonerNumber = "A1234AA",
               bookingId = 10001,
-              prisonPayBand = PrisonPayBand(
-                id = lowPayBand.prisonPayBandId,
-                displaySequence = lowPayBand.displaySequence,
-                alias = lowPayBand.payBandAlias,
-                description = lowPayBand.payBandDescription,
-                prisonCode = lowPayBand.prisonCode,
-                nomisPayBand = lowPayBand.nomisPayBand,
+              payRate = ActivityPay(
+                id = 0,
+                incentiveNomisCode = "BAS",
+                incentiveLevel = "Basic",
+                rate = 30,
+                pieceRate = 40,
+                pieceRateItems = 50,
+                prisonPayBand = lowPayBand.toModel(),
               ),
               startDate = timestamp.toLocalDate(),
               endDate = null,

--- a/src/test/resources/test_data/seed-activity-id-1.sql
+++ b/src/test/resources/test_data/seed-activity-id-1.sql
@@ -7,6 +7,12 @@ values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1'
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
 
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (2, 1, 'BAS', 'Basic', 2, 225, 250, 1);
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (3, 1, 'BAS', 'Basic', 3, 325, 350, 1);
+
 insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
 values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
 

--- a/src/test/resources/test_data/seed-activity-id-2.sql
+++ b/src/test/resources/test_data/seed-activity-id-2.sql
@@ -2,7 +2,13 @@ insert into activity(activity_id, prison_code, activity_category_id, activity_ti
 values (2, 'PVI', 1, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
-values (2, 2, 'BAS', 'Basic', 1, 75, 0, 0);
+values (1, 2, 'BAS', 'Basic', 1, 125, 150, 1);
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (2, 2, 'BAS', 'Basic', 2, 225, 250, 1);
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (3, 2, 'BAS', 'Basic', 3, 325, 350, 1);
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
 values (3, 2, 'English AM', 3, 'L3', 'Location 3', 10, '2022-10-21');

--- a/src/test/resources/test_data/seed-activity-id-6.sql
+++ b/src/test/resources/test_data/seed-activity-id-6.sql
@@ -4,6 +4,12 @@ values (1, 'PVI', 8, 1, true, false, false, false, 'H', 'Retirement', 'Basic ret
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
 
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (2, 1, 'BAS', 'Basic', 2, 225, 250, 1);
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (3, 1, 'BAS', 'Basic', 3, 325, 350, 1);
+
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
 values (1, 1, 'Retirement AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
 


### PR DESCRIPTION
## Overview

These changes are to support the UI requirements for SAA-669. Specifically, these changes include:

**1. Introducing a new `suitability` endpoint to the `activity-schedule-controller`**

This endpoint encapsulates the business rules around assessing candidate allocation suitability and returns an `AllocationSuitability` object which details the suitability of a given candidate for allocation.

**2. Updating the `Allocation` model to return the associated pay rate in place of the pay band**

Note: The `ActivityPay` model includes the pay band information but also includes the activity pay rate needed for SAA-669. Areas of the UI impacted by this change have been updated in, https://github.com/ministryofjustice/hmpps-activities-management/pull/326
