### PR TITLE
SAA-875 apply activity end date changes to the associated schedules, allocations and planned deallocations.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -107,8 +107,17 @@ data class ActivitySchedule(
         throw IllegalArgumentException("End date must be after the start date")
       } else {
         value
-      }
+      }.also { updateImpactedAllocations(it) }
     }
+
+  private fun updateImpactedAllocations(newEndDate: LocalDate?) {
+    newEndDate?.let {
+      allocations
+        .filterNot { allocation -> allocation.status(PrisonerStatus.ENDED) }
+        .filter { allocation -> allocation.endDate == null || allocation.endDate?.isAfter(newEndDate) == true }
+        .forEach { allocation -> allocation.endDate = newEndDate }
+    }
+  }
 
   fun instances() = instances.toList()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -51,13 +51,20 @@ data class Allocation(
 
   var endDate: LocalDate? = null
     set(value) {
-      field = if (value == null) {
-        plannedDeallocation = null
-        null
-      } else {
-        value
+      field = value.also { updatePlannedDeallocation(it) }
+    }
+
+  private fun updatePlannedDeallocation(newEndDate: LocalDate?) {
+    if (newEndDate == null) {
+      plannedDeallocation = null
+    } else {
+      plannedDeallocation?.apply {
+        if (plannedDate.isAfter(newEndDate)) {
+          plannedDate = newEndDate
+        }
       }
     }
+  }
 
   @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinColumn(name = "planned_deallocation_id", nullable = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -172,8 +172,8 @@ class ActivityService(
   }
 
   private fun failIfDescriptionDiffers(requestDescription: String, apiDescription: String?) {
-    if (requestDescription != apiDescription) {
-      throw IllegalArgumentException("The education level description '$requestDescription' does not match that of the NOMIS education level '$apiDescription'")
+    require(requestDescription == apiDescription) {
+      "The education level description '$requestDescription' does not match that of the NOMIS education level '$apiDescription'"
     }
   }
 
@@ -334,17 +334,17 @@ class ActivityService(
     request: ActivityUpdateRequest,
     activity: Activity,
   ) {
-    request.startDate?.apply {
-      activity.startDate = this
+    request.startDate?.let { newStartDate ->
+      activity.startDate = newStartDate
       activity.schedules().forEach {
-        if (it.startDate < this) {
+        if (it.startDate < newStartDate) {
           // start date has been moved later so remove all instances between the original start date and the day before the new start date
-          it.removeInstances(it.startDate, this.minusDays(1))
-        } else if (this < it.startDate) {
+          it.removeInstances(it.startDate, newStartDate.minusDays(1))
+        } else if (newStartDate < it.startDate) {
           // start date has been moved earlier so create new instances between the new start date and the day before the original start date
-          it.addInstances(activity, it.slots(), this, it.startDate.minusDays(1))
+          it.addInstances(activity, it.slots(), newStartDate, it.startDate.minusDays(1))
         }
-        it.startDate = this
+        it.startDate = newStartDate
       }
     }
   }
@@ -353,18 +353,17 @@ class ActivityService(
     request: ActivityUpdateRequest,
     activity: Activity,
   ) {
-    request.endDate?.apply {
-      activity.endDate = this
+    request.endDate?.let { newEndDate ->
+      activity.endDate = newEndDate
       activity.schedules().forEach {
-        if (it.endDate == null || it.endDate!! > this) {
+        if (it.endDate == null || it.endDate!! > newEndDate) {
           // end date has been set or moved earlier so remove all instances from the day after the new end date
-          (it.endDate)?.let { it1 -> it.removeInstances(this.plusDays(1), it1) }
-        } else if (it.endDate !== null && it.endDate!! < this) {
+          (it.endDate)?.let { it1 -> it.removeInstances(newEndDate.plusDays(1), it1) }
+        } else if (it.endDate !== null && it.endDate!! < newEndDate) {
           // end date has been moved later so add new instances from the day after the original end date up to the new end date
-          it.addInstances(activity, it.slots(), it.endDate!!.plusDays(1), this)
+          it.addInstances(activity, it.slots(), it.endDate!!.plusDays(1), newEndDate)
         }
-        it.endDate = this
-        it.allocations().forEach { it.endDate = this }
+        it.endDate = newEndDate
       }
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -925,4 +925,34 @@ class ActivityScheduleTest {
       assertThat(hasNoInstancesOnDate(tomorrow, slotOne.startTime to slotOne.endTime)).isTrue
     }
   }
+
+  @Test
+  fun `change to schedule end date is applied to allocations`() {
+    val schedule =
+      activitySchedule(activity = activityEntity(), noAllocations = true, startDate = yesterday, endDate = tomorrow)
+
+    schedule.allocatePrisoner(
+      prisonerNumber = "1111111".toPrisonerNumber(),
+      payBand = lowPayBand,
+      bookingId = 10001,
+      allocatedBy = "FRED",
+      endDate = tomorrow,
+    )
+
+    schedule.allocatePrisoner(
+      prisonerNumber = "2222222".toPrisonerNumber(),
+      payBand = lowPayBand,
+      bookingId = 20002,
+      allocatedBy = "BILL",
+      endDate = tomorrow,
+    )
+
+    assertThat(schedule.allocations()).hasSize(2)
+
+    schedule.allocations().forEach { allocation -> assertThat(allocation.endDate).isEqualTo(tomorrow) }
+
+    schedule.endDate = today
+
+    schedule.allocations().forEach { allocation -> assertThat(allocation.endDate).isEqualTo(today) }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -955,4 +955,38 @@ class ActivityScheduleTest {
 
     schedule.allocations().forEach { allocation -> assertThat(allocation.endDate).isEqualTo(today) }
   }
+
+  @Test
+  fun `change to schedule end date is is not applied to ended allocations`() {
+    val schedule =
+      activitySchedule(
+        activity = activityEntity(),
+        noAllocations = true,
+        startDate = yesterday,
+        endDate = tomorrow.plusDays(1),
+      )
+
+    val activeAllocation = schedule.allocatePrisoner(
+      prisonerNumber = "1111111".toPrisonerNumber(),
+      payBand = lowPayBand,
+      bookingId = 10001,
+      allocatedBy = "FRED",
+      endDate = tomorrow.plusDays(1),
+    )
+
+    val endedAllocation = schedule.allocatePrisoner(
+      prisonerNumber = "2222222".toPrisonerNumber(),
+      payBand = lowPayBand,
+      bookingId = 20002,
+      allocatedBy = "BILL",
+      endDate = tomorrow.plusDays(1),
+    ).deallocateNow()
+
+    assertThat(schedule.allocations()).hasSize(2)
+
+    schedule.endDate = tomorrow
+
+    assertThat(activeAllocation.endDate).isEqualTo(tomorrow)
+    assertThat(endedAllocation.endDate).isEqualTo(today)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -300,4 +300,36 @@ class AllocationTest {
       ),
     )
   }
+
+  @Test
+  fun `planned deallocation is updated when new end date is before planned`() {
+    val allocation = allocation().apply {
+      endDate = null
+    }.deallocateOn(tomorrow, DeallocationReason.TRANSFERRED, "by test")
+
+    assertThat(allocation.plannedDeallocation?.plannedDate).isEqualTo(tomorrow)
+
+    allocation.apply {
+      endDate = today
+    }
+
+    assertThat(allocation.endDate).isEqualTo(today)
+    assertThat(allocation.plannedDeallocation?.plannedDate).isEqualTo(today)
+  }
+
+  @Test
+  fun `planned deallocation is not updated when new end date is after planned date`() {
+    val allocation = allocation().apply {
+      endDate = null
+    }.deallocateOn(tomorrow, DeallocationReason.TRANSFERRED, "by test")
+
+    assertThat(allocation.plannedDeallocation?.plannedDate).isEqualTo(tomorrow)
+
+    allocation.apply {
+      endDate = tomorrow.plusDays(1)
+    }
+
+    assertThat(allocation.endDate).isEqualTo(tomorrow.plusDays(1))
+    assertThat(allocation.plannedDeallocation?.plannedDate).isEqualTo(tomorrow)
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -18,8 +18,10 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityState
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.read
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.schedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.educationCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand1
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testActivityPayRateBand2
@@ -713,6 +715,26 @@ class ActivityIntegrationTest : IntegrationTestBase() {
       assertThat(additionalInformation).isEqualTo(ScheduleCreatedInformation(1))
       assertThat(occurredAt).isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
       assertThat(description).isEqualTo("An activity schedule has been updated in the activities management service")
+    }
+  }
+
+  @Test
+  @Sql("classpath:test_data/seed-activity-update-end-date.sql")
+  fun `updateActivity end date - is successful`() {
+    with(webTestClient.getActivityById(1)) {
+      assertThat(endDate).isNull()
+      assertThat(schedules).hasSize(1)
+      assertThat(schedules.first().endDate).isNull()
+      assertThat(schedules.first().allocations).hasSize(1)
+      assertThat(schedules.first().allocations.first().endDate).isNull()
+    }
+
+    val newEndDate = ActivityUpdateRequest(endDate = TimeSource.tomorrow())
+
+    with(webTestClient.updateActivity(pentonvillePrisonCode, 1, newEndDate)) {
+      assertThat(endDate).isEqualTo(TimeSource.tomorrow())
+      assertThat(schedules.first().endDate).isEqualTo(TimeSource.tomorrow())
+      assertThat(schedules.first().allocations.first().endDate).isEqualTo(TimeSource.tomorrow())
     }
   }
 }

--- a/src/test/resources/test_data/seed-activity-update-end-date.sql
+++ b/src/test/resources/test_data/seed-activity-update-end-date.sql
@@ -1,0 +1,17 @@
+INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
+VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
+
+insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
+values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date, runs_on_bank_holiday)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date, null, true);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (1, 1, 'A11111A', 10001, 1, current_date, null, current_timestamp, 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');


### PR DESCRIPTION
I have tested these changes locally running the UI against them.