### PR TITLE
SAA-877 archived activities should not be updateable this change prevents that.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -258,6 +258,10 @@ class ActivityService(
     val activity = activityRepository.findOrThrowNotFound(activityId)
     val now = LocalDateTime.now()
 
+    require(activity.state(ActivityState.ARCHIVED).not()) {
+      "Activity cannot be updated because it is now archived."
+    }
+
     applyCategoryUpdate(request, activity)
     applyTierUpdate(request, activity)
     applySummaryUpdate(prisonCode, request, activity)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
@@ -726,4 +726,16 @@ class ActivityServiceTest {
     }.isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Activity start date cannot be changed. Activity already started.")
   }
+
+  @Test
+  fun `updateActivity - fails if activity has already ended (archived)`() {
+    val activity = activityEntity(startDate = TimeSource.yesterday().minusDays(1), endDate = TimeSource.yesterday())
+
+    whenever(activityRepository.findById(1)).thenReturn(Optional.of(activity))
+
+    assertThatThrownBy {
+      service.updateActivity(moorlandPrisonCode, 1, ActivityUpdateRequest(endDate = TimeSource.tomorrow()), "TEST")
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Activity cannot be updated because it is now archived.")
+  }
 }


### PR DESCRIPTION
The API was not guarding the updating of archived activities.

At time of writing the frontend still doesn't.  You can go directly to edit an (archived) activity bypassing the journey to get there.

