### PR TITLE
SAA-909: Return appointment name in API responses

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentDetails
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentCategorySummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentLocationSummary
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentName
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toSummary
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -140,6 +141,7 @@ data class Appointment(
       appointmentId,
       appointmentType,
       prisonCode,
+      referenceCodeMap[categoryCode].toAppointmentName(categoryCode, appointmentDescription),
       prisoners.toSummary(),
       referenceCodeMap[categoryCode].toAppointmentCategorySummary(categoryCode),
       appointmentDescription,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrence.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointme
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentOccurrenceSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentCategorySummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentLocationSummary
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentName
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toSummary
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -149,6 +150,7 @@ data class AppointmentOccurrence(
       appointment.appointmentType,
       sequenceNumber,
       prisonCode,
+      referenceCodeMap[appointment.categoryCode].toAppointmentName(appointment.categoryCode, appointment.appointmentDescription),
       allocations().map { prisonerMap[it.prisonerNumber].toSummary(prisonCode, it.prisonerNumber, it.bookingId) },
       referenceCodeMap[appointment.categoryCode].toAppointmentCategorySummary(appointment.categoryCode),
       appointment.appointmentDescription,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceSearch.kt
@@ -12,6 +12,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.AppointmentOccurrenceSearchResult
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentCategorySummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentLocationSummary
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentName
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -69,6 +70,7 @@ data class AppointmentOccurrenceSearch(
     appointmentOccurrenceId,
     appointmentType,
     prisonCode,
+    referenceCodeMap[categoryCode].toAppointmentName(categoryCode, appointmentDescription),
     allocations = allocations.toModel(),
     referenceCodeMap[categoryCode].toAppointmentCategorySummary(categoryCode),
     appointmentDescription,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointment.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.BulkAppoi
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.BulkAppointmentSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentCategorySummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentLocationSummary
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentName
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toSummary
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -91,6 +92,7 @@ data class BulkAppointment(
     return BulkAppointmentDetails(
       bulkAppointmentId,
       prisonCode,
+      referenceCodeMap[categoryCode].toAppointmentName(categoryCode, appointmentDescription),
       referenceCodeMap[categoryCode].toAppointmentCategorySummary(categoryCode),
       appointmentDescription,
       if (inCell) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentDetails.kt
@@ -40,6 +40,14 @@ data class AppointmentDetails(
   @Schema(
     description =
     """
+    The appointment name
+    """,
+  )
+  val appointmentName: String,
+
+  @Schema(
+    description =
+    """
     Summary of the prisoner or prisoners allocated to the first future occurrence (or most recent past occurrence if all
     occurrences are in the past) of this appointment. Prisoners are allocated at the occurrence level to allow for per
     occurrence allocation changes. The occurrence summary does not contain any information on the allocated prisoners

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentOccurrenceDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentOccurrenceDetails.kt
@@ -58,6 +58,14 @@ data class AppointmentOccurrenceDetails(
   @Schema(
     description =
     """
+    The appointment name
+    """,
+  )
+  val appointmentName: String,
+
+  @Schema(
+    description =
+    """
     Summary of the prisoner or prisoners allocated to this appointment occurrence. Prisoners are allocated at the
     occurrence level to allow for per occurrence allocation changes.
     """,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/BulkAppointmentDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/BulkAppointmentDetails.kt
@@ -29,6 +29,14 @@ data class BulkAppointmentDetails(
   @Schema(
     description =
     """
+    The appointment name
+    """,
+  )
+  val appointmentName: String,
+
+  @Schema(
+    description =
+    """
     The summary of the category used to create the set of appointments in bulk
     """,
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/AppointmentOccurrenceSearchResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/AppointmentOccurrenceSearchResult.kt
@@ -49,6 +49,14 @@ data class AppointmentOccurrenceSearchResult(
   @Schema(
     description =
     """
+    The appointment name
+    """,
+  )
+  val appointmentName: String,
+
+  @Schema(
+    description =
+    """
     The prisoner or prisoners attending this appointment occurrence. Appointments of type INDIVIDUAL will have one
     prisoner allocated to each appointment occurrence. Appointments of type GROUP can have more than one prisoner
     allocated to each appointment occurrence

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/PrisonApiTransformations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/PrisonApiTransformations.kt
@@ -272,6 +272,11 @@ fun PrisonApiReferenceCode?.toAppointmentCategorySummary(code: String) =
     ModelAppointmentCategorySummary(this.code, this.description)
   }
 
+fun PrisonApiReferenceCode?.toAppointmentName(code: String, description: String?) =
+  this.toAppointmentCategorySummary(code).description.let { category ->
+    if (!description.isNullOrEmpty()) "$description ($category)" else category
+  }
+
 fun List<PrisonApiReferenceCode>.toAppointmentCategorySummary() = map { it.toAppointmentCategorySummary(it.code) }
 
 fun PrisonApiLocation?.toAppointmentLocationSummary(locationId: Long, prisonCode: String) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -148,8 +148,11 @@ fun transformAppointmentInstanceToScheduledEvents(
     cancelled = it.isCancelled,
     suspended = false,
     categoryCode = it.categoryCode,
-    categoryDescription = referenceCodesForAppointmentsMap[it.categoryCode]?.description ?: "Unknown",
-    summary = it.appointmentDescription ?: referenceCodesForAppointmentsMap[it.categoryCode]?.description,
+    categoryDescription = referenceCodesForAppointmentsMap[it.categoryCode].toAppointmentCategorySummary(it.categoryCode).description,
+    summary = referenceCodesForAppointmentsMap[it.categoryCode].toAppointmentName(
+      it.categoryCode,
+      it.appointmentDescription,
+    ),
     comments = it.comment,
     prisonerNumber = it.prisonerNumber,
     inCell = it.inCell,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceTest.kt
@@ -458,6 +458,64 @@ class AppointmentOccurrenceTest {
   }
 
   @Test
+  fun `entity to details mapping includes appointment description in name`() {
+    val appointment = appointmentEntity(appointmentDescription = "appointment name")
+    val entity = appointment.occurrences().first()
+    val referenceCodeMap = mapOf(
+      appointment.categoryCode to appointmentCategoryReferenceCode(
+        appointment.categoryCode,
+        "test category",
+      ),
+    )
+    val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
+    val userMap = mapOf(
+      appointment.createdBy to userDetail(1, "CREATE.USER", "CREATE", "USER"),
+    )
+    val prisonerMap = mapOf(
+      "A1234BC" to PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+        bookingId = 456,
+        firstName = "TEST",
+        lastName = "PRISONER",
+        prisonId = "TPR",
+        cellLocation = "1-2-3",
+      ),
+    )
+    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+      assertThat(appointmentName).isEqualTo("appointment name (test category)")
+    }
+  }
+
+  @Test
+  fun `entity to details mapping does not include appointment description in name`() {
+    val appointment = appointmentEntity(appointmentDescription = null)
+    val entity = appointment.occurrences().first()
+    val referenceCodeMap = mapOf(
+      appointment.categoryCode to appointmentCategoryReferenceCode(
+        appointment.categoryCode,
+        "test category",
+      ),
+    )
+    val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
+    val userMap = mapOf(
+      appointment.createdBy to userDetail(1, "CREATE.USER", "CREATE", "USER"),
+    )
+    val prisonerMap = mapOf(
+      "A1234BC" to PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+        bookingId = 456,
+        firstName = "TEST",
+        lastName = "PRISONER",
+        prisonId = "TPR",
+        cellLocation = "1-2-3",
+      ),
+    )
+    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+      assertThat(appointmentName).isEqualTo("test category")
+    }
+  }
+
+  @Test
   fun `cannot allocate multiple prisoners to individual appointment`() {
     assertThrows<IllegalArgumentException>(
       "Cannot allocate multiple prisoners to an individual appointment",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
@@ -137,10 +137,10 @@ class AppointmentTest {
     )
     assertThat(entity.toDetails(prisoners, referenceCodeMap, locationMap, userMap)).isEqualTo(
       appointmentDetails(
-        "Appointment description",
-        entity.created,
-        entity.updated,
-        UserSummary(2, "UPDATE.USER", "UPDATE", "USER"),
+        appointmentDescription = "Appointment description",
+        created = entity.created,
+        updated = entity.updated,
+        updatedBy = UserSummary(2, "UPDATE.USER", "UPDATE", "USER"),
       ),
     )
   }
@@ -295,6 +295,62 @@ class AppointmentTest {
     )
     with(entity.toDetails(prisoners, referenceCodeMap, locationMap, userMap)) {
       assertThat(repeat).isEqualTo(AppointmentRepeat(AppointmentRepeatPeriodModel.FORTNIGHTLY, 2))
+    }
+  }
+
+  @Test
+  fun `entity to details mapping includes appointment description in name`() {
+    val entity = appointmentEntity(appointmentDescription = "appointment name")
+    val referenceCodeMap = mapOf(
+      entity.categoryCode to appointmentCategoryReferenceCode(
+        entity.categoryCode,
+        "test category",
+      ),
+    )
+    val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
+    val userMap = mapOf(
+      entity.createdBy to userDetail(1, "CREATE.USER", "CREATE", "USER"),
+    )
+    val prisoners = listOf(
+      PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+        bookingId = 456,
+        firstName = "TEST",
+        lastName = "PRISONER",
+        prisonId = "TPR",
+        cellLocation = "1-2-3",
+      ),
+    )
+    with(entity.toDetails(prisoners, referenceCodeMap, locationMap, userMap)) {
+      assertThat(appointmentName).isEqualTo("appointment name (test category)")
+    }
+  }
+
+  @Test
+  fun `entity to details mapping does not include appointment description in name`() {
+    val entity = appointmentEntity(appointmentDescription = null)
+    val referenceCodeMap = mapOf(
+      entity.categoryCode to appointmentCategoryReferenceCode(
+        entity.categoryCode,
+        "test category",
+      ),
+    )
+    val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
+    val userMap = mapOf(
+      entity.createdBy to userDetail(1, "CREATE.USER", "CREATE", "USER"),
+    )
+    val prisoners = listOf(
+      PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = "A1234BC",
+        bookingId = 456,
+        firstName = "TEST",
+        lastName = "PRISONER",
+        prisonId = "TPR",
+        cellLocation = "1-2-3",
+      ),
+    )
+    with(entity.toDetails(prisoners, referenceCodeMap, locationMap, userMap)) {
+      assertThat(appointmentName).isEqualTo("test category")
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
@@ -119,7 +119,6 @@ class AppointmentTest {
   @Test
   fun `entity to details mapping`() {
     val entity = appointmentEntity()
-    val occurrenceEntity = entity.occurrences().first()
     val referenceCodeMap = mapOf(entity.categoryCode to appointmentCategoryReferenceCode(entity.categoryCode))
     val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
     val userMap = mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointmentTest.kt
@@ -90,6 +90,48 @@ class BulkAppointmentTest {
   }
 
   @Test
+  fun `entity to details mapping includes appointment description in name`() {
+    val entity = bulkAppointmentEntity(appointmentDescription = "appointment name")
+    val referenceCodeMap = mapOf(
+      entity.categoryCode to appointmentCategoryReferenceCode(
+        entity.categoryCode,
+        "test category",
+      ),
+    )
+    val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
+    val userMap = mapOf(
+      "CREATE.USER" to userDetail(1, "CREATE.USER", "CREATE", "USER"),
+      "UPDATE.USER" to userDetail(2, "UPDATE.USER", "UPDATE", "USER"),
+    )
+    val prisonerMap = getPrisonerMap()
+
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
+      assertThat(appointmentName).isEqualTo("appointment name (test category)")
+    }
+  }
+
+  @Test
+  fun `entity to details mapping does not include appointment description in name`() {
+    val entity = bulkAppointmentEntity()
+    val referenceCodeMap = mapOf(
+      entity.categoryCode to appointmentCategoryReferenceCode(
+        entity.categoryCode,
+        "test category",
+      ),
+    )
+    val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
+    val userMap = mapOf(
+      "CREATE.USER" to userDetail(1, "CREATE.USER", "CREATE", "USER"),
+      "UPDATE.USER" to userDetail(2, "UPDATE.USER", "UPDATE", "USER"),
+    )
+    val prisonerMap = getPrisonerMap()
+
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
+      assertThat(appointmentName).isEqualTo("test category")
+    }
+  }
+
+  @Test
   fun `entity to details mapping reference code not found`() {
     val entity = bulkAppointmentEntity()
     val referenceCodeMap = emptyMap<String, ReferenceCode>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
@@ -166,6 +166,7 @@ internal fun appointmentOccurrenceSearchEntity(
 internal fun bulkAppointmentEntity(
   bulkAppointmentId: Long = 1,
   inCell: Boolean = false,
+  appointmentDescription: String? = null,
   startDate: LocalDate = LocalDate.now().plusDays(1),
   startTime: LocalTime = LocalTime.of(9, 0),
   endTime: LocalTime = LocalTime.of(10, 30),
@@ -175,7 +176,7 @@ internal fun bulkAppointmentEntity(
     bulkAppointmentId = bulkAppointmentId,
     prisonCode = "TPR",
     categoryCode = "TEST",
-    appointmentDescription = null,
+    appointmentDescription = appointmentDescription,
     internalLocationId = if (inCell) null else 123,
     inCell = inCell,
     startDate = startDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
@@ -100,6 +100,7 @@ internal fun appointmentInstanceEntity(
   createdBy: String = "CREATE.USER",
   updatedBy: String? = "UPDATE.USER",
   appointmentDescription: String? = null,
+  categoryCode: String = "TEST",
 ) =
   AppointmentInstance(
     appointmentInstanceId = 3,
@@ -110,7 +111,7 @@ internal fun appointmentInstanceEntity(
     prisonCode = "TPR",
     prisonerNumber = prisonerNumber,
     bookingId = bookingId,
-    categoryCode = "TEST",
+    categoryCode = categoryCode,
     appointmentDescription = appointmentDescription,
     internalLocationId = if (inCell) null else internalLocationId,
     inCell = inCell,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
@@ -187,6 +187,7 @@ fun appointmentMigrateRequest(
 
 fun appointmentDetails(
   appointmentDescription: String? = null,
+  category: AppointmentCategorySummary = appointmentCategorySummary(),
   created: LocalDateTime = LocalDateTime.now(),
   updated: LocalDateTime? = LocalDateTime.now(),
   updatedBy: UserSummary? = UserSummary(2, "UPDATE.USER", "UPDATE", "USER"),
@@ -194,13 +195,11 @@ fun appointmentDetails(
   1,
   AppointmentType.INDIVIDUAL,
   "TPR",
-  appointmentCategorySummary().description.let { category ->
-    if (!appointmentDescription.isNullOrEmpty()) "$appointmentDescription ($category)" else category
-  },
+  if (!appointmentDescription.isNullOrEmpty()) "$appointmentDescription (${category.description})" else category.description,
   prisoners = listOf(
     PrisonerSummary("A1234BC", 456, "TEST", "PRISONER", "TPR", "1-2-3"),
   ),
-  appointmentCategorySummary(),
+  category = category,
   appointmentDescription,
   AppointmentLocationSummary(123, "TPR", "Test Appointment Location User Description"),
   false,
@@ -305,6 +304,7 @@ fun bulkAppointmentDetails(
 ) = BulkAppointmentDetails(
   bulkAppointmentId,
   "TPR",
+  appointmentName = if (!appointmentDescription.isNullOrEmpty()) "$appointmentDescription (${category.description})" else category.description,
   category,
   appointmentDescription,
   AppointmentLocationSummary(123, "TPR", "Test Appointment Location User Description"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
@@ -194,6 +194,9 @@ fun appointmentDetails(
   1,
   AppointmentType.INDIVIDUAL,
   "TPR",
+  appointmentCategorySummary().description.let { category ->
+    if (!appointmentDescription.isNullOrEmpty()) "$appointmentDescription ($category)" else category
+  },
   prisoners = listOf(
     PrisonerSummary("A1234BC", 456, "TEST", "PRISONER", "TPR", "1-2-3"),
   ),
@@ -252,6 +255,7 @@ fun appointmentOccurrenceDetails(
   AppointmentType.INDIVIDUAL,
   sequenceNumber,
   "TPR",
+  if (!appointmentDescription.isNullOrEmpty()) "$appointmentDescription (${category.description})" else category.description,
   prisoners,
   category,
   appointmentDescription,
@@ -276,6 +280,7 @@ fun appointmentOccurrenceSearchResultModel() = AppointmentOccurrenceSearchResult
   2,
   AppointmentType.INDIVIDUAL,
   "TPR",
+  appointmentCategorySummary().description,
   listOf(appointmentOccurrenceAllocationModel()),
   appointmentCategorySummary(),
   null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentDetailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentDetailsIntegrationTest.kt
@@ -57,6 +57,7 @@ class AppointmentDetailsIntegrationTest : IntegrationTestBase() {
         1,
         AppointmentType.INDIVIDUAL,
         "TPR",
+        "Appointment description (Appointment Category 1)",
         prisoners = listOf(
           PrisonerSummary("A1234BC", 456, "Tim", "Harrison", "TPR", "1-2-3"),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentOccurrenceDetailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentOccurrenceDetailsIntegrationTest.kt
@@ -80,6 +80,7 @@ class AppointmentOccurrenceDetailsIntegrationTest : IntegrationTestBase() {
         AppointmentType.INDIVIDUAL,
         1,
         "TPR",
+        "Appointment description (Appointment Category 1)",
         prisoners = listOf(
           PrisonerSummary("A1234BC", 456, "Tim", "Harrison", "TPR", "1-2-3"),
         ),
@@ -128,6 +129,7 @@ class AppointmentOccurrenceDetailsIntegrationTest : IntegrationTestBase() {
         AppointmentType.INDIVIDUAL,
         1,
         "TPR",
+        "Appointment description (Appointment Category 1)",
         prisoners = listOf(
           PrisonerSummary("A1234BC", 456, "Tim", "Harrison", "TPR", "1-2-3"),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/BulkAppointmentDetailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/BulkAppointmentDetailsIntegrationTest.kt
@@ -84,6 +84,7 @@ class BulkAppointmentDetailsIntegrationTest : IntegrationTestBase() {
       BulkAppointmentDetails(
         6,
         "TPR",
+        if (!appointmentDescription.isNullOrEmpty()) "$appointmentDescription (${category.description})" else category.description,
         category,
         appointmentDescription,
         AppointmentLocationSummary(123, "TPR", "Test Appointment Location User Description"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
@@ -115,7 +115,7 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
           assertThat(it.internalLocationDescription).isEqualTo("Unknown")
           assertThat(it.categoryCode).isEqualTo("AC1")
           assertThat(it.categoryDescription).isEqualTo("Appointment Category 1")
-          assertThat(it.summary).isEqualTo("Appointment description")
+          assertThat(it.summary).isEqualTo("Appointment description (Appointment Category 1)")
           assertThat(it.comments).isEqualTo("Appointment occurrence level comment")
           assertThat(it.date).isEqualTo(LocalDate.of(2022, 10, 1))
           assertThat(it.startTime).isEqualTo(LocalTime.of(9, 0))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentDetailsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentDetailsServiceTest.kt
@@ -72,6 +72,7 @@ class AppointmentDetailsServiceTest {
         entity.appointmentId,
         AppointmentType.INDIVIDUAL,
         entity.prisonCode,
+        "Appointment description (Test Category)",
         prisoners = listOf(
           PrisonerSummary("A1234BC", 456, "TEST", "PRISONER", "TPR", "1-2-3"),
         ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -263,12 +263,45 @@ class TransformFunctionsTest {
     }
 
     @Test
+    fun `appointment instance with empty appointmentDescription to scheduled event`() {
+      val entity = appointmentInstanceEntity(appointmentDescription = "")
+      val scheduledEvents = transform(entity)
+
+      with(scheduledEvents.first()) {
+        assertThat(summary).isEqualTo("Test Category")
+      }
+    }
+
+    @Test
+    fun `appointment instance with unknown appointment category to scheduled event`() {
+      val entity = appointmentInstanceEntity(categoryCode = "UNKNOWN")
+      val scheduledEvents = transform(entity)
+
+      with(scheduledEvents.first()) {
+        assertThat(summary).isEqualTo("UNKNOWN")
+      }
+    }
+
+    @Test
     fun `appointment instance with appointmentDescription to scheduled event`() {
       val entity = appointmentInstanceEntity(appointmentDescription = "Description of appointment")
       val scheduledEvents = transform(entity)
 
       with(scheduledEvents.first()) {
-        assertThat(summary).isEqualTo("Description of appointment")
+        assertThat(summary).isEqualTo("Description of appointment (Test Category)")
+      }
+    }
+
+    @Test
+    fun `appointment instance with appointmentDescription and unknown category code to scheduled event`() {
+      val entity = appointmentInstanceEntity(
+        appointmentDescription = "Description of appointment",
+        categoryCode = "UNKNOWN",
+      )
+      val scheduledEvents = transform(entity)
+
+      with(scheduledEvents.first()) {
+        assertThat(summary).isEqualTo("Description of appointment (UNKNOWN)")
       }
     }
 
@@ -385,6 +418,33 @@ class TransformFunctionsTest {
     assertThat(listOf(appointmentCategoryReferenceCode("MEDO", "Medical - Doctor")).toAppointmentCategorySummary()).isEqualTo(
       listOf(AppointmentCategorySummary("MEDO", "Medical - Doctor")),
     )
+  }
+
+  @Test
+  fun `reference code to appointment name mapping`() {
+    assertThat(
+      appointmentCategoryReferenceCode("MEDO", "Medical - Doctor")
+        .toAppointmentName("MEDO", "John's doctor appointment"),
+    ).isEqualTo("John's doctor appointment (Medical - Doctor)")
+  }
+
+  @Test
+  fun `reference code to appointment name mapping for null reference code`() {
+    assertThat(null.toAppointmentName("MEDO", "John's doctor appointment"))
+      .isEqualTo("John's doctor appointment (UNKNOWN)")
+  }
+
+  @Test
+  fun `reference code to appointment name mapping with no description`() {
+    assertThat(
+      appointmentCategoryReferenceCode("MEDO", "Medical - Doctor")
+        .toAppointmentName("MEDO", null),
+    ).isEqualTo("Medical - Doctor")
+  }
+
+  @Test
+  fun `reference code to appointment name mapping for null reference code and no description`() {
+    assertThat(null.toAppointmentName("MEDO", null)).isEqualTo("UNKNOWN")
   }
 
   @Test


### PR DESCRIPTION
## Overview

Updates endpoints returning appointment details to include appointment name.