### PR TITLE
SAA-868 updates to activity schedule slots is now also applied to instances.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -153,7 +153,14 @@ data class ActivitySchedule(
   fun isSuspendedOn(date: LocalDate) = suspensions.any { it.isSuspendedOn(date) }
 
   fun hasNoInstancesOnDate(day: LocalDate) =
-    this.instances.none { scheduledInstance -> scheduledInstance.sessionDate == day }
+    instances.none { instance -> instance.sessionDate == day }
+
+  fun hasNoInstancesOnDate(day: LocalDate, startEndTime: Pair<LocalTime, LocalTime>) =
+    instances.none { instance ->
+      instance.sessionDate == day &&
+        instance.startTime == startEndTime.first &&
+        instance.endTime == startEndTime.second
+    }
 
   fun addInstance(
     sessionDate: LocalDate,
@@ -297,10 +304,18 @@ data class ActivitySchedule(
     instances.removeAll(instances().filter { it.sessionDate.between(fromDate, toDate) })
   }
 
-  fun updateSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
+  fun updateSlotsAndRemoveRedundantInstances(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
     removeRedundantSlots(updates)
     updateMatchingSlots(updates)
     addNewSlots(updates)
+
+    val instancesToKeep = instances
+      .filter {
+        it.sessionDate >= LocalDate.now() &&
+          (it.attendances.isNotEmpty() || updates[it.startTime to it.endTime]?.contains(it.dayOfWeek()) == true)
+      }
+
+    instances.removeIf { instancesToKeep.contains(it).not() }
   }
 
   private fun removeRedundantSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
@@ -66,6 +66,8 @@ data class ScheduledInstance(
     attendances.forEach(Attendance::uncancel)
   }
 
+  fun dayOfWeek() = sessionDate.dayOfWeek
+
   fun toModel() = ModelScheduledInstance(
     activitySchedule = this.activitySchedule.toModelLite(),
     id = this.scheduledInstanceId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -673,10 +673,11 @@ class ActivityIntegrationTest : IntegrationTestBase() {
 
   @Test
   @Sql("classpath:test_data/seed-activity-update-slot.sql")
-  fun `updateActivity slot - is successful`() {
+  fun `updateActivity slot and instances - is successful`() {
     with(webTestClient.getActivityById(1).schedules.first()) {
       assertThat(slots).hasSize(1)
       assertThat(slots.first().daysOfWeek).containsExactly("Mon")
+      assertThat(instances).isEmpty()
     }
 
     val mondayTuesdaySlot = ActivityUpdateRequest(slots = listOf(Slot("AM", monday = true, tuesday = true)))
@@ -684,13 +685,15 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     with(webTestClient.updateActivity(pentonvillePrisonCode, 1, mondayTuesdaySlot).schedules.first()) {
       assertThat(slots).hasSize(1)
       assertThat(slots.first().daysOfWeek).containsExactly("Mon", "Tue")
+      assertThat(instances).hasSize(4)
     }
 
-    val thursdayFridaySlot = ActivityUpdateRequest(slots = listOf(Slot("AM", thursday = true, friday = true)))
+    val thursdayFridaySlot = ActivityUpdateRequest(slots = listOf(Slot("AM", friday = true)))
 
     with(webTestClient.updateActivity(pentonvillePrisonCode, 1, thursdayFridaySlot).schedules.first()) {
       assertThat(slots).hasSize(1)
-      assertThat(slots.first().daysOfWeek).containsExactly("Thu", "Fri")
+      assertThat(slots.first().daysOfWeek).containsExactly("Fri")
+      assertThat(instances).hasSize(2)
     }
 
     verify(eventsPublisher, times(2)).send(eventCaptor.capture())


### PR DESCRIPTION
I have run this locally against the UI.

If the slots are updated via the slots change/link screen upon editing an activity changes to slots and instances are propagated.
