### PR TITLE
SAA-987 changes to suspend future attendances when allocations are suspended via the acitivities changed event.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -16,6 +16,7 @@ import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
 import org.hibernate.annotations.Fetch
 import org.hibernate.annotations.FetchMode
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.enumeration.ServiceName
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -110,7 +111,7 @@ data class Attendance(
     newCaseNoteId: String?,
     newOtherAbsenceReason: String?,
   ): Attendance {
-    if (!editable()) throw IllegalArgumentException("Attendance record for prisoner '$prisonerNumber' can no longer be modified")
+    require(editable()) { "Attendance record for prisoner '$prisonerNumber' can no longer be modified" }
 
     if (status != AttendanceStatus.WAITING || history().isNotEmpty()) addAttendanceToHistory()
 
@@ -179,6 +180,18 @@ data class Attendance(
         this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(14))
       )
   }
+
+  fun completeWithoutPayment(reason: AttendanceReason) =
+    apply {
+      require(editable()) { "Attendance record for prisoner '$prisonerNumber' can no longer be modified" }
+
+      attendanceReason = reason
+      issuePayment = false
+      status = AttendanceStatus.COMPLETED
+      recordedTime = LocalDateTime.now()
+      recordedBy = ServiceName.SERVICE_NAME.value
+      addAttendanceToHistory()
+    }
 }
 
 enum class AttendanceStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceRepository.kt
@@ -25,9 +25,9 @@ interface AttendanceRepository : JpaRepository<Attendance, Long> {
         FROM Attendance a
        WHERE a.scheduledInstance.activitySchedule.activity.prisonCode = :prisonCode
          AND a.status = 'WAITING'
-         AND a.scheduledInstance.sessionDate = :sessionDate
+         AND a.scheduledInstance.sessionDate >= :sessionDate
          AND a.prisonerNumber = :prisonerNumber
     """,
   )
-  fun findWaitingAttendancesOnDateForPrisoner(prisonCode: String, sessionDate: LocalDate, prisonerNumber: String): List<Attendance>
+  fun findWaitingAttendancesOnOrAfterDateForPrisoner(prisonCode: String, sessionDate: LocalDate, prisonerNumber: String): List<Attendance>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceRepository.kt
@@ -18,4 +18,16 @@ interface AttendanceRepository : JpaRepository<Attendance, Long> {
     """,
   )
   fun findWaitingAttendancesOnDate(prisonCode: String, sessionDate: LocalDate): List<Attendance>
+
+  @Query(
+    """
+      SELECT a
+        FROM Attendance a
+       WHERE a.scheduledInstance.activitySchedule.activity.prisonCode = :prisonCode
+         AND a.status = 'WAITING'
+         AND a.scheduledInstance.sessionDate = :sessionDate
+         AND a.prisonerNumber = :prisonerNumber
+    """,
+  )
+  fun findWaitingAttendancesOnDateForPrisoner(prisonCode: String, sessionDate: LocalDate, prisonerNumber: String): List<Attendance>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
@@ -2,19 +2,26 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceReasonEnum
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceReasonRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.Action
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.ActivitiesChangedEvent
 import java.time.LocalDateTime
 
 @Component
+@Transactional
 class ActivitiesChangedEventHandler(
   private val rolloutPrisonRepository: RolloutPrisonRepository,
   private val allocationRepository: AllocationRepository,
+  private val attendanceRepository: AttendanceRepository,
+  private val attendanceReasonRepository: AttendanceReasonRepository,
 ) : EventHandler<ActivitiesChangedEvent> {
 
   companion object {
@@ -26,8 +33,8 @@ class ActivitiesChangedEventHandler(
 
     if (rolloutPrisonRepository.findByCode(event.prisonCode())?.isActivitiesRolledOut() == true) {
       return when (event.action()) {
-        Action.SUSPEND -> suspendOffenderAllocations(event).let { Outcome.success() }
-        Action.END -> deallocateOffenderAllocations(event).let { Outcome.success() }
+        Action.SUSPEND -> suspendPrisonerAllocationsAndAttendances(event).let { Outcome.success() }
+        Action.END -> deallocatePrisonerAllocations(event).let { Outcome.success() }
         else -> log.warn("Unable to process $event, unknown action").let { Outcome.failed() }
       }
     }
@@ -35,28 +42,41 @@ class ActivitiesChangedEventHandler(
     return Outcome.success()
   }
 
-  private fun suspendOffenderAllocations(event: ActivitiesChangedEvent) =
-    allocationRepository.findByPrisonCodeAndPrisonerNumber(event.prisonCode(), event.prisonerNumber())
-      .suspendAndSaveAffectedAllocations()
-      .let {
-        log.info("Suspended ${it.size} allocations for prisoner ${event.prisonerNumber()} at prison ${event.prisonCode()}.")
-      }
-
-  private fun List<Allocation>.suspendAndSaveAffectedAllocations() =
+  private fun suspendPrisonerAllocationsAndAttendances(event: ActivitiesChangedEvent) =
     LocalDateTime.now().let { now ->
-      this.filter { it.status(PrisonerStatus.ACTIVE) }.map { it.autoSuspend(now, "Temporary absence") }
-    }.saveAffectedAllocations()
+      allocationRepository.findByPrisonCodeAndPrisonerNumber(event.prisonCode(), event.prisonerNumber())
+        .suspendAllocations(now, event)
+        .suspendAttendances(now, event)
+    }
 
-  private fun deallocateOffenderAllocations(event: ActivitiesChangedEvent) =
+  private fun List<Allocation>.suspendAllocations(suspendedAt: LocalDateTime, event: ActivitiesChangedEvent) =
+    filter { it.status(PrisonerStatus.ACTIVE) }
+      .onEach { it.autoSuspend(suspendedAt, "Temporary absence") }
+      .also { log.info("Suspended ${it.size} allocations for prisoner ${event.prisonerNumber()} at prison ${event.prisonCode()}.") }
+
+  private fun List<Allocation>.suspendAttendances(
+    dateTime: LocalDateTime,
+    event: ActivitiesChangedEvent,
+  ) {
+    val reason = attendanceReasonRepository.findByCode(AttendanceReasonEnum.SUSPENDED)
+
+    forEach { allocation ->
+      attendanceRepository.findWaitingAttendancesOnDateForPrisoner(
+        event.prisonCode(),
+        dateTime.toLocalDate(),
+        allocation.prisonerNumber,
+      )
+        .filter { attendance -> attendance.editable() && attendance.scheduledInstance.startTime > dateTime.toLocalTime() }
+        .onEach { attendance -> attendance.completeWithoutPayment(reason) }
+        .also { log.info("Suspended ${it.size} attendances for prisoner ${allocation.prisonerNumber} allocation ID ${allocation.allocationId} at prison ${event.prisonCode()}e.") }
+    }
+  }
+
+  private fun deallocatePrisonerAllocations(event: ActivitiesChangedEvent) =
     allocationRepository.findByPrisonCodeAndPrisonerNumber(event.prisonCode(), event.prisonerNumber())
-      .deallocateAndSaveAffectedAllocations(DeallocationReason.TEMPORARY_ABSENCE)
-      .also {
-        log.info("Deallocated prisoner ${event.prisonerNumber()} at prison ${event.prisonCode()} from ${it.size} allocations.")
-      }
+      .deallocateAffectedAllocations(DeallocationReason.TEMPORARY_ABSENCE)
+      .also { log.info("Deallocated prisoner ${event.prisonerNumber()} at prison ${event.prisonCode()} from ${it.size} allocations.") }
 
-  private fun List<Allocation>.deallocateAndSaveAffectedAllocations(reason: DeallocationReason) =
-    this.filterNot { it.status(PrisonerStatus.ENDED) }.map { it.deallocateNowWithReason(reason) }.saveAffectedAllocations()
-
-  private fun List<Allocation>.saveAffectedAllocations() =
-    allocationRepository.saveAllAndFlush(this).toList()
+  private fun List<Allocation>.deallocateAffectedAllocations(reason: DeallocationReason) =
+    this.filterNot { it.status(PrisonerStatus.ENDED) }.onEach { it.deallocateNowWithReason(reason) }
 }

--- a/src/test/resources/test_data/seed-activity-changed-event.sql
+++ b/src/test/resources/test_data/seed-activity-changed-event.sql
@@ -42,3 +42,9 @@ values (2, current_date, '23:58:00', '23:59:00', false, null, null, null, null);
 
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
 values (2, 2, 'A11111A', null, null, null, null, 'WAITING', null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date + 1, '00:01:00', '00:02:00', false, null, null, null, null);
+
+insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (3, 3, 'A11111A', null, null, null, null, 'WAITING', null, null, null);

--- a/src/test/resources/test_data/seed-activity-changed-event.sql
+++ b/src/test/resources/test_data/seed-activity-changed-event.sql
@@ -1,0 +1,44 @@
+--
+-- The time slots for the prison have been set at two extremes very early or very late to prevent test fragility with timings
+--
+INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
+VALUES(3, 'PVI', '00:01:00', '00:02:00', '13:00:00', '16:30:00', '23:58:00', '23:59:00');
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
+
+insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
+values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag)
+values (1, 1, '00:01:00', '00:02:00', true, true, true, true, true, true, true);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (2, 1, 'Maths ED', 2, 'L2', 'Location 2', 10, '2022-10-10');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag)
+values (2, 2, '23:58:00', '23:59:00', true, true, true, true, true, true, true);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (1, 1, 'A11111A', 10001, 1, '2022-10-10', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (2, 2, 'A11111A', 10001, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date, '00:01:00', '00:02:00', false, null, null, null, null);
+
+insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (1, 1, 'A11111A', null, null, null, null, 'WAITING', null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (2, current_date, '23:58:00', '23:59:00', false, null, null, null, null);
+
+insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (2, 2, 'A11111A', null, null, null, null, 'WAITING', null, null, null);


### PR DESCRIPTION
When an allocation is suspended any future attendance records associated with that allocation should also be suspended without pay.

In this scenario future attendance records are any attendance records that are after the time of the allocation being suspended.