### PR TITLE
SAA-851 changes to fix issue where planned deallocation not being used if present upon ending allocations.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -12,7 +12,6 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.onOrBefore
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.enumeration.ServiceName
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -91,10 +90,10 @@ data class Allocation(
    */
   fun ends(date: LocalDate) = date == endDate || date == plannedDeallocation?.plannedDate
 
-  fun deallocateOn(date: LocalDate, reason: DeallocationReason, deallocatedBy: String) {
+  fun deallocateOn(date: LocalDate, reason: DeallocationReason, deallocatedBy: String) =
     this.apply {
       if (prisonerStatus == PrisonerStatus.ENDED) throw IllegalStateException("Allocation with ID '$allocationId' is already deallocated.")
-      if (date.onOrBefore(LocalDate.now())) throw IllegalArgumentException("Planned deallocation date must be in the future.")
+      if (date.isBefore(LocalDate.now())) throw IllegalArgumentException("Planned deallocation date must not be in the past.")
       if (maybeEndDate() != null && date.isAfter(maybeEndDate())) throw IllegalArgumentException("Planned date cannot be after ${maybeEndDate()}.")
 
       if (plannedDeallocation == null) {
@@ -113,7 +112,6 @@ data class Allocation(
         }
       }
     }
-  }
 
   private fun maybeEndDate() =
     when {
@@ -123,7 +121,7 @@ data class Allocation(
       else -> null
     }
 
-  fun deallocateNow(reason: DeallocationReason) =
+  fun deallocateNowWithReason(reason: DeallocationReason) =
     this.apply {
       if (prisonerStatus == PrisonerStatus.ENDED) throw IllegalStateException("Allocation with ID '$allocationId' is already deallocated.")
 
@@ -132,6 +130,30 @@ data class Allocation(
       deallocatedBy = ServiceName.SERVICE_NAME.value
       deallocatedTime = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
       endDate = LocalDate.now()
+    }
+
+  /**
+   * This will default to ENDED for the reason unless there is planned deallocation that matches now which overrides it.
+   */
+  fun deallocateNow() =
+    this.apply {
+      if (prisonerStatus == PrisonerStatus.ENDED) throw IllegalStateException("Allocation with ID '$allocationId' is already deallocated.")
+
+      val today = LocalDate.now()
+
+      if (plannedDeallocation != null && plannedDeallocation?.plannedDate == today) {
+        prisonerStatus = PrisonerStatus.ENDED
+        deallocatedReason = plannedDeallocation?.plannedReason
+        deallocatedBy = plannedDeallocation?.plannedBy
+        deallocatedTime = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
+        endDate = today
+      } else {
+        prisonerStatus = PrisonerStatus.ENDED
+        deallocatedReason = DeallocationReason.ENDED
+        deallocatedBy = ServiceName.SERVICE_NAME.value
+        deallocatedTime = LocalDateTime.now().truncatedTo(ChronoUnit.SECONDS)
+        endDate = today
+      }
     }
 
   fun status(vararg status: PrisonerStatus) = status.any { it == prisonerStatus }
@@ -160,7 +182,11 @@ data class Allocation(
     )
 
   fun activate() =
-    this.apply { prisonerStatus = PrisonerStatus.ACTIVE }
+    this.apply {
+      failWithMessageIfAllocationsIsNot("You can only activate pending allocations", PrisonerStatus.PENDING)
+
+      prisonerStatus = PrisonerStatus.ACTIVE
+    }
 
   fun autoSuspend(dateTime: LocalDateTime, reason: String) =
     this.apply {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -43,12 +43,12 @@ class ManageAllocationsService(
 
       AllocationOperation.DEALLOCATE_ENDING -> {
         log.info("Ending allocations due to end today.")
-        allocationsDueToEnd().allocations(DeallocationReason.ENDED)
+        allocationsDueToEnd().deallocate()
       }
 
       AllocationOperation.DEALLOCATE_EXPIRING -> {
         log.info("Expiring allocations due to expire today.")
-        allocationsDueToExpire().allocations(DeallocationReason.EXPIRED)
+        allocationsDueToExpire().deallocate(DeallocationReason.EXPIRED)
       }
     }
   }
@@ -82,13 +82,14 @@ class ManageAllocationsService(
 
   private fun List<Allocation>.activatePending() =
     filter { allocation -> allocation.prisonerStatus == PrisonerStatus.PENDING }
-      .forEach {
+      .onEach {
         it.activate()
+
         allocationRepository.saveAndFlush(it)
-      }
+      }.also { log.info("Activated ${it.size} pending allocation(s).") }
 
   private fun List<Allocation>.ending(date: LocalDate) =
-    filter { it.ends(date) && !it.status(PrisonerStatus.ENDED) }
+    filterNot { it.status(PrisonerStatus.ENDED) }.filter { it.ends(date) }
 
   private fun allocationsDueToExpire(): Map<ActivitySchedule, List<Allocation>> =
     forEachRolledOutPrison()
@@ -134,11 +135,13 @@ class ManageAllocationsService(
       false
     }
 
-  private fun Map<ActivitySchedule, List<Allocation>>.allocations(reason: DeallocationReason) {
+  private fun Map<ActivitySchedule, List<Allocation>>.deallocate(reason: DeallocationReason? = null) {
     this.keys.forEach { schedule ->
       continueToRunOnFailure(
         block = {
-          getOrDefault(schedule, emptyList()).map { allocation -> allocation.deallocateNow(reason) }
+          getOrDefault(schedule, emptyList()).map { allocation ->
+            reason?.let { allocation.deallocateNowWithReason(reason) } ?: allocation.deallocateNow()
+          }
             .let {
               if (it.isNotEmpty()) {
                 activityScheduleRepository.saveAndFlush(schedule)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
@@ -55,7 +55,7 @@ class ActivitiesChangedEventHandler(
       }
 
   private fun List<Allocation>.deallocateAndSaveAffectedAllocations(reason: DeallocationReason) =
-    this.filterNot { it.status(PrisonerStatus.ENDED) }.map { it.deallocateNow(reason) }.saveAffectedAllocations()
+    this.filterNot { it.status(PrisonerStatus.ENDED) }.map { it.deallocateNowWithReason(reason) }.saveAffectedAllocations()
 
   private fun List<Allocation>.saveAffectedAllocations() =
     allocationRepository.saveAllAndFlush(this).toList()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandler.kt
@@ -73,7 +73,7 @@ class OffenderReleasedEventHandler(
     } ?: log.warn("Prisoner for $event not found").let { false }
 
   private fun List<Allocation>.deallocateAndSaveAffectedAllocations(reason: DeallocationReason) =
-    this.filterNot { it.status(PrisonerStatus.ENDED) }.map { it.deallocateNow(reason) }.saveAffectedAllocations()
+    this.filterNot { it.status(PrisonerStatus.ENDED) }.map { it.deallocateNowWithReason(reason) }.saveAffectedAllocations()
 
   private fun List<Allocation>.saveAffectedAllocations() =
     allocationRepository.saveAllAndFlush(this).toList()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -280,7 +280,7 @@ class ActivityScheduleTest {
       allocatedBy = "FREDDIE",
     )
 
-    allocation.deallocateNow(DeallocationReason.OTHER)
+    allocation.deallocateNowWithReason(DeallocationReason.OTHER)
 
     assertDoesNotThrow {
       schedule.allocatePrisoner(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
+import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
@@ -42,7 +43,7 @@ class AllocationTest {
     assertThat(allocation.deallocatedBy).isNull()
     assertThat(allocation.deallocatedTime).isNull()
 
-    allocation.deallocateNow(DeallocationReason.ENDED)
+    allocation.deallocateNowWithReason(DeallocationReason.ENDED)
 
     assertThat(allocation.status(PrisonerStatus.ENDED)).isTrue
     assertThat(allocation.deallocatedReason).isEqualTo(DeallocationReason.ENDED)
@@ -52,11 +53,35 @@ class AllocationTest {
 
   @Test
   fun `check cannot deallocate if allocation already ended`() {
-    val allocation = allocation().apply { deallocateNow(DeallocationReason.ENDED) }
+    val allocation = allocation().apply { deallocateNowWithReason(DeallocationReason.ENDED) }
 
-    assertThatThrownBy { allocation.deallocateNow(DeallocationReason.ENDED) }
+    assertThatThrownBy { allocation.deallocateNowWithReason(DeallocationReason.ENDED) }
       .isInstanceOf(IllegalStateException::class.java)
       .hasMessage("Allocation with ID '0' is already deallocated.")
+  }
+
+  @Test
+  fun `check default deallocation when deallocate now`() {
+    val allocation = allocation()
+
+    allocation.deallocateNow()
+
+    assertThat(allocation.status(PrisonerStatus.ENDED)).isTrue
+    assertThat(allocation.deallocatedReason).isEqualTo(DeallocationReason.ENDED)
+    assertThat(allocation.deallocatedBy).isEqualTo("Activities Management Service")
+    assertThat(allocation.deallocatedTime).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
+  }
+
+  @Test
+  fun `check planned deallocation takes precedence when deallocate now`() {
+    val allocation = allocation().deallocateOn(LocalDate.now(), DeallocationReason.TRANSFERRED, "by test")
+
+    allocation.deallocateNow()
+
+    assertThat(allocation.status(PrisonerStatus.ENDED)).isTrue
+    assertThat(allocation.deallocatedReason).isEqualTo(DeallocationReason.TRANSFERRED)
+    assertThat(allocation.deallocatedBy).isEqualTo("by test")
+    assertThat(allocation.deallocatedTime).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
   }
 
   @Test
@@ -75,7 +100,7 @@ class AllocationTest {
 
   @Test
   fun `check cannot auto-suspend an ended allocation`() {
-    val allocation = allocation().apply { deallocateNow(DeallocationReason.ENDED) }
+    val allocation = allocation().apply { deallocateNowWithReason(DeallocationReason.ENDED) }
       .also { assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.ENDED) }
 
     assertThatThrownBy { allocation.autoSuspend(today.atStartOfDay(), "Temporarily released from prison") }
@@ -132,7 +157,7 @@ class AllocationTest {
 
   @Test
   fun `check cannot unsuspend an ended allocation`() {
-    val allocation = allocation().apply { deallocateNow(DeallocationReason.ENDED) }
+    val allocation = allocation().apply { deallocateNowWithReason(DeallocationReason.ENDED) }
       .also { assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.ENDED) }
 
     assertThatThrownBy { allocation.reactivateAutoSuspensions() }
@@ -141,13 +166,13 @@ class AllocationTest {
   }
 
   @Test
-  fun `planned deallocation must be in the future`() {
+  fun `planned deallocation must be on or after today`() {
     val allocation = allocation().also { assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.ACTIVE) }
 
     assertThatThrownBy {
-      allocation.deallocateOn(today, DeallocationReason.TRANSFERRED, "by test")
+      allocation.deallocateOn(yesterday, DeallocationReason.TRANSFERRED, "by test")
     }.isInstanceOf(IllegalArgumentException::class.java)
-      .hasMessage("Planned deallocation date must be in the future.")
+      .hasMessage("Planned deallocation date must not be in the past.")
   }
 
   @Test
@@ -224,12 +249,35 @@ class AllocationTest {
   @Test
   fun `cannot plan deallocation if already ended`() {
     val allocation = allocation().copy(allocationId = 1).apply { endDate = null }
-      .apply { deallocateNow(DeallocationReason.ENDED) }
+      .apply { deallocateNowWithReason(DeallocationReason.ENDED) }
       .also { assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.ENDED) }
 
     assertThatThrownBy {
       allocation.deallocateOn(tomorrow, DeallocationReason.TRANSFERRED, "by test")
     }.isInstanceOf(IllegalStateException::class.java)
       .hasMessage("Allocation with ID '1' is already deallocated.")
+  }
+
+  @Test
+  fun `activate pending allocation`() {
+    val allocation = allocation().copy(prisonerStatus = PrisonerStatus.PENDING)
+      .also { assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.PENDING) }
+
+    allocation.activate()
+
+    assertThat(allocation.prisonerStatus).isEqualTo(PrisonerStatus.ACTIVE)
+  }
+
+  @Test
+  fun `allocotion must be pending to activate`() {
+    val allocation = allocation().copy(prisonerStatus = PrisonerStatus.PENDING)
+      .also { assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.PENDING) }
+
+    allocation.activate()
+
+    assertThatThrownBy {
+      allocation.activate()
+    }.isInstanceOf(IllegalStateException::class.java)
+      .hasMessage("You can only activate pending allocations")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
@@ -108,7 +108,7 @@ class AllocationTest : ModelTest() {
   @Test
   fun `check deallocated allocation transformation`() {
     val allocation = allocation().also {
-      it.deallocateNow(DeallocationReason.ENDED)
+      it.deallocateNowWithReason(DeallocationReason.ENDED)
       assertThat(it.prisonerStatus).isEqualTo(PrisonerStatus.ENDED)
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
@@ -65,7 +65,7 @@ class ActivityScheduleServiceTest {
   @Test
   fun `ended allocations for a given schedule are not returned`() {
     val schedule = schedule().apply {
-      allocations().first().apply { deallocateNow(DeallocationReason.ENDED) }
+      allocations().first().apply { deallocateNowWithReason(DeallocationReason.ENDED) }
     }
 
     whenever(repository.findById(1)).thenReturn(Optional.of(schedule))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
@@ -95,7 +95,7 @@ class ManageAttendancesServiceTest {
   @Test
   fun `attendance record is not created when allocation has ended`() {
     instance.activitySchedule.activity.attendanceRequired = true
-    allocation.deallocateNow(DeallocationReason.ENDED)
+    allocation.deallocateNowWithReason(DeallocationReason.ENDED)
 
     whenever(scheduledInstanceRepository.findAllBySessionDate(today)).thenReturn(listOf(instance))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
@@ -91,7 +91,7 @@ class ActivitiesChangedEventHandlerTest {
     val allocations = listOf(
       allocation().copy(allocationId = 1, prisonerNumber = "123456"),
       allocation().copy(allocationId = 2, prisonerNumber = "123456")
-        .also { it.deallocateNow(DeallocationReason.ENDED) },
+        .also { it.deallocateNowWithReason(DeallocationReason.ENDED) },
       allocation().copy(allocationId = 3, prisonerNumber = "123456"),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandlerTest.kt
@@ -77,7 +77,7 @@ class OffenderReceivedEventHandlerTest {
       allocation().copy(allocationId = 2, prisonerNumber = "123456").autoSuspend(now, "Auto Reason")
     val userSuspended =
       allocation().copy(allocationId = 3, prisonerNumber = "123456").userSuspend(now, "User reason", "username")
-    val ended = allocation().copy(allocationId = 3, prisonerNumber = "123456").deallocateNow(DeallocationReason.ENDED)
+    val ended = allocation().copy(allocationId = 3, prisonerNumber = "123456").deallocateNowWithReason(DeallocationReason.ENDED)
 
     val allocations = listOf(autoSuspendedOne, autoSuspendedTwo, userSuspended, ended)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
@@ -198,7 +198,7 @@ class OffenderReleasedEventHandlerTest {
   @Test
   fun `only un-ended allocations are ended on release of prisoner`() {
     val previouslyEndedAllocation = allocation().copy(allocationId = 1, prisonerNumber = "123456")
-      .also { it.deallocateNow(DeallocationReason.ENDED) }
+      .also { it.deallocateNowWithReason(DeallocationReason.ENDED) }
     val previouslySuspendedAllocation = allocation().copy(allocationId = 2, prisonerNumber = "123456")
       .also { it.autoSuspend(LocalDateTime.now(), "reason") }
     val previouslyActiveAllocation = allocation().copy(allocationId = 3, prisonerNumber = "123456")


### PR DESCRIPTION
Although allocations due to end are being picked up by the job to end them if there was a planned deallocation present which applied to the day of ending it was not being used.  This fix resolves that.