### PR TITLE
SAA-1012: Only remove redundant future instances when updating slots

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -327,13 +327,12 @@ data class ActivitySchedule(
     updateMatchingSlots(updates)
     addNewSlots(updates)
 
-    val instancesToKeep = instances
-      .filter {
-        it.sessionDate >= LocalDate.now() &&
-          (it.attendances.isNotEmpty() || updates[it.startTime to it.endTime]?.contains(it.dayOfWeek()) == true)
-      }
+    // Remove any instances that are in the future (not included today) and are no longer required
+    val instancesToRemove = instances
+      .filter { it.sessionDate > LocalDate.now() }
+      .filter { updates[it.startTime to it.endTime]?.contains(it.dayOfWeek()) == false }
 
-    instances.removeIf { instancesToKeep.contains(it).not() }
+    instances.removeIf { instancesToRemove.contains(it) }
   }
 
   private fun removeRedundantSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -224,9 +224,9 @@ class ActivityService(
     fromDate: LocalDate? = null,
     toDate: LocalDate? = null,
   ) {
-    val today = LocalDate.now()
-    val endDay = today.plusDays(daysInAdvance)
-    val listOfDatesToSchedule = today.datesUntil(endDay).toList()
+    val tomorrow = LocalDate.now().plusDays(1)
+    val endDay = LocalDate.now().plusDays(daysInAdvance)
+    val listOfDatesToSchedule = tomorrow.datesUntil(endDay).toList()
 
     listOfDatesToSchedule.filter { this.isActiveOn(it) }
       .filter { fromDate == null || it >= fromDate }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -1019,16 +1019,16 @@ class ActivityScheduleTest {
   }
 
   @Test
-  fun `slot update does not remove instance with attendance`() {
+  fun `slot update removes redundant instances in the future`() {
     val schedule =
       activitySchedule(activity = activityEntity(startDate = yesterday), noSlots = true, noInstances = true)
 
     assertThat(schedule.slots()).isEmpty()
 
-    val slotOne = schedule.addSlot(LocalTime.MIDNIGHT, LocalTime.NOON, setOf(today.dayOfWeek))
+    val slotOne = schedule.addSlot(LocalTime.MIDNIGHT, LocalTime.NOON, setOf(yesterday.dayOfWeek))
     val slotTwo = schedule.addSlot(LocalTime.MIDNIGHT, LocalTime.NOON, setOf(tomorrow.dayOfWeek))
 
-    val instanceOne = schedule.addInstance(today, slotOne).apply {
+    val instanceOne = schedule.addInstance(yesterday, slotOne).apply {
       attendances.add(
         attendance(),
       )
@@ -1037,11 +1037,11 @@ class ActivityScheduleTest {
 
     assertThat(schedule.instances()).containsOnly(instanceOne, instanceTwo)
 
-    val updates = mapOf(Pair(LocalTime.MIDNIGHT, LocalTime.NOON) to setOf(instanceTwo.dayOfWeek()))
+    val updates = mapOf(Pair(LocalTime.MIDNIGHT, LocalTime.NOON) to setOf(today.dayOfWeek))
 
     schedule.updateSlotsAndRemoveRedundantInstances(updates)
 
-    assertThat(schedule.instances()).containsOnly(instanceOne, instanceTwo)
+    assertThat(schedule.instances()).containsOnly(instanceOne)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -802,7 +802,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     with(webTestClient.updateActivity(pentonvillePrisonCode, 1, mondayTuesdaySlot).schedules.first()) {
       assertThat(slots).hasSize(1)
       assertThat(slots.first().daysOfWeek).containsExactly("Mon", "Tue")
-      assertThat(instances).hasSize(4)
+      assertThat(instances).hasSizeBetween(3, 4)
     }
 
     val thursdayFridaySlot = ActivityUpdateRequest(slots = listOf(Slot("AM", thursday = true)))
@@ -810,7 +810,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     with(webTestClient.updateActivity(pentonvillePrisonCode, 1, thursdayFridaySlot).schedules.first()) {
       assertThat(slots).hasSize(1)
       assertThat(slots.first().daysOfWeek).containsExactly("Thu")
-      assertThat(instances).hasSize(2)
+      assertThat(instances).hasSizeBetween(1, 2)
     }
 
     verify(eventsPublisher, times(2)).send(eventCaptor.capture())


### PR DESCRIPTION
## Overview

Small change to the create / remove instance logic. This fixes the bug where all past instances are removed during a slot update and implements the following rules for activity create / edit requests:

- All past instances should be kept (regardless of attendance or previous slot settings)
- Any instances already scheduled for today should remain active
- Any future instances (tomorrow or after) which are no longer valid should be removed (regardless of existing attendance records)
- Any future instances (tomorrow or after) which are still valid should be kept
- Where new instances need to be created these should be created for tomorrow onwards