### PR TITLE
Use a more consistent paginated endpoint for fetching all prisoners for activity candidates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/api/PrisonerSearchApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/api/PrisonerSearchApiClient.kt
@@ -14,7 +14,7 @@ class PrisonerSearchApiClient(private val prisonerSearchApiWebClient: WebClient)
 
   fun getAllPrisonersInPrison(prisonCode: String) = prisonerSearchApiWebClient
     .get()
-    .uri("/prisoner-search/prison/$prisonCode?size=2000")
+    .uri("/prison/$prisonCode/prisoners?size=2000")
     .header("Content-Type", "application/json")
     .retrieve()
     .bodyToMono(typeReference<PagedPrisoner>())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -14,7 +14,7 @@ class PrisonerSearchApiMockServer : WireMockServer(8111) {
 
   fun stubGetAllPrisonersInPrison(prisonCode: String) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/prisoner-search/prison/$prisonCode?size=2000"))
+      WireMock.get(WireMock.urlEqualTo("/prison/$prisonCode/prisoners?size=2000"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
* The previously used endpoint would have occasionally returned the list in a different order, which would have messed up the pagination on the frontend. This endpoint is more consistent