### PR TITLE
SAA-996: Multi-week schedule updates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -212,15 +212,8 @@ data class ActivitySchedule(
     }
   }
 
-  // TODO - Add support for adding slots of multi-week schedules
-  fun addSlot(startTime: LocalTime, endTime: LocalTime, daysOfWeek: Set<DayOfWeek>) =
-    addSlot(ActivityScheduleSlot.valueOf(this, 1, startTime, endTime, daysOfWeek))
-
-  fun addSlot(slot: ActivityScheduleSlot): ActivityScheduleSlot {
-    if (slot.activitySchedule.activityScheduleId != activityScheduleId) throw IllegalArgumentException("Can only add slots that belong to this schedule.")
-
-    slots.add(slot)
-
+  fun addSlot(weekNumber: Int, startTime: LocalTime, endTime: LocalTime, daysOfWeek: Set<DayOfWeek>): ActivityScheduleSlot {
+    slots.add(ActivityScheduleSlot.valueOf(this, weekNumber, startTime, endTime, daysOfWeek))
     return slots.last()
   }
 
@@ -318,38 +311,29 @@ data class ActivitySchedule(
       .sortedWith(compareBy<ScheduledInstance> { it.sessionDate }.thenBy { it.startTime })
       .let { sorted -> sorted.getOrNull(sorted.indexOf(scheduledInstance) + 1) }
 
-  fun removeInstances(fromDate: LocalDate, toDate: LocalDate?) {
-    instances.removeAll(instances().filter { it.sessionDate.between(fromDate, toDate) })
-  }
+  fun removeInstances(instancesToRemove: List<ScheduledInstance>) = instances.removeAll(instancesToRemove)
 
-  fun updateSlotsAndRemoveRedundantInstances(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
+  fun updateSlots(updates: Map<Pair<Int, Pair<LocalTime, LocalTime>>, Set<DayOfWeek>>) {
     removeRedundantSlots(updates)
     updateMatchingSlots(updates)
     addNewSlots(updates)
-
-    // Remove any instances that are in the future (not included today) and are no longer required
-    val instancesToRemove = instances
-      .filter { it.sessionDate > LocalDate.now() }
-      .filter { updates[it.startTime to it.endTime]?.contains(it.dayOfWeek()) == false }
-
-    instances.removeIf { instancesToRemove.contains(it) }
   }
 
-  private fun removeRedundantSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
-    slots.removeAll(slots.filterNot { updates.containsKey(Pair(it.startTime, it.endTime)) })
+  private fun removeRedundantSlots(updates: Map<Pair<Int, Pair<LocalTime, LocalTime>>, Set<DayOfWeek>>) {
+    slots.removeAll(slots.filterNot { updates.containsKey(Pair(it.weekNumber, it.startTime to it.endTime)) })
   }
 
-  private fun updateMatchingSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
+  private fun updateMatchingSlots(updates: Map<Pair<Int, Pair<LocalTime, LocalTime>>, Set<DayOfWeek>>) {
     slots.forEach { slot ->
-      updates[slot.startTime to slot.endTime]?.let(slot::update)
+      updates[Pair(slot.weekNumber, slot.startTime to slot.endTime)]?.let(slot::update)
     }
   }
 
-  private fun addNewSlots(updates: Map<Pair<LocalTime, LocalTime>, Set<DayOfWeek>>) {
+  private fun addNewSlots(updates: Map<Pair<Int, Pair<LocalTime, LocalTime>>, Set<DayOfWeek>>) {
     updates.keys.filterNot { key ->
-      slots.map { Pair(it.startTime, it.endTime) }.contains(key)
+      slots.map { Pair(it.weekNumber, it.startTime to it.endTime) }.contains(key)
     }.forEach {
-      addSlot(it.first, it.second, updates[it]!!)
+      addSlot(it.first, it.second.first, it.second.second, updates[it]!!)
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeService.kt
@@ -75,6 +75,15 @@ class PrisonRegimeService(
 
         LocalTimeRange(start, end)
       }
+
+  fun getPrisonTimeSlots(prisonCode: String): Map<TimeSlot, Pair<LocalTime, LocalTime>> =
+    getPrisonRegimeByPrisonCode(prisonCode).let { pr ->
+      mapOf(
+        TimeSlot.AM to Pair(pr.amStart, pr.amFinish),
+        TimeSlot.PM to Pair(pr.pmStart, pr.pmFinish),
+        TimeSlot.ED to Pair(pr.edStart, pr.edFinish),
+      )
+    }
 }
 
 data class Priority(val priority: Int, val eventCategory: EventCategory? = null)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
@@ -413,6 +413,7 @@ class ActivityTest {
     val schedule = activity.schedules().first()
 
     schedule.addSlot(
+      weekNumber = 1,
       startTime = LocalTime.NOON,
       endTime = LocalTime.NOON.plusHours(1),
       setOf(*DayOfWeek.values()),
@@ -429,6 +430,7 @@ class ActivityTest {
     val schedule = activity.schedules().first()
 
     schedule.addSlot(
+      weekNumber = 1,
       startTime = LocalTime.NOON,
       endTime = LocalTime.NOON.plusHours(1),
       setOf(*DayOfWeek.values()),
@@ -453,6 +455,7 @@ class ActivityTest {
     val schedule = activity.schedules().first()
 
     schedule.addSlot(
+      weekNumber = 1,
       startTime = LocalTime.NOON,
       endTime = LocalTime.NOON.plusHours(1),
       setOf(*DayOfWeek.values()),
@@ -490,6 +493,7 @@ class ActivityTest {
       scheduleWeeks = 1,
     ).apply {
       addSlot(
+        weekNumber = 1,
         startTime = LocalTime.NOON,
         endTime = LocalTime.NOON.plusHours(1),
         setOf(*DayOfWeek.values()),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -22,6 +22,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.A
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityMinimumEducationLevelCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.Slot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transform
+import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -143,13 +144,7 @@ internal fun activitySchedule(
   timestamp: LocalDateTime = LocalDate.now().atStartOfDay(),
   description: String = "schedule description",
   scheduleWeeks: Int = 1,
-  monday: Boolean = true,
-  tuesday: Boolean = false,
-  wednesday: Boolean = false,
-  thursday: Boolean = false,
-  friday: Boolean = false,
-  saturday: Boolean = false,
-  sunday: Boolean = false,
+  daysOfWeek: Set<DayOfWeek> = setOf(DayOfWeek.MONDAY),
   runsOnBankHolidays: Boolean = false,
   startDate: LocalDate? = null,
   endDate: LocalDate? = null,
@@ -180,22 +175,7 @@ internal fun activitySchedule(
       )
     }
     if (!noSlots) {
-      this.addSlot(
-        ActivityScheduleSlot(
-          activityScheduleSlotId = 1,
-          weekNumber = 1,
-          activitySchedule = this,
-          startTime = timestamp.toLocalTime(),
-          endTime = timestamp.toLocalTime().plusHours(1),
-          mondayFlag = monday,
-          tuesdayFlag = tuesday,
-          wednesdayFlag = wednesday,
-          thursdayFlag = thursday,
-          fridayFlag = friday,
-          saturdayFlag = saturday,
-          sundayFlag = sunday,
-        ),
-      )
+      this.addSlot(1, timestamp.toLocalTime(), timestamp.toLocalTime().plusHours(1), daysOfWeek)
     }
     if (!noInstances && !noSlots) {
       this.addInstance(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
@@ -21,8 +21,8 @@ import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toPrisonerNumber
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityScheduleSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.toModelLite
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityCategory
@@ -44,6 +44,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.read
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.runEveryDayOfWeek
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityUpdateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.Slot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
@@ -129,7 +130,16 @@ class ActivityServiceTest {
   fun setUp() {
     openMocks(this)
     whenever(prisonApiClient.getLocation(1)).thenReturn(Mono.just(location))
-    whenever(prisonRegimeService.getPrisonRegimeByPrisonCode("MDI")).thenReturn(transform(prisonRegime()))
+    whenever(prisonRegimeService.getPrisonRegimeByPrisonCode(any())).thenReturn(transform(prisonRegime()))
+    whenever(prisonRegimeService.getPrisonTimeSlots(any())).thenReturn(
+      transform(prisonRegime()).let { pr ->
+        mapOf(
+          TimeSlot.AM to Pair(pr.amStart, pr.amFinish),
+          TimeSlot.PM to Pair(pr.pmStart, pr.pmFinish),
+          TimeSlot.ED to Pair(pr.edStart, pr.edFinish),
+        )
+      },
+    )
   }
 
   @Test
@@ -747,10 +757,11 @@ class ActivityServiceTest {
   fun `updateActivity - setting of the end date is successful`() {
     val activity = activityEntity(startDate = TimeSource.tomorrow())
     activity.schedules().forEach {
-      it.addInstance(TimeSource.tomorrow().plusDays(1), it.slots().first())
-      it.addInstance(TimeSource.tomorrow().plusDays(2), it.slots().first())
-      it.addInstance(TimeSource.tomorrow().plusDays(3), it.slots().first())
-      it.addInstance(TimeSource.tomorrow().plusDays(4), it.slots().first())
+      val everydaySlot = it.addSlot(1, LocalTime.NOON, LocalTime.NOON.plusHours(1), DayOfWeek.values().toSet())
+      it.addInstance(TimeSource.tomorrow().plusDays(1), everydaySlot)
+      it.addInstance(TimeSource.tomorrow().plusDays(2), everydaySlot)
+      it.addInstance(TimeSource.tomorrow().plusDays(3), everydaySlot)
+      it.addInstance(TimeSource.tomorrow().plusDays(4), everydaySlot)
     }
 
     whenever(activityRepository.findByActivityIdAndPrisonCode(1, moorlandPrisonCode)).thenReturn(activity)
@@ -798,11 +809,12 @@ class ActivityServiceTest {
   fun `updateActivity - bringing the end date closer is successful`() {
     val activity = activityEntity(startDate = TimeSource.tomorrow(), endDate = TimeSource.tomorrow().plusDays(5))
     activity.schedules().forEach {
-      it.addInstance(TimeSource.tomorrow().plusDays(1), it.slots().first())
-      it.addInstance(TimeSource.tomorrow().plusDays(2), it.slots().first())
-      it.addInstance(TimeSource.tomorrow().plusDays(3), it.slots().first())
-      it.addInstance(TimeSource.tomorrow().plusDays(4), it.slots().first())
-      it.addInstance(TimeSource.tomorrow().plusDays(5), it.slots().first())
+      val everydaySlot = it.addSlot(1, LocalTime.NOON, LocalTime.NOON.plusHours(1), DayOfWeek.values().toSet())
+      it.addInstance(TimeSource.tomorrow().plusDays(1), everydaySlot)
+      it.addInstance(TimeSource.tomorrow().plusDays(2), everydaySlot)
+      it.addInstance(TimeSource.tomorrow().plusDays(3), everydaySlot)
+      it.addInstance(TimeSource.tomorrow().plusDays(4), everydaySlot)
+      it.addInstance(TimeSource.tomorrow().plusDays(5), everydaySlot)
     }
 
     whenever(activityRepository.findByActivityIdAndPrisonCode(1, moorlandPrisonCode)).thenReturn(activity)
@@ -849,6 +861,167 @@ class ActivityServiceTest {
   }
 
   @Test
+  fun `updateActivity - add new slot (adds new instances)`() {
+    val activity = activityEntity(noSchedules = true).also {
+      whenever(activityRepository.findByActivityIdAndPrisonCode(it.activityId, it.prisonCode)) doReturn (it)
+    }
+
+    val schedule = activity.addSchedule(activitySchedule(activity, noInstances = true, noSlots = true))
+
+    schedule.slots() hasSize 0
+    schedule.instances() hasSize 0
+
+    val tomorrow = LocalDate.now().plusDays(1)
+
+    service().updateActivity(
+      activity.prisonCode,
+      activity.activityId,
+      ActivityUpdateRequest(
+        slots = listOf(
+          Slot(
+            timeSlot = "AM",
+            monday = tomorrow.dayOfWeek == DayOfWeek.MONDAY,
+            tuesday = tomorrow.dayOfWeek == DayOfWeek.TUESDAY,
+            wednesday = tomorrow.dayOfWeek == DayOfWeek.WEDNESDAY,
+            thursday = tomorrow.dayOfWeek == DayOfWeek.THURSDAY,
+            friday = tomorrow.dayOfWeek == DayOfWeek.FRIDAY,
+            saturday = tomorrow.dayOfWeek == DayOfWeek.SATURDAY,
+            sunday = tomorrow.dayOfWeek == DayOfWeek.SUNDAY,
+          ),
+        ),
+      ),
+      "TEST",
+    )
+
+    schedule.slots() hasSize 1
+    schedule.instances() hasSize 1
+  }
+
+  @Test
+  fun `updateActivity - remove slots (removes instances)`() {
+    val activity = activityEntity(noSchedules = true).also {
+      whenever(activityRepository.findByActivityIdAndPrisonCode(it.activityId, it.prisonCode)) doReturn (it)
+    }
+
+    val tomorrow = LocalDate.now().plusDays(1)
+
+    val schedule = activity.addSchedule(activitySchedule(activity, noInstances = true, noSlots = true))
+    val slot1 = schedule.addSlot(
+      1,
+      prisonRegime().amStart,
+      prisonRegime().amFinish,
+      setOf(
+        tomorrow.dayOfWeek,
+      ),
+    )
+    val slot2 = schedule.addSlot(
+      1,
+      prisonRegime().pmStart,
+      prisonRegime().pmFinish,
+      setOf(tomorrow.plusDays(1).dayOfWeek),
+    )
+    val instance1 = schedule.addInstance(tomorrow, slot1)
+    val instance2 = schedule.addInstance(tomorrow.plusDays(1), slot2)
+
+    schedule.slots() hasSize 2
+    schedule.instances() hasSize 2
+    assertThat(schedule.slots()).containsAll(listOf(slot1, slot2))
+    assertThat(schedule.instances()).containsAll(listOf(instance1, instance2))
+
+    service().updateActivity(
+      activity.prisonCode,
+      activity.activityId,
+      ActivityUpdateRequest(
+        slots = listOf(
+          Slot(
+            timeSlot = "AM",
+            monday = tomorrow.dayOfWeek == DayOfWeek.MONDAY,
+            tuesday = tomorrow.dayOfWeek == DayOfWeek.TUESDAY,
+            wednesday = tomorrow.dayOfWeek == DayOfWeek.WEDNESDAY,
+            thursday = tomorrow.dayOfWeek == DayOfWeek.THURSDAY,
+            friday = tomorrow.dayOfWeek == DayOfWeek.FRIDAY,
+            saturday = tomorrow.dayOfWeek == DayOfWeek.SATURDAY,
+            sunday = tomorrow.dayOfWeek == DayOfWeek.SUNDAY,
+          ),
+        ),
+      ),
+      "TEST",
+    )
+
+    schedule.slots() hasSize 1
+    schedule.instances() hasSize 1
+    assertThat(schedule.slots()).contains(slot1)
+    assertThat(schedule.instances()).contains(instance1)
+  }
+
+  @Test
+  fun `updateActivity - update existing slot (adds & removes instances)`() {
+    val activity = activityEntity(noSchedules = true).also {
+      whenever(activityRepository.findByActivityIdAndPrisonCode(it.activityId, it.prisonCode)) doReturn (it)
+    }
+
+    val tomorrow = LocalDate.now().plusDays(1)
+
+    val schedule = activity.addSchedule(activitySchedule(activity, noInstances = true, noSlots = true))
+
+    val slot1 = schedule.addSlot(
+      1,
+      prisonRegime().amStart,
+      prisonRegime().amFinish,
+      setOf(tomorrow.dayOfWeek),
+    )
+    val slot2 = schedule.addSlot(
+      1,
+      prisonRegime().pmStart,
+      prisonRegime().pmFinish,
+      setOf(tomorrow.plusDays(1).dayOfWeek),
+    )
+    val instance1 = schedule.addInstance(tomorrow, slot1)
+    val instance2 = schedule.addInstance(tomorrow.plusDays(1), slot2)
+
+    assertThat(schedule.slots()).containsAll(listOf(slot1, slot2))
+    assertThat(schedule.instances()).containsAll(listOf(instance1, instance2))
+
+    service().updateActivity(
+      activity.prisonCode,
+      activity.activityId,
+      ActivityUpdateRequest(
+        slots = listOf(
+          Slot(
+            timeSlot = "ED",
+            monday = tomorrow.dayOfWeek == DayOfWeek.MONDAY,
+            tuesday = tomorrow.dayOfWeek == DayOfWeek.TUESDAY,
+            wednesday = tomorrow.dayOfWeek == DayOfWeek.WEDNESDAY,
+            thursday = tomorrow.dayOfWeek == DayOfWeek.THURSDAY,
+            friday = tomorrow.dayOfWeek == DayOfWeek.FRIDAY,
+            saturday = tomorrow.dayOfWeek == DayOfWeek.SATURDAY,
+            sunday = tomorrow.dayOfWeek == DayOfWeek.SUNDAY,
+          ),
+          Slot(
+            timeSlot = "PM",
+            monday = tomorrow.plusDays(1).dayOfWeek == DayOfWeek.MONDAY,
+            tuesday = tomorrow.plusDays(1).dayOfWeek == DayOfWeek.TUESDAY,
+            wednesday = tomorrow.plusDays(1).dayOfWeek == DayOfWeek.WEDNESDAY,
+            thursday = tomorrow.plusDays(1).dayOfWeek == DayOfWeek.THURSDAY,
+            friday = tomorrow.plusDays(1).dayOfWeek == DayOfWeek.FRIDAY,
+            saturday = tomorrow.plusDays(1).dayOfWeek == DayOfWeek.SATURDAY,
+            sunday = tomorrow.plusDays(1).dayOfWeek == DayOfWeek.SUNDAY,
+          ),
+        ),
+      ),
+      "TEST",
+    )
+
+    // One slot and instance should be removed and replaced with one new slot and instance
+    schedule.slots() hasSize 2
+    assertThat(schedule.slots()).doesNotContain(slot1)
+    assertThat(schedule.slots()).contains(slot2)
+    schedule.instances() hasSize 2
+    assertThat(schedule.instances()).doesNotContain(instance1)
+    assertThat(schedule.instances()).contains(instance2)
+  }
+
+  @Test
   fun `updateActivity - now runs on bank holiday`() {
     val bankHoliday = TimeSource.tomorrow().also { whenever(bankHolidayService.isEnglishBankHoliday(it)) doReturn true }
     val dayAfterBankHoliday = bankHoliday.plusDays(1)
@@ -861,6 +1034,7 @@ class ActivityServiceTest {
       activity.addSchedule(activitySchedule(activity, runsOnBankHolidays = false, noInstances = true, noSlots = true))
         .apply {
           addSlot(
+            1,
             LocalTime.NOON,
             LocalTime.NOON.plusHours(1),
             setOf(bankHoliday.dayOfWeek, dayAfterBankHoliday.dayOfWeek),
@@ -894,6 +1068,7 @@ class ActivityServiceTest {
       activity.addSchedule(activitySchedule(activity, runsOnBankHolidays = false, noInstances = true, noSlots = true))
         .apply {
           addSlot(
+            1,
             LocalTime.NOON,
             LocalTime.NOON.plusHours(1),
             setOf(bankHoliday.dayOfWeek, dayAfterBankHoliday.dayOfWeek),
@@ -937,22 +1112,16 @@ class ActivityServiceTest {
       activitySchedule(activity, scheduleWeeks = 2, noSlots = true, noInstances = true, noAllocations = true),
     ).apply {
       addSlot(
-        ActivityScheduleSlot.valueOf(
-          this,
-          1,
-          LocalTime.NOON,
-          LocalTime.NOON.plusHours(1),
-          setOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY),
-        ),
+        weekNumber = 1,
+        startTime = LocalTime.NOON,
+        endTime = LocalTime.NOON.plusHours(1),
+        daysOfWeek = setOf(tomorrow.dayOfWeek, tomorrow.plusDays(2).dayOfWeek),
       )
       addSlot(
-        ActivityScheduleSlot.valueOf(
-          this,
-          2,
-          LocalTime.NOON,
-          LocalTime.NOON.plusHours(1),
-          setOf(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY),
-        ),
+        weekNumber = 2,
+        startTime = LocalTime.NOON,
+        endTime = LocalTime.NOON.plusHours(1),
+        daysOfWeek = setOf(tomorrow.plusDays(1).dayOfWeek, tomorrow.plusDays(3).dayOfWeek),
       )
     }
 
@@ -967,23 +1136,22 @@ class ActivityServiceTest {
       updatedBy = "TEST",
     )
 
-    // After updating there should be at least one instance for both week 1 and 2 scheduled on the correct day
-    with(schedule.instances().filter { schedule.getWeekNumber(it.sessionDate) == 1 }) {
-      assertThat(this.size).isGreaterThanOrEqualTo(1)
-
-      assertThat(
-        this.filter { listOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY).contains(it.dayOfWeek()) }.size,
-      ).isGreaterThanOrEqualTo(1)
-      this.filter { listOf(DayOfWeek.TUESDAY, DayOfWeek.THURSDAY).contains(it.dayOfWeek()) } hasSize 0
+    val week1Schedules = schedule.instances().filter { schedule.getWeekNumber(it.sessionDate) == 1 }
+    assertThat(week1Schedules.size).isEqualTo(2)
+    week1Schedules.all {
+      listOf(
+        tomorrow.dayOfWeek,
+        tomorrow.plusDays(2).dayOfWeek,
+      ).contains(it.dayOfWeek())
     }
 
-    with(schedule.instances().filter { schedule.getWeekNumber(it.sessionDate) == 2 }) {
-      assertThat(this.size).isGreaterThanOrEqualTo(1)
-
-      assertThat(
-        this.filter { listOf(DayOfWeek.TUESDAY, DayOfWeek.TUESDAY).contains(it.dayOfWeek()) }.size,
-      ).isGreaterThanOrEqualTo(1)
-      this.filter { listOf(DayOfWeek.MONDAY, DayOfWeek.WEDNESDAY).contains(it.dayOfWeek()) } hasSize 0
+    val week2Schedules = schedule.instances().filter { schedule.getWeekNumber(it.sessionDate) == 2 }
+    assertThat(week2Schedules.size).isEqualTo(2)
+    week2Schedules.all {
+      listOf(
+        tomorrow.plusDays(1).dayOfWeek,
+        tomorrow.plusDays(3).dayOfWeek,
+      ).contains(it.dayOfWeek())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesServiceTest.kt
@@ -19,7 +19,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityBasic
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityScheduleSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityScheduleSuspension
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.RolloutPrison
@@ -251,7 +250,6 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 1,
-            monday = true,
             noAllocations = true,
             noInstances = true,
           ),
@@ -269,8 +267,7 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 2,
-            monday = false,
-            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.TUESDAY),
             noAllocations = true,
             noInstances = true,
           ),
@@ -288,8 +285,7 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 3,
-            monday = false,
-            wednesday = true,
+            daysOfWeek = setOf(DayOfWeek.WEDNESDAY),
             noAllocations = true,
             noInstances = true,
           ),
@@ -310,7 +306,6 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 4,
-            monday = true,
             noAllocations = true,
             noInstances = true,
           ),
@@ -328,8 +323,7 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 5,
-            monday = false,
-            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.TUESDAY),
             noAllocations = true,
             noInstances = true,
           ),
@@ -347,8 +341,7 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 6,
-            monday = false,
-            wednesday = true,
+            daysOfWeek = setOf(DayOfWeek.WEDNESDAY),
             noAllocations = true,
             noInstances = true,
           ),
@@ -373,13 +366,7 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 1,
-            monday = LocalDate.now().dayOfWeek.equals(DayOfWeek.MONDAY),
-            tuesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.TUESDAY),
-            wednesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.WEDNESDAY),
-            thursday = LocalDate.now().dayOfWeek.equals(DayOfWeek.THURSDAY),
-            friday = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
-            saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
-            sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
+            daysOfWeek = setOf(LocalDate.now().dayOfWeek),
             noInstances = true,
           ).apply {
             this.addInstance(
@@ -408,13 +395,7 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 1,
-            monday = LocalDate.now().dayOfWeek.equals(DayOfWeek.MONDAY),
-            tuesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.TUESDAY),
-            wednesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.WEDNESDAY),
-            thursday = LocalDate.now().dayOfWeek.equals(DayOfWeek.THURSDAY),
-            friday = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
-            saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
-            sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
+            daysOfWeek = setOf(LocalDate.now().dayOfWeek),
             noInstances = true,
           ).apply {
             this.suspensions.clear()
@@ -447,13 +428,7 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 1,
-            monday = LocalDate.now().dayOfWeek.equals(DayOfWeek.MONDAY),
-            tuesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.TUESDAY),
-            wednesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.WEDNESDAY),
-            thursday = LocalDate.now().dayOfWeek.equals(DayOfWeek.THURSDAY),
-            friday = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
-            saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
-            sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
+            daysOfWeek = setOf(LocalDate.now().dayOfWeek),
             runsOnBankHolidays = false,
             noInstances = true,
           ).apply {
@@ -480,13 +455,7 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 1,
-            monday = LocalDate.now().dayOfWeek.equals(DayOfWeek.MONDAY),
-            tuesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.TUESDAY),
-            wednesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.WEDNESDAY),
-            thursday = LocalDate.now().dayOfWeek.equals(DayOfWeek.THURSDAY),
-            friday = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
-            saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
-            sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
+            daysOfWeek = setOf(LocalDate.now().dayOfWeek),
             runsOnBankHolidays = true,
             noInstances = true,
           ).apply {
@@ -513,47 +482,21 @@ class ManageScheduledInstancesServiceTest {
           activitySchedule(
             activity = this,
             activityScheduleId = 1,
-            monday = LocalDate.now().dayOfWeek.equals(DayOfWeek.MONDAY),
-            tuesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.TUESDAY),
-            wednesday = LocalDate.now().dayOfWeek.equals(DayOfWeek.WEDNESDAY),
-            thursday = LocalDate.now().dayOfWeek.equals(DayOfWeek.THURSDAY),
-            friday = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
-            saturday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
-            sunday = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
+            daysOfWeek = setOf(LocalDate.now().dayOfWeek),
             noSlots = true,
           ).apply {
             this.suspensions.clear()
             this.addSlot(
-              ActivityScheduleSlot(
-                activityScheduleSlotId = 1,
-                weekNumber = 1,
-                activitySchedule = this,
-                startTime = LocalTime.of(9, 30),
-                endTime = LocalTime.of(11, 30),
-                mondayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.MONDAY),
-                tuesdayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.TUESDAY),
-                wednesdayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.WEDNESDAY),
-                thursdayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.THURSDAY),
-                fridayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
-                saturdayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
-                sundayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
-              ),
+              weekNumber = 1,
+              startTime = LocalTime.of(9, 30),
+              endTime = LocalTime.of(11, 30),
+              daysOfWeek = setOf(LocalDate.now().dayOfWeek),
             )
             this.addSlot(
-              ActivityScheduleSlot(
-                activityScheduleSlotId = 2,
-                weekNumber = 1,
-                activitySchedule = this,
-                startTime = LocalTime.of(13, 30),
-                endTime = LocalTime.of(15, 30),
-                mondayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.MONDAY),
-                tuesdayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.TUESDAY),
-                wednesdayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.WEDNESDAY),
-                thursdayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.THURSDAY),
-                fridayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.FRIDAY),
-                saturdayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.SATURDAY),
-                sundayFlag = LocalDate.now().dayOfWeek.equals(DayOfWeek.SUNDAY),
-              ),
+              weekNumber = 1,
+              startTime = LocalTime.of(13, 30),
+              endTime = LocalTime.of(15, 30),
+              daysOfWeek = setOf(LocalDate.now().dayOfWeek),
             )
           },
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonRegimeServiceTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonReg
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventPriorityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonPayBandRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonRegimeRepository
+import java.time.LocalTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonPayBand as EntityPrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonPayBand as ModelPrisonPayBand
 
@@ -277,5 +278,18 @@ class PrisonRegimeServiceTest {
 
     assertThat(result.start).isEqualTo("18:00")
     assertThat(result.end).isEqualTo("23:59")
+  }
+
+  @Test
+  fun `returns prison time slot map`() {
+    val prisonCode = "PBI"
+    whenever(prisonRegimeRepository.findByPrisonCode(prisonCode))
+      .thenReturn(prisonRegime())
+    val prisonTimeSlots = service.getPrisonTimeSlots(prisonCode)
+
+    assertThat(prisonTimeSlots.values).hasSize(3)
+    assertThat(prisonTimeSlots[TimeSlot.AM]).isEqualTo(LocalTime.of(9, 0) to LocalTime.of(12, 0))
+    assertThat(prisonTimeSlots[TimeSlot.PM]).isEqualTo(LocalTime.of(13, 0) to LocalTime.of(16, 30))
+    assertThat(prisonTimeSlots[TimeSlot.ED]).isEqualTo(LocalTime.of(18, 0) to LocalTime.of(20, 0))
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -156,7 +156,7 @@ class TransformFunctionsTest {
           activity = activity.toModelLite(),
           slots = listOf(
             ActivityScheduleSlot(
-              id = 1L,
+              id = 0,
               weekNumber = 1,
               startTime = timestamp.toLocalTime(),
               endTime = timestamp.toLocalTime().plusHours(1),


### PR DESCRIPTION
## Overview

This change primarily updates the `addSlot()` method to support adding slots for multi-week schedules, but also includes some improves around creating and removing instances.

Note: Because `createActivity()` and `updateActivity()` use the request models I will add tests for creating and updating multi-week schedules once those models have been updated.