### PR TITLE
SAA-1016 changes to support removal of attendances on reciept of a prisoner being released event.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
@@ -30,6 +30,7 @@ data class ScheduledInstance(
   @JoinColumn(name = "activity_schedule_id", nullable = false)
   val activitySchedule: ActivitySchedule,
 
+  // TODO ideally should be private
   @OneToMany(mappedBy = "scheduledInstance", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
   @Fetch(FetchMode.SUBSELECT)
   val attendances: MutableList<Attendance> = mutableListOf(),
@@ -125,6 +126,12 @@ data class ScheduledInstance(
     attendances
       .filterNot { it.attendanceReason?.code == AttendanceReasonEnum.SUSPENDED }
       .forEach(Attendance::uncancel)
+  }
+
+  fun remove(attendance: Attendance) {
+    require(attendances.contains(attendance)) { "Attendance record with ${attendance.attendanceId} does not exist on the scheduled instance" }
+
+    attendances.remove(attendance)
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceRepository.kt
@@ -25,10 +25,10 @@ interface AttendanceRepository : JpaRepository<Attendance, Long> {
       SELECT a
         FROM Attendance a
        WHERE a.scheduledInstance.activitySchedule.activity.prisonCode = :prisonCode
-         AND a.status = :attendanceStatus
+         AND (:attendanceStatus is null or a.status = :attendanceStatus)
          AND a.scheduledInstance.sessionDate >= :sessionDate
          AND a.prisonerNumber = :prisonerNumber
     """,
   )
-  fun findAttendancesOnOrAfterDateForPrisoner(prisonCode: String, sessionDate: LocalDate, attendanceStatus: AttendanceStatus, prisonerNumber: String): List<Attendance>
+  fun findAttendancesOnOrAfterDateForPrisoner(prisonCode: String, sessionDate: LocalDate, attendanceStatus: AttendanceStatus? = null, prisonerNumber: String): List<Attendance>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
@@ -35,7 +35,7 @@ class ActivitiesChangedEventHandler(
     if (rolloutPrisonRepository.findByCode(event.prisonCode())?.isActivitiesRolledOut() == true) {
       return when (event.action()) {
         Action.SUSPEND -> suspendPrisonerAllocationsAndAttendances(event).let { Outcome.success() }
-        Action.END -> deallocatePrisonerAllocations(event).let { Outcome.success() }
+        Action.END -> deallocatePrisonerAndRemoveFutureAttendances(event).let { Outcome.success() }
         else -> log.warn("Unable to process $event, unknown action").let { Outcome.failed() }
       }
     }
@@ -79,7 +79,7 @@ class ActivitiesChangedEventHandler(
     }
   }
 
-  private fun deallocatePrisonerAllocations(event: ActivitiesChangedEvent) =
+  private fun deallocatePrisonerAndRemoveFutureAttendances(event: ActivitiesChangedEvent) =
     allocationRepository.findByPrisonCodeAndPrisonerNumber(event.prisonCode(), event.prisonerNumber())
       .deallocateAffectedAllocations(DeallocationReason.TEMPORARY_ABSENCE)
       .also { log.info("Deallocated prisoner ${event.prisonerNumber()} at prison ${event.prisonCode()} from ${it.size} allocations.") }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandler.kt
@@ -86,7 +86,6 @@ class OffenderReceivedEventHandler(
             (attendance.scheduledInstance.sessionDate > now.toLocalDate())
         }
         .onEach { attendance ->
-          log.info("attendance ${attendance.attendanceId}")
           if (attendance.scheduledInstance.cancelled) {
             // If the schedule instance was cancelled (and still is) after the initial suspension then we need to cancel instead of unsuspend
             attendance.cancel(cancelledReason).also { log.info("Cancelled attendance ${attendance.attendanceId}") }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstanceTest.kt
@@ -181,4 +181,26 @@ class ScheduledInstanceTest {
       attendances.forEach { it.attendanceReason isEqualTo attendanceReason(AttendanceReasonEnum.SUSPENDED) }
     }
   }
+
+  @Test
+  fun `can remove attendance`() {
+    val attendance = instance.attendances.first()
+
+    assertThat(instance.attendances).contains(attendance)
+
+    instance.remove(attendance)
+
+    assertThat(instance.attendances).doesNotContain(attendance)
+  }
+
+  @Test
+  fun `fails to remove attendance if attendance not present`() {
+    val attendance = instance.attendances.first()
+
+    instance.remove(attendance)
+
+    assertThatThrownBy { instance.remove(attendance) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Attendance record with ${attendance.attendanceId} does not exist on the scheduled instance")
+  }
 }

--- a/src/test/resources/test_data/seed-offender-released-event-deletes-attendances.sql
+++ b/src/test/resources/test_data/seed-offender-released-event-deletes-attendances.sql
@@ -1,0 +1,50 @@
+--
+-- The time slots for the prison have been set at two extremes very early or very late to prevent test fragility with timings
+--
+INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
+VALUES(3, 'PVI', '00:01:00', '00:02:00', '13:00:00', '16:30:00', '23:58:00', '23:59:00');
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
+
+insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
+values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag)
+values (1, 1, '00:01:00', '00:02:00', true, true, true, true, true, true, true);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (2, 1, 'Maths ED', 2, 'L2', 'Location 2', 10, '2022-10-10');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag)
+values (2, 2, '23:58:00', '23:59:00', true, true, true, true, true, true, true);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (1, 1, 'A11111A', 10001, 1, '2022-10-10', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (2, 2, 'A11111A', 10001, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date, '00:01:00', '00:02:00', false, null, null, null, null);
+
+insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (1, 1, 'A11111A', null, null, null, null, 'WAITING', null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (2, current_date, '23:58:00', '23:59:00', true, current_timestamp, 'cancelled by some user', 'tutor sick', null);
+
+insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (2, 2, 'A11111A', null, null, null, null, 'WAITING', null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date + 1, '00:01:00', '00:02:00', true, current_timestamp, 'cancelled by some user', 'tutor sick', null);
+
+insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (3, 3, 'A11111A', null, null, null, null, 'WAITING', null, null, null);


### PR DESCRIPTION
This is the first of two changes.  This change is to allow for the removal of futures upon a prisoner being permanently released from prison.

Part two is to create an audit trail with the DPS audit service.