### PR TITLE
SAA-875 futher changes to ensure date boundaries are honoured when changing activity start and end dates.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -62,8 +62,6 @@ data class Activity(
 
   var startDate: LocalDate,
 
-  var endDate: LocalDate? = null,
-
   var riskLevel: String,
 
   var minimumIncentiveNomisCode: String,
@@ -78,6 +76,13 @@ data class Activity(
 
   var updatedBy: String? = null,
 ) {
+
+  var endDate: LocalDate? = null
+    set(value) {
+      require(value == null || value >= startDate) { "Activity end date cannot be before activity start date." }
+
+      field = value
+    }
 
   @OneToMany(mappedBy = "activity", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @Fetch(FetchMode.SUBSELECT)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -64,14 +64,9 @@ data class ActivitySchedule(
 
   var instancesLastUpdatedTime: LocalDateTime? = null,
 ) {
-  init {
-    failIfInvalidCapacity()
-  }
 
-  private fun failIfInvalidCapacity() {
-    if (capacity < 1) {
-      throw IllegalArgumentException("The schedule capacity must be greater than zero.")
-    }
+  init {
+    require(capacity > 0) { "The schedule capacity must be greater than zero." }
   }
 
   @OneToMany(
@@ -103,11 +98,11 @@ data class ActivitySchedule(
 
   var endDate: LocalDate? = null
     set(value) {
-      field = if (value != null && value.isAfter(startDate).not()) {
-        throw IllegalArgumentException("End date must be after the start date")
-      } else {
-        value
-      }.also { updateImpactedAllocations(it) }
+      require(value == null || value >= startDate) {
+        "Activity schedule end date cannot be before activity schedule start date."
+      }
+
+      field = value.also { updateImpactedAllocations(it) }
     }
 
   private fun updateImpactedAllocations(newEndDate: LocalDate?) {
@@ -115,7 +110,9 @@ data class ActivitySchedule(
       allocations
         .filterNot { allocation -> allocation.status(PrisonerStatus.ENDED) }
         .filter { allocation -> allocation.endDate == null || allocation.endDate?.isAfter(newEndDate) == true }
-        .forEach { allocation -> allocation.endDate = newEndDate }
+        .forEach { allocation ->
+          allocation.endDate = newEndDate
+        }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -421,18 +421,17 @@ class ActivityScheduleTest {
   }
 
   @Test
-  fun `end date must be after the start date`() {
+  fun `end date must be on or after the start date`() {
     val schedule = activityEntity().schedules().first().apply { endDate = null }
 
     assertThat(schedule.endDate).isNull()
 
     schedule.endDate = schedule.startDate.plusDays(1)
 
-    assertThatThrownBy { schedule.endDate = schedule.startDate }.isInstanceOf(IllegalArgumentException::class.java)
     assertThatThrownBy {
       schedule.endDate = schedule.startDate.minusDays(1)
     }.isInstanceOf(IllegalArgumentException::class.java)
-      .hasMessage("End date must be after the start date")
+      .hasMessage("Activity schedule end date cannot be before activity schedule start date.")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
@@ -24,9 +24,9 @@ class ActivityTest {
   private val yesterday = today.minusDays(1)
   private val tomorrow = today.plusDays(1)
 
-  private val activityWithNoEndDate = activityEntity().copy(startDate = today, endDate = null)
+  private val activityWithNoEndDate = activityEntity(startDate = today, endDate = null)
 
-  private val activityWithEndDate = activityWithNoEndDate.copy(endDate = tomorrow)
+  private val activityWithEndDate = activityWithNoEndDate.copy().apply { endDate = tomorrow }
 
   @Test
   fun `check activity active status that starts today with open end date`() {
@@ -183,7 +183,7 @@ class ActivityTest {
   @Test
   fun `cannot add schedule when start date is not before end date of the activity`() {
     val activity =
-      activityEntity(noSchedules = true).copy(startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1))
+      activityEntity(noSchedules = true).copy(startDate = LocalDate.now()).apply { endDate = LocalDate.now().plusDays(1) }
     assertThat(activity.schedules()).isEmpty()
 
     assertThatThrownBy {
@@ -207,7 +207,7 @@ class ActivityTest {
   @Test
   fun `cannot add schedule when end date is after the end date of the activity`() {
     val activity =
-      activityEntity(noSchedules = true).copy(startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1))
+      activityEntity(noSchedules = true).copy(startDate = LocalDate.now()).apply { endDate = LocalDate.now().plusDays(1) }
     assertThat(activity.schedules()).isEmpty()
 
     assertThatThrownBy {
@@ -514,5 +514,19 @@ class ActivityTest {
     with(activityWithEndDate) {
       assertThat(isUnemployment()).isFalse
     }
+  }
+
+  @Test
+  fun `end date must be on or after the start date`() {
+    val activity = activityEntity(startDate = today, endDate = tomorrow)
+
+    activity.endDate = null
+    activity.endDate = today
+
+    assertThatThrownBy {
+      activity.endDate = yesterday
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Activity end date cannot be before activity start date.")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -334,10 +334,11 @@ class AllocationTest {
   }
 
   @Test
-  fun `allocation end date cannot be before start date`() {
+  fun `allocation end date must be on or after the start date`() {
     val allocation = allocation().copy(prisonerNumber = "123456")
 
     allocation.endDate = allocation.startDate
+    allocation.endDate = null
 
     assertThatThrownBy {
       allocation.endDate = allocation.startDate.minusDays(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -67,11 +67,11 @@ internal fun activityEntity(
     minimumIncentiveNomisCode = "BAS",
     minimumIncentiveLevel = "Basic",
     startDate = startDate,
-    endDate = endDate,
     createdTime = timestamp,
     createdBy = "test",
     inCell = inCell,
   ).apply {
+    this.endDate = endDate
     if (!noEligibilityRules) {
       this.addEligibilityRule(eligibilityRuleOver21)
     }


### PR DESCRIPTION
The following (new) checks have been added:

- You cannot change the activity start date to be after its end date.
- You cannot change the activity start date if it has already has started i.e. today or earlier.
- You cannot change the activity start date to the today's date, it must be a future date.
- You cannot change the activity start date to be later than that of any allocations.
