### PR TITLE
SDIT-897 Cater for multiple allocations on attendance sync

### DIFF
--- a/src/main/resources/migrations/common/V2023.06.20__fix_attendance_sync_view.sql
+++ b/src/main/resources/migrations/common/V2023.06.20__fix_attendance_sync_view.sql
@@ -1,0 +1,25 @@
+-- =============================================
+-- ATTENDANCE SYNC VIEW
+-- =============================================
+
+CREATE OR REPLACE VIEW v_attendance_sync AS
+select a.attendance_id,
+       a.scheduled_instance_id,
+       si.activity_schedule_id,
+       si.session_date,
+       si.start_time as session_start_time,
+       si.end_time   as session_end_time,
+       a.prisoner_number,
+       a2.booking_id,
+       ar.code       as attendance_reason_code,
+       a.comment,
+       a.status,
+       a.pay_amount,
+       a.bonus_amount,
+       a.issue_payment
+from attendance a
+         join scheduled_instance si on a.scheduled_instance_id = si.scheduled_instance_id
+         join allocation a2 on si.activity_schedule_id = a2.activity_schedule_id and
+                               a.prisoner_number = a2.prisoner_number and
+                               a2.prisoner_status != 'ENDED'
+         left join attendance_reason ar on a.attendance_reason_id = ar.attendance_reason_id;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AttendanceSyncIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AttendanceSyncIntegrationTest.kt
@@ -80,6 +80,40 @@ class AttendanceSyncIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/seed-activity-id-17.sql",
   )
   @Test
+  fun `should return attendance sync where prisoner has been deallocated and reallocated`() {
+    val attendanceSync =
+      webTestClient.get()
+        .uri("/synchronisation/attendance/3")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ACTIVITIES")))
+        .exchange()
+        .expectStatus().isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(AttendanceSync::class.java)
+        .returnResult().responseBody!!
+
+    with(attendanceSync) {
+      assertThat(attendanceId).isEqualTo(3)
+      assertThat(scheduledInstanceId).isEqualTo(1)
+      assertThat(activityScheduleId).isEqualTo(1)
+      assertThat(sessionDate).isEqualTo(LocalDate.now())
+      assertThat(sessionStartTime).isEqualTo("10:00")
+      assertThat(sessionEndTime).isEqualTo("11:00")
+      assertThat(prisonerNumber).isEqualTo("A33333A")
+      assertThat(bookingId).isEqualTo(10003)
+      assertThat(attendanceReasonCode).isEqualTo("SICK")
+      assertThat(comment).isNull()
+      assertThat(status).isEqualTo("COMPLETED")
+      assertThat(payAmount).isEqualTo(200)
+      assertThat(bonusAmount).isNull()
+      assertThat(issuePayment).isNull()
+    }
+  }
+
+  @Sql(
+    "classpath:test_data/seed-activity-id-17.sql",
+  )
+  @Test
   fun `should return unauthorised`() {
     webTestClient.get()
       .uri("/synchronisation/attendance/1")

--- a/src/test/resources/test_data/seed-activity-id-17.sql
+++ b/src/test/resources/test_data/seed-activity-id-17.sql
@@ -29,7 +29,7 @@ insert into allocation(allocation_id, activity_schedule_id, prisoner_number, boo
 values (2, 1, 'A22222A', 10002, 2, '2022-10-10', null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (3, 1, 'A33333A', 10003, 2, '2022-10-10', '2022-10-11', '2022-10-10 09:00:00', 'MRS BLOGS', '2022-10-11 09:00:00', 'SYSTEM', 'Allocation end data reached', null, null, null, 'ENDED');
+values (3, 1, 'A33333A', 10003, 2, '2022-10-10', '2022-10-11', '2022-10-10 09:00:00', 'MRS BLOGS', '2022-10-11 09:00:00', 'SYSTEM', 'ENDED', null, null, null, 'ENDED');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (4, 2, 'A11111A', 10001, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
@@ -37,12 +37,18 @@ values (4, 2, 'A11111A', 10001, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'M
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (5, 2, 'A22222A', 10002, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
-insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
-values (1, now(), '10:00:00', '11:00:00', true, now(), 'Old Canceller', 'Nobody Available', null);
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (6, 1, 'A33333A', 10003, 2, '2022-10-20', null, '2022-10-20 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'SUSPENDED');
+
+insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, 1, now(), '10:00:00', '11:00:00', true, now(), 'Old Canceller', 'Nobody Available', null);
 
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces, issue_payment)
 values (1, 1, 'A22222A', 1, 'Attendance Comment', now(), 'Old Recorder', 'COMPLETED', 150, 50, null, false);
 
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces, issue_payment)
 values (2, 1, 'A11111A', null, null, now(), 'Old Recorder', 'WAITING', null, null, null, null);
+
+insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces, issue_payment)
+values (3, 1, 'A33333A', 1, null, now(), 'Old Recorder', 'COMPLETED', 200, null, null, null);
 


### PR DESCRIPTION
And only grab the active allocation (i.e. not ENDED)