### PR TITLE
SAA-918: Use default location prefix format where no explicit pattern exists

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationController.kt
@@ -157,11 +157,6 @@ class LocationController(
         description = "Forbidden, requires an appropriate role",
         content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
       ),
-      ApiResponse(
-        responseCode = "404",
-        description = "Requested resource not found",
-        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
-      ),
     ],
   )
   fun getLocationPrefixForGroup(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/LocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/LocationService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
-import jakarta.persistence.EntityNotFoundException
 import org.apache.commons.text.WordUtils
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.stereotype.Service
@@ -20,11 +19,8 @@ class LocationService(
   fun getLocationPrefixFromGroup(agencyId: String, group: String): LocationPrefixDto {
     val agencyGroupKey = "${agencyId}_$group"
     val pattern = groupsProperties.getProperty(agencyGroupKey)
-      ?: throw EntityNotFoundException("No location prefix found for prison $agencyId and group name '$group'")
 
-    val locationPrefix = pattern
-      .replace(".", "")
-      .replace("+", "")
+    val locationPrefix = pattern?.replace(".", "")?.replace("+", "") ?: "$agencyId-${group.replace('_', '-')}-"
 
     return LocationPrefixDto(locationPrefix)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationControllerTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
-import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
@@ -131,22 +130,6 @@ class LocationControllerTest : ControllerTestBase<LocationController>() {
       .andReturn().response
 
     assertThat(response.contentAsString).isEqualTo(mapper.writeValueAsString(result))
-    verify(locationService).getLocationPrefixFromGroup(prisonCode, groupName)
-  }
-
-  @Test
-  fun `Location prefix - 404 response when prefix not found`() {
-    whenever(locationService.getLocationPrefixFromGroup(prisonCode, groupName))
-      .thenThrow(EntityNotFoundException("Not found"))
-
-    val response = mockMvc.get("/locations/prison/$prisonCode/location-prefix") {
-      param("groupName", groupName)
-    }
-      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
-      .andExpect { status { isNotFound() } }
-      .andReturn().response
-
-    assertThat(response.contentAsString).contains("Not found")
     verify(locationService).getLocationPrefixFromGroup(prisonCode, groupName)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/LocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/LocationServiceTest.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
-import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.kotlin.mock
@@ -127,18 +125,17 @@ class LocationServiceTest {
   }
 
   @Test
-  fun `should throw entity not found error when trying to load the location prefix`() {
-    whenever(groupsProperties.getProperty(anyString())).thenReturn(null)
-    Assertions.assertThrows(EntityNotFoundException::class.java) {
-      locationService.getLocationPrefixFromGroup("XXX", "1")
-    }
-  }
-
-  @Test
-  fun `should return location prefix for group`() {
+  fun `should return location prefix for prisons using pattern for group`() {
     whenever(groupsProperties.getProperty(anyString())).thenReturn("MDI-2-")
     val locationPrefixDto = locationService.getLocationPrefixFromGroup("MDI", "Houseblock 7")
     assertThat(locationPrefixDto.locationPrefix).isEqualTo("MDI-2-")
+  }
+
+  @Test
+  fun `should return location prefix for prisons using default for group`() {
+    whenever(groupsProperties.getProperty(anyString())).thenReturn(null)
+    val locationPrefixDto = locationService.getLocationPrefixFromGroup("LDI", "A_B")
+    assertThat(locationPrefixDto.locationPrefix).isEqualTo("LDI-A-B-")
   }
 
   @Test


### PR DESCRIPTION
Matches the existing Whereabouts approach used in https://github.com/ministryofjustice/whereabouts-api/blob/main/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/LocationGroupServiceSelector.kt and https://github.com/ministryofjustice/whereabouts-api/blob/main/src/main/java/uk/gov/justice/digital/hmpps/whereabouts/services/LocationGroupFromPrisonApiService.kt

Tested with Leeds and Gartree