### PR TITLE
SAA-954 changes to prevent updating allocation start date to be after allocation end date.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
@@ -63,6 +63,10 @@ class AllocationsService(private val allocationRepository: AllocationRepository,
         "Allocation start date cannot be before the activity start date or after the activity end date."
       }
 
+      require(allocation.endDate == null || newStartDate <= allocation.endDate) {
+        "Allocation start date cannot be after allocation end date"
+      }
+
       allocation.startDate = newStartDate
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationServiceTest.kt
@@ -278,4 +278,19 @@ class AllocationServiceTest {
       .isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Allocation start date must be in the future")
   }
+
+  @Test
+  fun `updateAllocation - fails if allocation start date after end date`() {
+    val allocation = allocation(startDate = TimeSource.tomorrow()).apply { endDate = TimeSource.tomorrow() }
+    val allocationId = allocation.allocationId
+    val prisonCode = allocation.activitySchedule.activity.prisonCode
+
+    whenever(allocationRepository.findByAllocationIdAndPrisonCode(allocationId, prisonCode)).thenReturn(allocation)
+
+    assertThatThrownBy {
+      service.updateAllocation(allocationId, AllocationUpdateRequest(startDate = allocation.endDate?.plusDays(1)), prisonCode, "user")
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Allocation start date cannot be after allocation end date")
+  }
 }


### PR DESCRIPTION
Found this issue whilst API testing.