### PR TITLE
SAA-669: Added overrides

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -11,9 +11,9 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.LocationGroup
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderAdjudicationHearing
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetail
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetails
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetail
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetails
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/OffenderNonAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/OffenderNonAssociation.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+// Overridden because the `assignedLivingUnitDescription` and `assignedLivingUnitId` fields can be null despite the
+// required=true option.
+data class OffenderNonAssociation(
+  @Schema(example = "G0135GA", required = true, description = "The offenders number")
+  @get:JsonProperty("offenderNo", required = true) val offenderNo: String,
+
+  @Schema(example = "Joseph", required = true, description = "The offenders first name")
+  @get:JsonProperty("firstName", required = true) val firstName: String,
+
+  @Schema(example = "Bloggs", required = true, description = "The offenders last name")
+  @get:JsonProperty("lastName", required = true) val lastName: String,
+
+  @Schema(example = "PER", required = true, description = "The non-association reason code")
+  @get:JsonProperty("reasonCode", required = true) val reasonCode: String,
+
+  @Schema(example = "Perpetrator", required = true, description = "The non-association reason description")
+  @get:JsonProperty("reasonDescription", required = true) val reasonDescription: String,
+
+  @Schema(example = "Pentonville (PVI)", required = true, description = "Description of the agency (e.g. prison) the offender is assigned to.")
+  @get:JsonProperty("agencyDescription", required = true) val agencyDescription: String,
+
+  @Schema(example = "PVI-1-2-4", required = true, description = "Description of living unit (e.g. cell) the offender is assigned to.")
+  @get:JsonProperty("assignedLivingUnitDescription", required = true) val assignedLivingUnitDescription: String? = null,
+
+  @Schema(example = "123", required = true, description = "Id of living unit (e.g. cell) the offender is assigned to.")
+  @get:JsonProperty("assignedLivingUnitId", required = true) val assignedLivingUnitId: Long? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/OffenderNonAssociationDetail.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/OffenderNonAssociationDetail.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+// Overridden because it implements overridden class, `OffenderNonAssociation`
+data class OffenderNonAssociationDetail(
+  @Schema(example = "VIC", required = true, description = "The non-association reason code")
+  @get:JsonProperty("reasonCode", required = true) val reasonCode: String,
+
+  @Schema(example = "Victim", required = true, description = "The non-association reason description")
+  @get:JsonProperty("reasonDescription", required = true) val reasonDescription: String,
+
+  @Schema(example = "WING", required = true, description = "The non-association type code")
+  @get:JsonProperty("typeCode", required = true) val typeCode: String,
+
+  @Schema(example = "Do Not Locate on Same Wing", required = true, description = "The non-association type description")
+  @get:JsonProperty("typeDescription", required = true) val typeDescription: String,
+
+  @Schema(example = "2021-07-05T10:35:17", required = true, description = "Date and time the mom-association is effective from. In Europe/London (ISO 8601) format without timezone offset e.g. YYYY-MM-DDTHH:MM:SS.")
+  @get:JsonProperty("effectiveDate", required = true) val effectiveDate: String,
+
+  @Schema(example = "null", required = true, description = "")
+  @get:JsonProperty("offenderNonAssociation", required = true) val offenderNonAssociation: OffenderNonAssociation,
+
+  @Schema(example = "2021-07-05T10:35:17", description = "Date and time the mom-association expires. In Europe/London (ISO 8601) format without timezone offset e.g. YYYY-MM-DDTHH:MM:SS.")
+  @get:JsonProperty("expiryDate") val expiryDate: String? = null,
+
+  @Schema(example = "null", description = "The person who authorised the non-association (free text).")
+  @get:JsonProperty("authorisedBy") val authorisedBy: String? = null,
+
+  @Schema(example = "null", description = "Additional free text comments related to the non-association.")
+  @get:JsonProperty("comments") val comments: String? = null
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/OffenderNonAssociationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/OffenderNonAssociationDetails.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+// Overridden because it implements overridden class, `OffenderNonAssociationDetail`
+data class OffenderNonAssociationDetails(
+  @Schema(example = "G9109UD", required = true, description = "The offenders number")
+  @get:JsonProperty("offenderNo", required = true) val offenderNo: String,
+
+  @Schema(example = "Fred", required = true, description = "The offenders first name")
+  @get:JsonProperty("firstName", required = true) val firstName: String,
+
+  @Schema(example = "Bloggs", required = true, description = "The offenders last name")
+  @get:JsonProperty("lastName", required = true) val lastName: String,
+
+  @Schema(example = "Moorland (HMP & YOI)", required = true, description = "Description of the agency (e.g. prison) the offender is assigned to.")
+  @get:JsonProperty("agencyDescription", required = true) val agencyDescription: String,
+
+  @Schema(example = "MDI-1-1-3", required = true, description = "Description of living unit (e.g. cell) the offender is assigned to.")
+  @get:JsonProperty("assignedLivingUnitDescription", required = true) val assignedLivingUnitDescription: String,
+
+  @Schema(example = "123", required = true, description = "Id of living unit (e.g. cell) the offender is assigned to.")
+  @get:JsonProperty("assignedLivingUnitId", required = true) val assignedLivingUnitId: Long,
+
+  @Schema(example = "null", description = "Offender non-association details")
+  @get:JsonProperty("nonAssociations") val nonAssociations: List<OffenderNonAssociationDetail>? = null
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/NonAssociationSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/NonAssociationSuitability.kt
@@ -1,7 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability
 
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetail
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetail
 
 @Schema(description = "Prisoner workplace risk assessment suitability")
 data class NonAssociationSuitability(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/NonAssociationSuitability.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/NonAssociationSuitability.kt
@@ -1,12 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability
 
 import io.swagger.v3.oas.annotations.media.Schema
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetail
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.nonassociation.NonAssociationDetails
 
 @Schema(description = "Prisoner workplace risk assessment suitability")
 data class NonAssociationSuitability(
   @Schema(description = "The prisoner's suitability", example = "True")
   val suitable: Boolean,
   @Schema(description = "The prisoner's non-associations")
-  val nonAssociations: List<OffenderNonAssociationDetail>,
+  val nonAssociations: List<NonAssociationDetails>,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/nonassociation/NonAssociationDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/nonassociation/NonAssociationDetails.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.nonassociation
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDateTime
+
+@Schema(description = "Prisoner non-association details")
+data class NonAssociationDetails(
+  @Schema(example = "VIC", required = true, description = "The non-association reason code")
+  @get:JsonProperty("reasonCode", required = true)
+  val reasonCode: String,
+
+  @Schema(example = "Victim", required = true, description = "The non-association reason description")
+  @get:JsonProperty("reasonDescription", required = true)
+  val reasonDescription: String,
+
+  @Schema(example = "WING", required = true, description = "The non-association type code")
+  @get:JsonProperty("typeCode", required = true)
+  val typeCode: String,
+
+  @Schema(example = "Do Not Locate on Same Wing", required = true, description = "The non-association type description")
+  @get:JsonProperty("typeDescription", required = true)
+  val typeDescription: String,
+
+  @Schema(example = "2021-07-05T10:35:17", required = true, description = "Date and time the mom-association is effective from. In Europe/London (ISO 8601) format without timezone offset e.g. YYYY-MM-DDTHH:MM:SS.")
+  @get:JsonProperty("effectiveDate", required = true)
+  val effectiveDate: LocalDateTime,
+
+  @Schema(example = "2021-07-05T10:35:17", description = "Date and time the mom-association expires. In Europe/London (ISO 8601) format without timezone offset e.g. YYYY-MM-DDTHH:MM:SS.")
+  @get:JsonProperty("expiryDate")
+  val expiryDate: LocalDateTime? = null,
+
+  @Schema(example = "null", required = true, description = "")
+  @get:JsonProperty("offenderNonAssociation", required = true)
+  val offenderNonAssociation: OffenderNonAssociation,
+
+  @Schema(example = "null", description = "The person who authorised the non-association (free text).")
+  @get:JsonProperty("authorisedBy")
+  val authorisedBy: String? = null,
+
+  @Schema(example = "null", description = "Additional free text comments related to the non-association.")
+  @get:JsonProperty("comments")
+  val comments: String? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/nonassociation/OffenderNonAssociation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/suitability/nonassociation/OffenderNonAssociation.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.nonassociation
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(description = "Offender non-association details")
+data class OffenderNonAssociation(
+  @Schema(example = "G0135GA", required = true, description = "The offenders number")
+  @get:JsonProperty("offenderNo", required = true)
+  val offenderNo: String,
+
+  @Schema(example = "Joseph", required = true, description = "The offenders first name")
+  @get:JsonProperty("firstName", required = true)
+  val firstName: String,
+
+  @Schema(example = "Bloggs", required = true, description = "The offenders last name")
+  @get:JsonProperty("lastName", required = true)
+  val lastName: String,
+
+  @Schema(example = "PER", required = true, description = "The non-association reason code")
+  @get:JsonProperty("reasonCode", required = true)
+  val reasonCode: String,
+
+  @Schema(example = "Perpetrator", required = true, description = "The non-association reason description")
+  @get:JsonProperty("reasonDescription", required = true)
+  val reasonDescription: String,
+
+  @Schema(example = "Pentonville (PVI)", required = true, description = "Description of the agency (e.g. prison) the offender is assigned to.")
+  @get:JsonProperty("agencyDescription", required = true)
+  val agencyDescription: String,
+
+  @Schema(example = "PVI-1-2-4", required = true, description = "Description of living unit (e.g. cell) the offender is assigned to.")
+  @get:JsonProperty("assignedLivingUnitDescription", required = true)
+  val assignedLivingUnitDescription: String? = null,
+
+  @Schema(example = "123", required = true, description = "Id of living unit (e.g. cell) the offender is assigned to.")
+  @get:JsonProperty("assignedLivingUnitId", required = true)
+  val assignedLivingUnitId: Long? = null,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesService.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitabili
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.WRASuitability
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transformOffenderNonAssociationDetail
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -218,7 +219,9 @@ class CandidatesService(
 
     return NonAssociationSuitability(
       allocationNonAssociations.isNullOrEmpty(),
-      allocationNonAssociations,
+      allocationNonAssociations.map {
+        transformOffenderNonAssociationDetail(it)
+      },
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesService.kt
@@ -2,8 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.CurrentIncentive
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util
 
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventReview
@@ -10,7 +11,10 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.toModel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RolloutPrisonPlan
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.nonassociation.NonAssociationDetails
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.nonassociation.OffenderNonAssociation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.EventPriorities
+import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity as EntityActivity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityCategory as EntityActivityCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityEligibility as EntityActivityEligibility
@@ -358,6 +362,30 @@ fun EntityPrisonPayBand.toModelPrisonPayBand() =
     displaySequence = this.displaySequence,
     nomisPayBand = this.nomisPayBand,
     prisonCode = this.prisonCode,
+  )
+
+fun transformOffenderNonAssociationDetail(offenderNonAssociationDetail: OffenderNonAssociationDetail) =
+  NonAssociationDetails(
+    reasonCode = offenderNonAssociationDetail.reasonCode,
+    reasonDescription = offenderNonAssociationDetail.reasonDescription,
+    typeCode = offenderNonAssociationDetail.typeCode,
+    typeDescription = offenderNonAssociationDetail.typeDescription,
+    effectiveDate = LocalDateTime.parse(offenderNonAssociationDetail.effectiveDate),
+    expiryDate = offenderNonAssociationDetail.expiryDate?.let { LocalDateTime.parse(offenderNonAssociationDetail.expiryDate) },
+    offenderNonAssociation = with(offenderNonAssociationDetail.offenderNonAssociation) {
+      OffenderNonAssociation(
+        offenderNo = this.offenderNo,
+        firstName = this.firstName,
+        lastName = this.lastName,
+        reasonCode = this.reasonCode,
+        reasonDescription = this.reasonDescription,
+        agencyDescription = this.agencyDescription,
+        assignedLivingUnitDescription = this.assignedLivingUnitDescription,
+        assignedLivingUnitId = this.assignedLivingUnitId,
+      )
+    },
+    authorisedBy = offenderNonAssociationDetail.authorisedBy,
+    comments = offenderNonAssociationDetail.comments,
   )
 
 fun transform(prisonRegime: EntityPrisonRegime) = ModelPrisonRegime(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.assertThrows
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.WebClientResponseException
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
@@ -19,6 +20,8 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.wiremock.PrisonApiMockServer
 import java.time.LocalDate
+import kotlin.reflect.full.declaredFunctions
+import kotlin.reflect.typeOf
 
 class PrisonApiClientTest {
 
@@ -403,5 +406,12 @@ class PrisonApiClientTest {
       assertThat(offenderNo).isEqualTo("B4793VX")
       assertThat(hearingId).isEqualTo(1)
     }
+  }
+
+  @Test
+  fun `verify overridden return type for non-associations`() {
+    val function = PrisonApiClient::class.declaredFunctions.first { it.name == "getOffenderNonAssociations" }
+
+    assertThat(function.returnType).isEqualTo(typeOf<List<OffenderNonAssociationDetail>?>())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
@@ -9,9 +9,9 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociation
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderNonAssociationDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.CurrentIncentive
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.IncentiveLevel

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
@@ -26,6 +26,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitabili
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.ReleaseDateSuitability
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.WRASuitability
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transformOffenderNonAssociationDetail
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.*
@@ -444,7 +445,7 @@ class CandidatesServiceTest {
       assertThat(suitability.nonAssociation).isEqualTo(
         NonAssociationSuitability(
           suitable = false,
-          nonAssociations = listOf(offenderNonAssociation),
+          nonAssociations = listOf(transformOffenderNonAssociationDetail(offenderNonAssociation)),
         ),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance
@@ -30,6 +31,8 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonerS
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RolloutPrisonPlan
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ScheduledEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.UserSummary
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.nonassociation.NonAssociationDetails
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.suitability.nonassociation.OffenderNonAssociation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.EventPriorities
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.LocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.Priority
@@ -39,6 +42,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.Referen
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociation as PrisonApiOffenderNonAssociation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityEligibility as ModelActivityEligibility
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityMinimumEducationLevel as ModelActivityMinimumEducationLevel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPay as ModelActivityPay
@@ -320,6 +324,53 @@ class TransformFunctionsTest {
         activitiesRolloutDate = LocalDate.of(2022, 12, 22),
         appointmentsRolledOut = true,
         appointmentsRolloutDate = LocalDate.of(2022, 12, 23),
+      ),
+    )
+  }
+
+  @Test
+  fun `transformation of OffenderNonAssociationDetail to NonAssociationDetails`() {
+    val nonAssociationDetail = OffenderNonAssociationDetail(
+      reasonCode = "VIC",
+      reasonDescription = "Victim",
+      typeCode = "WING",
+      typeDescription = "Do Not Locate on Same Wing",
+      effectiveDate = "2021-07-05T10:35:17",
+      expiryDate = "2024-07-05T10:35:17",
+      offenderNonAssociation = PrisonApiOffenderNonAssociation(
+        offenderNo = "G0135GA",
+        firstName = "Joseph",
+        lastName = "Bloggs",
+        reasonCode = "PER",
+        reasonDescription = "Perpetrator",
+        agencyDescription = "Pentonville",
+        assignedLivingUnitDescription = "PVI-1-2-4",
+        assignedLivingUnitId = 123,
+      ),
+      authorisedBy = "Test user",
+      comments = "A comment",
+    )
+
+    assertThat(transformOffenderNonAssociationDetail(nonAssociationDetail)).isEqualTo(
+      NonAssociationDetails(
+        reasonCode = "VIC",
+        reasonDescription = "Victim",
+        typeCode = "WING",
+        typeDescription = "Do Not Locate on Same Wing",
+        effectiveDate = LocalDateTime.parse("2021-07-05T10:35:17"),
+        expiryDate = LocalDateTime.parse("2024-07-05T10:35:17"),
+        offenderNonAssociation = OffenderNonAssociation(
+          offenderNo = "G0135GA",
+          firstName = "Joseph",
+          lastName = "Bloggs",
+          reasonCode = "PER",
+          reasonDescription = "Perpetrator",
+          agencyDescription = "Pentonville",
+          assignedLivingUnitDescription = "PVI-1-2-4",
+          assignedLivingUnitId = 123,
+        ),
+        authorisedBy = "Test user",
+        comments = "A comment",
       ),
     )
   }


### PR DESCRIPTION
## Overview

This adds overrides for fields `assignedLivingUnitDescription` and `assignedLivingUnitId` of `OffenderNonAssociation`.

Needed since these fields can be null despite being required.