### PR TITLE
SAA-954 allocation start date must be in future on creation and updates.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -90,6 +90,8 @@ class ActivityScheduleService(
   fun allocatePrisoner(scheduleId: Long, request: PrisonerAllocationRequest, allocatedBy: String) {
     log.info("Allocating prisoner ${request.prisonerNumber}.")
 
+    require(request.startDate!! > LocalDate.now()) { "Allocation start date must be in the future" }
+
     val schedule = repository.findOrThrowNotFound(scheduleId)
 
     val prisonPayBands = prisonPayBandRepository.findByPrisonCode(schedule.activity.prisonCode)
@@ -111,7 +113,7 @@ class ActivityScheduleService(
       bookingId = prisonerDetails.bookingId
         ?: throw IllegalStateException("Active prisoner $prisonerNumber does not have a booking id."),
       payBand = payBand,
-      startDate = request.startDate!!,
+      startDate = request.startDate,
       endDate = request.endDate,
       allocatedBy = allocatedBy,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -130,7 +130,7 @@ class ActivityService(
       description = request.description,
       inCell = request.inCell,
       onWing = request.onWing,
-      startDate = request.startDate!!,
+      startDate = request.startDate,
       riskLevel = request.riskLevel!!,
       minimumIncentiveNomisCode = request.minimumIncentiveNomisCode!!,
       minimumIncentiveLevel = request.minimumIncentiveLevel!!,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
@@ -53,9 +53,12 @@ class AllocationsService(private val allocationRepository: AllocationRepository,
     request.startDate?.let { newStartDate ->
       val (start, end) = allocation.activitySchedule.activity.startDate to allocation.activitySchedule.activity.endDate
 
+      require(request.startDate > LocalDate.now()) { "Allocation start date must be in the future" }
+
       require(allocation.startDate > LocalDate.now()) {
         "Start date cannot be updated once allocation has started"
       }
+
       require(newStartDate.between(start, end)) {
         "Allocation start date cannot be before the activity start date or after the activity end date."
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -251,7 +251,10 @@ internal fun activitySchedule(
     }
   }
 
-internal fun allocation() = activitySchedule(activityEntity()).allocations().first()
+internal fun allocation(startDate: LocalDate? = null) =
+  startDate
+    ?.let { activitySchedule(activityEntity(startDate = it)).allocations().first() }
+    ?: activitySchedule(activityEntity()).allocations().first()
 
 private fun activityWaiting(
   activity: Activity,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
@@ -245,4 +245,26 @@ class ActivityScheduleServiceTest {
     }.isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Allocation end date cannot be before allocation start date")
   }
+
+  @Test
+  fun `allocate throws exception for start date not in future`() {
+    var schedule = activitySchedule(activityEntity())
+
+    whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
+    whenever(prisonPayBandRepository.findByPrisonCode("123")).thenReturn(prisonPayBandsLowMediumHigh("123", 10))
+    whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = false)).doReturn(Mono.just(prisoner))
+
+    assertThatThrownBy {
+      service.allocatePrisoner(
+        schedule.activityScheduleId,
+        PrisonerAllocationRequest(
+          "123456",
+          11,
+          TimeSource.today(),
+        ),
+        "by test",
+      )
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Allocation start date must be in the future")
+  }
 }


### PR DESCRIPTION
Changes to ensure allocation start date changes are always in the future.

We cannot create/update an allocations start date to today's date.