### PR TITLE
SAA-876 reworking updates to slots to update slots affected and remove those no longer needed instead of removing all and then re-adding.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -189,18 +189,15 @@ data class ActivitySchedule(
     }
   }
 
-  fun addSlot(startTime: LocalTime, endTime: LocalTime, daysOfWeek: Set<DayOfWeek>) {
+  fun addSlot(startTime: LocalTime, endTime: LocalTime, daysOfWeek: Set<DayOfWeek>) =
     addSlot(ActivityScheduleSlot.valueOf(this, startTime, endTime, daysOfWeek))
-  }
 
-  fun addSlot(slot: ActivityScheduleSlot) {
+  fun addSlot(slot: ActivityScheduleSlot): ActivityScheduleSlot {
     if (slot.activitySchedule.activityScheduleId != activityScheduleId) throw IllegalArgumentException("Can only add slots that belong to this schedule.")
 
     slots.add(slot)
-  }
 
-  fun removeSlots() {
-    slots.clear()
+    return slots.last()
   }
 
   fun allocatePrisoner(
@@ -298,6 +295,12 @@ data class ActivitySchedule(
 
   fun removeInstances(fromDate: LocalDate, toDate: LocalDate) {
     instances.removeAll(instances().filter { it.sessionDate.between(fromDate, toDate) })
+  }
+
+  fun updateSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
+    slots.removeAll(slots.filterNot { updates.containsKey(Pair(it.startTime, it.endTime)) })
+
+    slots.forEach { slot -> updates[slot.startTime to slot.endTime]?.let(slot::update) }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -298,9 +298,27 @@ data class ActivitySchedule(
   }
 
   fun updateSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
-    slots.removeAll(slots.filterNot { updates.containsKey(Pair(it.startTime, it.endTime)) })
+    removeRedundantSlots(updates)
+    updateMatchingSlots(updates)
+    addNewSlots(updates)
+  }
 
-    slots.forEach { slot -> updates[slot.startTime to slot.endTime]?.let(slot::update) }
+  private fun removeRedundantSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
+    slots.removeAll(slots.filterNot { updates.containsKey(Pair(it.startTime, it.endTime)) })
+  }
+
+  private fun updateMatchingSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
+    slots.forEach { slot ->
+      updates[slot.startTime to slot.endTime]?.let(slot::update)
+    }
+  }
+
+  private fun addNewSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
+    updates.keys.filterNot { key ->
+      slots.map { Pair(it.startTime, it.endTime) }.contains(key)
+    }.forEach {
+      addSlot(it.first, it.second, updates[it]!!)
+    }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSlot.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSlot.kt
@@ -28,19 +28,19 @@ data class ActivityScheduleSlot(
 
   val endTime: LocalTime,
 
-  val mondayFlag: Boolean = false,
+  var mondayFlag: Boolean = false,
 
-  val tuesdayFlag: Boolean = false,
+  var tuesdayFlag: Boolean = false,
 
-  val wednesdayFlag: Boolean = false,
+  var wednesdayFlag: Boolean = false,
 
-  val thursdayFlag: Boolean = false,
+  var thursdayFlag: Boolean = false,
 
-  val fridayFlag: Boolean = false,
+  var fridayFlag: Boolean = false,
 
-  val saturdayFlag: Boolean = false,
+  var saturdayFlag: Boolean = false,
 
-  val sundayFlag: Boolean = false,
+  var sundayFlag: Boolean = false,
 
 ) {
   init {
@@ -78,6 +78,20 @@ data class ActivityScheduleSlot(
       saturdayFlag = daysOfWeek.contains(DayOfWeek.SATURDAY),
       sundayFlag = daysOfWeek.contains(DayOfWeek.SUNDAY),
     )
+  }
+
+  fun update(daysOfWeek: Set<DayOfWeek>) {
+    require(daysOfWeek.isNotEmpty()) {
+      "A slot must run on at least one day."
+    }
+
+    mondayFlag = daysOfWeek.contains(DayOfWeek.MONDAY)
+    tuesdayFlag = daysOfWeek.contains(DayOfWeek.TUESDAY)
+    wednesdayFlag = daysOfWeek.contains(DayOfWeek.WEDNESDAY)
+    thursdayFlag = daysOfWeek.contains(DayOfWeek.THURSDAY)
+    fridayFlag = daysOfWeek.contains(DayOfWeek.FRIDAY)
+    saturdayFlag = daysOfWeek.contains(DayOfWeek.SATURDAY)
+    sundayFlag = daysOfWeek.contains(DayOfWeek.SUNDAY)
   }
 
   fun toModel() = ModelActivityScheduleSlot(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
@@ -7,7 +7,9 @@ import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
+import java.time.DayOfWeek
 import java.time.LocalDate
 
 @Schema(description = "Describes a top-level activity to be created")
@@ -18,7 +20,10 @@ data class ActivityCreateRequest(
   @Schema(description = "The prison code where this activity takes place", example = "PVI")
   val prisonCode: String?,
 
-  @Schema(description = "Flag to indicate if attendance is required for this activity, e.g. gym induction might not be mandatory attendance", example = "false")
+  @Schema(
+    description = "Flag to indicate if attendance is required for this activity, e.g. gym induction might not be mandatory attendance",
+    example = "false",
+  )
   val attendanceRequired: Boolean = true,
 
   @Schema(description = "Flag to indicate if the location of the activity is in cell", example = "false")
@@ -30,16 +35,25 @@ data class ActivityCreateRequest(
   @Schema(description = "Flag to indicate if the activity carried out outside of the prison", example = "false")
   var outsideWork: Boolean,
 
-  @Schema(description = "Indicates whether the activity session is a (F)ull day or a (H)alf day (for payment purposes). ", example = "H")
+  @Schema(
+    description = "Indicates whether the activity session is a (F)ull day or a (H)alf day (for payment purposes). ",
+    example = "H",
+  )
   var payPerSession: PayPerSession?,
 
   @field:NotEmpty(message = "Activity summary must be supplied")
   @field:Size(max = 50, message = "Summary should not exceed {max} characters")
-  @Schema(description = "A brief summary description of this activity for use in forms and lists", example = "Maths level 1")
+  @Schema(
+    description = "A brief summary description of this activity for use in forms and lists",
+    example = "Maths level 1",
+  )
   val summary: String?,
 
   @field:Size(max = 300, message = "Description should not exceed {max} characters")
-  @Schema(description = "A detailed description for this activity", example = "A basic maths course suitable for introduction to the subject")
+  @Schema(
+    description = "A detailed description for this activity",
+    example = "A basic maths course suitable for introduction to the subject",
+  )
   val description: String?,
 
   @field:NotNull(message = "Category ID must be supplied")
@@ -63,7 +77,10 @@ data class ActivityCreateRequest(
 
   @field:NotEmpty(message = "Minimum incentive level NOMIS code must be supplied")
   @field:Size(max = 3, message = "Minimum incentive level NOMIS code should not exceed {max} characters")
-  @Schema(description = "The NOMIS code for the minimum incentive/earned privilege level for this activity", example = "BAS")
+  @Schema(
+    description = "The NOMIS code for the minimum incentive/earned privilege level for this activity",
+    example = "BAS",
+  )
   val minimumIncentiveNomisCode: String?,
 
   @field:NotEmpty(message = "Minimum incentive level must be supplied")
@@ -71,11 +88,17 @@ data class ActivityCreateRequest(
   @Schema(description = "The minimum incentive/earned privilege level for this activity", example = "Basic")
   val minimumIncentiveLevel: String?,
 
-  @Schema(description = "The date on which this activity will start. From this date, any schedules will be created as real, planned instances", example = "2022-12-23")
+  @Schema(
+    description = "The date on which this activity will start. From this date, any schedules will be created as real, planned instances",
+    example = "2022-12-23",
+  )
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   val startDate: LocalDate? = null,
 
-  @Schema(description = "The date on which this activity ends. From this date, there will be no more planned instances of the activity. If null, the activity has no end date and will be scheduled indefinitely.", example = "2022-12-23")
+  @Schema(
+    description = "The date on which this activity ends. From this date, there will be no more planned instances of the activity. If null, the activity has no end date and will be scheduled indefinitely.",
+    example = "2022-12-23",
+  )
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   val endDate: LocalDate? = null,
 
@@ -111,7 +134,7 @@ data class ActivityCreateRequest(
 
 data class Slot(
 
-  @field:NotNull(message = "The time slot must supplied")
+  @field:NotEmpty(message = "The time slot must supplied")
   @Schema(
     description = "The time slot of the activity schedule, morning afternoon or evening e.g. AM, PM or ED",
     example = "AM",
@@ -131,4 +154,18 @@ data class Slot(
   val saturday: Boolean = false,
 
   val sunday: Boolean = false,
-)
+) {
+  fun getDaysOfWeek(): Set<DayOfWeek> {
+    return setOfNotNull(
+      DayOfWeek.MONDAY.takeIf { monday },
+      DayOfWeek.TUESDAY.takeIf { tuesday },
+      DayOfWeek.WEDNESDAY.takeIf { wednesday },
+      DayOfWeek.THURSDAY.takeIf { thursday },
+      DayOfWeek.FRIDAY.takeIf { friday },
+      DayOfWeek.SATURDAY.takeIf { saturday },
+      DayOfWeek.SUNDAY.takeIf { sunday },
+    )
+  }
+
+  fun timeSlot() = TimeSlot.valueOf(timeSlot!!)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityUpdateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityUpdateRequest.kt
@@ -12,63 +12,78 @@ import java.time.LocalDate
 data class ActivityUpdateRequest(
 
   @Schema(description = "The category id for this activity, one of the high-level categories")
-  val categoryId: Long?,
+  val categoryId: Long? = null,
 
   @Schema(description = "The tier id for this activity, as defined by the Future Prison Regime team", example = "1")
-  val tierId: Long?,
+  val tierId: Long? = null,
 
   @field:Size(max = 50, message = "Summary should not exceed {max} characters")
-  @Schema(description = "A brief summary description of this activity for use in forms and lists", example = "Maths level 1")
-  val summary: String?,
+  @Schema(
+    description = "A brief summary description of this activity for use in forms and lists",
+    example = "Maths level 1",
+  )
+  val summary: String? = null,
 
-  @Schema(description = "The date on which this activity will start. From this date, any schedules will be created as real, planned instances", example = "2022-12-23")
+  @Schema(
+    description = "The date on which this activity will start. From this date, any schedules will be created as real, planned instances",
+    example = "2022-12-23",
+  )
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
   @field:FutureOrPresent(message = "Start date must not be in the past")
-  val startDate: LocalDate?,
+  val startDate: LocalDate? = null,
 
-  @Schema(description = "The date on which this activity ends. From this date, there will be no more planned instances of the activity. If null, the activity has no end date and will be scheduled indefinitely.", example = "2022-12-23")
+  @Schema(
+    description = "The date on which this activity ends. From this date, there will be no more planned instances of the activity. If null, the activity has no end date and will be scheduled indefinitely.",
+    example = "2022-12-23",
+  )
   @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
-  val endDate: LocalDate?,
+  val endDate: LocalDate? = null,
 
   @field:Size(max = 3, message = "Minimum incentive level NOMIS code should not exceed {max} characters")
-  @Schema(description = "The NOMIS code for the minimum incentive/earned privilege level for this activity", example = "BAS")
-  val minimumIncentiveNomisCode: String?,
+  @Schema(
+    description = "The NOMIS code for the minimum incentive/earned privilege level for this activity",
+    example = "BAS",
+  )
+  val minimumIncentiveNomisCode: String? = null,
 
   @field:Size(max = 10, message = "Minimum incentive level should not exceed {max} characters")
   @Schema(description = "The minimum incentive/earned privilege level for this activity", example = "Basic")
-  val minimumIncentiveLevel: String?,
+  val minimumIncentiveLevel: String? = null,
 
   @Schema(description = "Whether the schedule runs on bank holidays", example = "true")
-  val runsOnBankHoliday: Boolean?,
+  val runsOnBankHoliday: Boolean? = null,
 
   @field:Positive(message = "The capacity must be a positive integer")
   @Schema(
     description = "The maximum number of prisoners allowed for a scheduled instance of this schedule",
     example = "10",
   )
-  val capacity: Int?,
+  val capacity: Int? = null,
 
   @field:Size(max = 10, message = "Risk level should not exceed {max} characters")
   @Schema(description = "The most recent risk assessment level for this activity", example = "high")
-  val riskLevel: String?,
+  val riskLevel: String? = null,
 
   @Schema(description = "The optional NOMIS internal location id for this schedule", example = "98877667")
-  val locationId: Long?,
+  val locationId: Long? = null,
 
   @Schema(description = "Flag to indicate if the location of the activity is in cell", example = "false")
-  var inCell: Boolean?,
+  var inCell: Boolean? = null,
 
-  @Schema(description = "Flag to indicate if attendance is required for this activity, e.g. gym induction might not be mandatory attendance", example = "false")
-  val attendanceRequired: Boolean?,
+  @Schema(
+    description = "Flag to indicate if attendance is required for this activity, e.g. gym induction might not be mandatory attendance",
+    example = "false",
+  )
+  val attendanceRequired: Boolean? = null,
 
   @field:Valid
   @Schema(description = "The list of minimum education levels that apply to this activity")
-  val minimumEducationLevel: List<ActivityMinimumEducationLevelCreateRequest>?,
+  val minimumEducationLevel: List<ActivityMinimumEducationLevelCreateRequest>? = null,
 
   @field:Valid
   @Schema(description = "The list of pay rates that can apply to this activity")
-  val pay: List<ActivityPayCreateRequest>?,
+  val pay: List<ActivityPayCreateRequest>? = null,
 
   @Schema(description = "The days and times an activity schedule can take place")
-  val slots: List<Slot>?,
+  val slots: List<Slot>? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -486,9 +486,10 @@ class ActivityService(
         TimeSlot.PM to Pair(prisonRegime.pmStart, prisonRegime.pmFinish),
         TimeSlot.ED to Pair(prisonRegime.edStart, prisonRegime.edFinish),
       )
-    activity.schedules().forEach {
-      it.removeSlots()
-      it.addSlots(slots, timeSlots)
-    }
+
+    activity.schedules().forEach { it.updateSlots(slots.toMap(timeSlots)) }
   }
+
+  private fun List<Slot>.toMap(regimeTimeSlots: Map<TimeSlot, Pair<LocalTime, LocalTime>>) =
+    associate { regimeTimeSlots[it.timeSlot()]!! to it.getDaysOfWeek() }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -1,5 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Service
@@ -44,6 +46,11 @@ class ActivityService(
   private val bankHolidayService: BankHolidayService,
   @Value("\${online.create-scheduled-instances.days-in-advance}") private val daysInAdvance: Long = 14L,
 ) {
+
+  companion object {
+    val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
   fun getActivityById(activityId: Long) =
     transform(
       activityRepository.findOrThrowNotFound(activityId),
@@ -180,7 +187,12 @@ class ActivityService(
     }
   }
 
-  private fun ActivitySchedule.addInstances(activity: Activity, slots: List<ActivityScheduleSlot>, fromDate: LocalDate?, toDate: LocalDate?) {
+  private fun ActivitySchedule.addInstances(
+    activity: Activity,
+    slots: List<ActivityScheduleSlot>,
+    fromDate: LocalDate?,
+    toDate: LocalDate?,
+  ) {
     val today = LocalDate.now()
     val endDay = today.plusDays(daysInAdvance)
     val listOfDatesToSchedule = today.datesUntil(endDay).toList()
@@ -235,7 +247,12 @@ class ActivityService(
   }
 
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN')")
-  fun updateActivity(prisonCode: String, activityId: Long, request: ActivityUpdateRequest, updatedBy: String): ModelActivity {
+  fun updateActivity(
+    prisonCode: String,
+    activityId: Long,
+    request: ActivityUpdateRequest,
+    updatedBy: String,
+  ): ModelActivity {
     val activity = activityRepository.findOrThrowNotFound(activityId)
     val now = LocalDateTime.now()
 
@@ -479,6 +496,8 @@ class ActivityService(
     slots: List<Slot>,
     activity: Activity,
   ) {
+    log.info("slots changes - $slots")
+
     val prisonRegime = prisonRegimeService.getPrisonRegimeByPrisonCode(activity.prisonCode)
     val timeSlots =
       mapOf(
@@ -488,6 +507,8 @@ class ActivityService(
       )
 
     activity.schedules().forEach { it.updateSlots(slots.toMap(timeSlots)) }
+
+    log.info("updated slots - ${activity.schedules().first().slots()}")
   }
 
   private fun List<Slot>.toMap(regimeTimeSlots: Map<TimeSlot, Pair<LocalTime, LocalTime>>) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSlotTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleSlotTest.kt
@@ -1,8 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.mock
+import java.time.DayOfWeek
 import java.time.LocalTime
 
 class ActivityScheduleSlotTest {
@@ -184,5 +186,56 @@ class ActivityScheduleSlotTest {
       assertThat(sundayFlag).isTrue
       assertThat(daysOfWeek).containsExactly("Sun")
     }
+  }
+
+  @Test
+  fun `change day of slot`() {
+    val slot = ActivityScheduleSlot(
+      activityScheduleSlotId = 1,
+      activitySchedule = mock(),
+      startTime = LocalTime.now(),
+      endTime = LocalTime.now(),
+      mondayFlag = true,
+      sundayFlag = true,
+    )
+
+    with(slot) {
+      assertThat(mondayFlag).isTrue
+      assertThat(tuesdayFlag).isFalse
+      assertThat(wednesdayFlag).isFalse
+      assertThat(thursdayFlag).isFalse
+      assertThat(fridayFlag).isFalse
+      assertThat(saturdayFlag).isFalse
+      assertThat(sundayFlag).isTrue
+    }
+
+    slot.update(setOf(DayOfWeek.TUESDAY))
+
+    with(slot) {
+      assertThat(mondayFlag).isFalse
+      assertThat(tuesdayFlag).isTrue
+      assertThat(wednesdayFlag).isFalse
+      assertThat(thursdayFlag).isFalse
+      assertThat(fridayFlag).isFalse
+      assertThat(saturdayFlag).isFalse
+      assertThat(sundayFlag).isFalse
+    }
+  }
+
+  @Test
+  fun `must provide at least one day on update`() {
+    val slot = ActivityScheduleSlot(
+      activityScheduleSlotId = 1,
+      activitySchedule = mock(),
+      startTime = LocalTime.now(),
+      endTime = LocalTime.now(),
+      mondayFlag = true,
+      sundayFlag = true,
+    )
+
+    assertThatThrownBy {
+      slot.update(emptySet())
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("A slot must run on at least one day.")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -719,7 +719,7 @@ class ActivityScheduleTest {
   }
 
   @Test
-  fun `multiple slots are updated`() {
+  fun `multiple slots are updated and new slot added`() {
     val schedule =
       activitySchedule(activity = activityEntity(startDate = yesterday, endDate = tomorrow), noSlots = true)
 
@@ -731,7 +731,9 @@ class ActivityScheduleTest {
       setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY),
     )
     val slotTwo =
-      schedule.addSlot(LocalTime.NOON, LocalTime.MIDNIGHT.minusMinutes(1), setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY))
+      schedule.addSlot(LocalTime.NOON, LocalTime.NOON.plusMinutes(1), setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY))
+
+    val slotThree = Pair(LocalTime.NOON.minusMinutes(5), LocalTime.NOON.plusMinutes(10)) to setOf(DayOfWeek.SUNDAY)
 
     assertThat(slotOne.mondayFlag).isTrue
     assertThat(slotOne.tuesdayFlag).isTrue
@@ -752,7 +754,10 @@ class ActivityScheduleTest {
     val updates = mapOf(
       Pair(slotOne.startTime, slotOne.endTime) to setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY),
       Pair(slotTwo.startTime, slotTwo.endTime) to setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+      slotThree,
     )
+
+    assertThat(schedule.slots()).containsExactly(slotOne, slotTwo)
 
     schedule.updateSlots(updates)
 
@@ -771,6 +776,16 @@ class ActivityScheduleTest {
     assertThat(slotTwo.fridayFlag).isFalse
     assertThat(slotTwo.saturdayFlag).isFalse
     assertThat(slotTwo.sundayFlag).isFalse
+
+    with(schedule.slots()[2]) {
+      assertThat(mondayFlag).isFalse
+      assertThat(tuesdayFlag).isFalse
+      assertThat(wednesdayFlag).isFalse
+      assertThat(thursdayFlag).isFalse
+      assertThat(fridayFlag).isFalse
+      assertThat(saturdayFlag).isFalse
+      assertThat(sundayFlag).isTrue
+    }
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -272,7 +272,8 @@ class ActivityScheduleTest {
 
   @Test
   fun `cannot start allocation beyond the end date of the schedule or activity`() {
-    val schedule = activitySchedule(activity = activityEntity(startDate = yesterday, endDate = today), noAllocations = true)
+    val schedule =
+      activitySchedule(activity = activityEntity(startDate = yesterday, endDate = today), noAllocations = true)
 
     assertThatThrownBy {
       schedule.allocatePrisoner(
@@ -681,5 +682,133 @@ class ActivityScheduleTest {
       schedule.deallocatePrisonerOn("DOES NOT EXIST", TimeSource.tomorrow(), DeallocationReason.RELEASED, "by test")
     }.isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Allocation not found for prisoner DOES NOT EXIST for schedule ${schedule.activityScheduleId}.")
+  }
+
+  @Test
+  fun `single slot is updated`() {
+    val schedule =
+      activitySchedule(activity = activityEntity(startDate = yesterday, endDate = tomorrow), noSlots = true)
+
+    assertThat(schedule.slots()).isEmpty()
+
+    val slot = schedule.addSlot(
+      LocalTime.MIDNIGHT,
+      LocalTime.NOON,
+      setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY),
+    )
+
+    val updates = mapOf(Pair(LocalTime.MIDNIGHT, LocalTime.NOON) to setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY))
+
+    assertThat(slot.mondayFlag).isTrue
+    assertThat(slot.tuesdayFlag).isTrue
+    assertThat(slot.wednesdayFlag).isTrue
+    assertThat(slot.thursdayFlag).isFalse
+    assertThat(slot.fridayFlag).isFalse
+    assertThat(slot.saturdayFlag).isFalse
+    assertThat(slot.sundayFlag).isFalse
+
+    schedule.updateSlots(updates)
+
+    assertThat(slot.mondayFlag).isTrue
+    assertThat(slot.tuesdayFlag).isFalse
+    assertThat(slot.wednesdayFlag).isTrue
+    assertThat(slot.thursdayFlag).isFalse
+    assertThat(slot.fridayFlag).isFalse
+    assertThat(slot.saturdayFlag).isFalse
+    assertThat(slot.sundayFlag).isFalse
+  }
+
+  @Test
+  fun `multiple slots are updated`() {
+    val schedule =
+      activitySchedule(activity = activityEntity(startDate = yesterday, endDate = tomorrow), noSlots = true)
+
+    assertThat(schedule.slots()).isEmpty()
+
+    val slotOne = schedule.addSlot(
+      LocalTime.MIDNIGHT,
+      LocalTime.NOON,
+      setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY),
+    )
+    val slotTwo =
+      schedule.addSlot(LocalTime.NOON, LocalTime.MIDNIGHT.minusMinutes(1), setOf(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY))
+
+    assertThat(slotOne.mondayFlag).isTrue
+    assertThat(slotOne.tuesdayFlag).isTrue
+    assertThat(slotOne.wednesdayFlag).isTrue
+    assertThat(slotOne.thursdayFlag).isFalse
+    assertThat(slotOne.fridayFlag).isFalse
+    assertThat(slotOne.saturdayFlag).isFalse
+    assertThat(slotOne.sundayFlag).isFalse
+
+    assertThat(slotTwo.mondayFlag).isFalse
+    assertThat(slotTwo.tuesdayFlag).isFalse
+    assertThat(slotTwo.wednesdayFlag).isFalse
+    assertThat(slotTwo.thursdayFlag).isFalse
+    assertThat(slotTwo.fridayFlag).isFalse
+    assertThat(slotTwo.saturdayFlag).isTrue
+    assertThat(slotTwo.sundayFlag).isTrue
+
+    val updates = mapOf(
+      Pair(slotOne.startTime, slotOne.endTime) to setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY),
+      Pair(slotTwo.startTime, slotTwo.endTime) to setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+    )
+
+    schedule.updateSlots(updates)
+
+    assertThat(slotOne.mondayFlag).isTrue
+    assertThat(slotOne.tuesdayFlag).isFalse
+    assertThat(slotOne.wednesdayFlag).isTrue
+    assertThat(slotOne.thursdayFlag).isFalse
+    assertThat(slotOne.fridayFlag).isFalse
+    assertThat(slotOne.saturdayFlag).isFalse
+    assertThat(slotOne.sundayFlag).isFalse
+
+    assertThat(slotTwo.mondayFlag).isTrue
+    assertThat(slotTwo.tuesdayFlag).isTrue
+    assertThat(slotTwo.wednesdayFlag).isFalse
+    assertThat(slotTwo.thursdayFlag).isFalse
+    assertThat(slotTwo.fridayFlag).isFalse
+    assertThat(slotTwo.saturdayFlag).isFalse
+    assertThat(slotTwo.sundayFlag).isFalse
+  }
+
+  @Test
+  fun `slot removed on update`() {
+    val schedule =
+      activitySchedule(activity = activityEntity(startDate = yesterday, endDate = tomorrow), noSlots = true)
+
+    assertThat(schedule.slots()).isEmpty()
+
+    val slot = schedule.addSlot(
+      LocalTime.MIDNIGHT,
+      LocalTime.NOON,
+      setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY),
+    )
+
+    assertThat(schedule.slots()).contains(slot)
+
+    schedule.updateSlots(emptyMap())
+
+    assertThat(schedule.slots()).doesNotContain(slot)
+  }
+
+  @Test
+  fun `one slot removed and one slot updated`() {
+    val schedule =
+      activitySchedule(activity = activityEntity(startDate = yesterday, endDate = tomorrow), noSlots = true)
+
+    assertThat(schedule.slots()).isEmpty()
+
+    val slotOne = schedule.addSlot(LocalTime.MIDNIGHT, LocalTime.NOON, setOf(DayOfWeek.MONDAY))
+    val slotTwo = schedule.addSlot(LocalTime.NOON, LocalTime.NOON.plusMinutes(1), setOf(DayOfWeek.SATURDAY))
+
+    assertThat(schedule.slots()).contains(slotOne, slotTwo)
+
+    val updates = mapOf(Pair(slotOne.startTime, slotOne.endTime) to setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY))
+
+    schedule.updateSlots(updates)
+
+    assertThat(schedule.slots()).containsOnly(slotOne)
   }
 }

--- a/src/test/resources/test_data/seed-activity-update-slot.sql
+++ b/src/test/resources/test_data/seed-activity-update-slot.sql
@@ -1,0 +1,18 @@
+INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
+VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
+
+insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
+values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date);
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
+values (1, 1, '10:00:00', '11:00:00', true);
+


### PR DESCRIPTION
This is the first of two PR's.  It focuses on changing the way we update slots.

Previously it would clear all slots and re-add them again.

The changes in this PR means we only clear out slots we no longer care about and update those that we do care about.