### PR TITLE
SAA-979 changes to add/remove instances when the run on bank holiday flag is updated to true/false.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -214,6 +214,9 @@ class ActivityService(
     }
   }
 
+  /*
+   * Note: we add instances even if the activity hasn't started for unlock list purposes.
+   */
   private fun ActivitySchedule.addInstances(
     activity: Activity,
     slots: List<ActivityScheduleSlot>,
@@ -440,8 +443,20 @@ class ActivityService(
     request: ActivityUpdateRequest,
     activity: Activity,
   ) {
-    request.runsOnBankHoliday?.apply {
-      activity.schedules().forEach { it.runsOnBankHoliday = this }
+    request.runsOnBankHoliday?.let { runsOnBankHoliday ->
+      activity.schedules().forEach { schedule ->
+        schedule.runsOnBankHoliday = runsOnBankHoliday
+
+        if (runsOnBankHoliday) {
+          schedule.addInstances(activity, schedule.slots())
+        } else {
+          val futureSessionDatesToRemove = schedule.instances()
+            .filter { it.sessionDate > LocalDate.now() && bankHolidayService.isEnglishBankHoliday(it.sessionDate) }
+            .map { it.sessionDate }
+
+          futureSessionDatesToRemove.forEach { schedule.removeInstances(it, it) }
+        }
+      }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/Assertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/Assertions.kt
@@ -1,0 +1,11 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers
+
+import org.assertj.core.api.Assertions.assertThat
+
+internal infix fun <T> T.isEqualTo(value: T) {
+  assertThat(this).isEqualTo(value)
+}
+
+internal infix fun <T> Collection<T>.hasSize(size: Int) {
+  assertThat(this).hasSize(size)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -6,6 +6,7 @@ import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -19,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityState
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.read
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.educationCategory
@@ -43,11 +45,13 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.A
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.Slot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AuditRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.BankHolidayService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.HmppsAuditApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.HmppsAuditEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsPublisher
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundHMPPSDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.ScheduleCreatedInformation
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -65,6 +69,9 @@ class ActivityIntegrationTest : IntegrationTestBase() {
 
   @MockBean
   private lateinit var eventsPublisher: OutboundEventsPublisher
+
+  @MockBean
+  private lateinit var bankHolidayService: BankHolidayService
 
   @MockBean
   private lateinit var hmppsAuditApiClient: HmppsAuditApiClient
@@ -737,5 +744,107 @@ class ActivityIntegrationTest : IntegrationTestBase() {
       assertThat(schedules.first().endDate).isEqualTo(TimeSource.tomorrow())
       assertThat(schedules.first().allocations.first().endDate).isEqualTo(TimeSource.tomorrow())
     }
+  }
+
+  @Test
+  fun `updateActivity - runs on bank holidays updated to not run on bankholidays`() {
+    prisonApiMockServer.stubGetReferenceCode(
+      "EDU_LEVEL",
+      "1",
+      "prisonapi/education-level-code-1.json",
+    )
+
+    prisonApiMockServer.stubGetReferenceCode(
+      "STUDY_AREA",
+      "ENGLA",
+      "prisonapi/study-area-code-ENGLA.json",
+    )
+
+    prisonApiMockServer.stubGetLocation(
+      1L,
+      "prisonapi/location-id-1.json",
+    )
+
+    val startDate = TimeSource.tomorrow()
+
+    whenever(bankHolidayService.isEnglishBankHoliday(startDate)) doReturn true
+
+    val createActivityRequest: ActivityCreateRequest =
+      mapper.read<ActivityCreateRequest>("activity/activity-create-request-7.json")
+        .copy(
+          startDate = startDate,
+          slots = listOf(
+            Slot(
+              timeSlot = "AM",
+              monday = startDate.dayOfWeek == DayOfWeek.MONDAY,
+              tuesday = startDate.dayOfWeek == DayOfWeek.TUESDAY,
+              wednesday = startDate.dayOfWeek == DayOfWeek.WEDNESDAY,
+              thursday = startDate.dayOfWeek == DayOfWeek.THURSDAY,
+              friday = startDate.dayOfWeek == DayOfWeek.FRIDAY,
+              saturday = startDate.dayOfWeek == DayOfWeek.SATURDAY,
+              sunday = startDate.dayOfWeek == DayOfWeek.SUNDAY,
+            ),
+          ),
+          runsOnBankHoliday = true,
+        )
+
+    val activity = webTestClient.createActivity(createActivityRequest)!!
+
+    activity.schedules.flatMap { it.instances } hasSize 2
+
+    val updatedActivity = webTestClient.updateActivity(activity.prisonCode, activity.id, ActivityUpdateRequest(runsOnBankHoliday = false))
+
+    updatedActivity.schedules.flatMap { it.instances } hasSize 1
+  }
+
+  @Test
+  fun `updateActivity - does not run on bank holidays changed to does run on bank holidays`() {
+    prisonApiMockServer.stubGetReferenceCode(
+      "EDU_LEVEL",
+      "1",
+      "prisonapi/education-level-code-1.json",
+    )
+
+    prisonApiMockServer.stubGetReferenceCode(
+      "STUDY_AREA",
+      "ENGLA",
+      "prisonapi/study-area-code-ENGLA.json",
+    )
+
+    prisonApiMockServer.stubGetLocation(
+      1L,
+      "prisonapi/location-id-1.json",
+    )
+
+    val startDate = TimeSource.tomorrow()
+
+    whenever(bankHolidayService.isEnglishBankHoliday(startDate)) doReturn true
+
+    val createActivityRequest: ActivityCreateRequest =
+      mapper.read<ActivityCreateRequest>("activity/activity-create-request-7.json")
+        .copy(
+          startDate = startDate,
+          slots = listOf(
+            Slot(
+              timeSlot = "AM",
+              monday = startDate.dayOfWeek == DayOfWeek.MONDAY,
+              tuesday = startDate.dayOfWeek == DayOfWeek.TUESDAY,
+              wednesday = startDate.dayOfWeek == DayOfWeek.WEDNESDAY,
+              thursday = startDate.dayOfWeek == DayOfWeek.THURSDAY,
+              friday = startDate.dayOfWeek == DayOfWeek.FRIDAY,
+              saturday = startDate.dayOfWeek == DayOfWeek.SATURDAY,
+              sunday = startDate.dayOfWeek == DayOfWeek.SUNDAY,
+            ),
+          ),
+          runsOnBankHoliday = false,
+        )
+
+    val activity = webTestClient.createActivity(createActivityRequest)!!
+
+    activity.schedules.flatMap { it.instances } hasSize 1
+
+    val updatedActivity = webTestClient.updateActivity(activity.prisonCode, activity.id, ActivityUpdateRequest(runsOnBankHoliday = true))
+
+    updatedActivity.schedules.flatMap { it.instances } hasSize 2
   }
 }


### PR DESCRIPTION
This change removes or adds future scheduled instances for an activity when the runs on bank holiday flag is updated to true or false.

If an activity was initially set up to run on bank holidays but was subsequently updated to no longer run on bank holidays then any future instances that exist which run on bank holidays will be removed.

The opposite is true if the activity was initially set up to not run on bank holidays, future instances for those bank holidays will be added.