### PR TITLE
SAA-849: Fix flaky test

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
@@ -1493,7 +1493,7 @@ class ActivityServiceTest {
         weekNumber = 2,
         startTime = LocalTime.of(9, 0),
         endTime = LocalTime.of(12, 0),
-        daysOfWeek = setOf(tomorrow.plusDays(1).dayOfWeek),
+        daysOfWeek = setOf(tomorrow.dayOfWeek),
       )
     }
 


### PR DESCRIPTION
## Overview

Fixes flaky test caused by slot day falling out of week bounds during on weekends