### PR TITLE
SAA-875 small change to ensure when an acitivity end date is change we cannot end up with an allocation end before the start.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -51,6 +51,10 @@ data class Allocation(
 
   var endDate: LocalDate? = null
     set(value) {
+      require(value == null || value >= startDate) {
+        "Allocation end date for prisoner $prisonerNumber cannot be before allocation start date."
+      }
+
       field = value.also { updatePlannedDeallocation(it) }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -332,4 +332,16 @@ class AllocationTest {
     assertThat(allocation.endDate).isEqualTo(tomorrow.plusDays(1))
     assertThat(allocation.plannedDeallocation?.plannedDate).isEqualTo(tomorrow)
   }
+
+  @Test
+  fun `allocation end date cannot be before start date`() {
+    val allocation = allocation().copy(prisonerNumber = "123456")
+
+    allocation.endDate = allocation.startDate
+
+    assertThatThrownBy {
+      allocation.endDate = allocation.startDate.minusDays(1)
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Allocation end date for prisoner 123456 cannot be before allocation start date.")
+  }
 }


### PR DESCRIPTION
This resolves a gap in the update activity end date process whereby and allocation end date can end up before the allocation start date.