### PR TITLE
Fix bug with the workplace risk assessment filter

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesService.kt
@@ -126,8 +126,8 @@ class CandidatesService(
     return suitableRiskLevels == null ||
 
       suitableRiskLevels.contains("NONE") &&
-        (prisoner.alerts ?: emptyList())
-          .none { it.alertType == "R" && riskAssessmentCodes.contains(it.alertCode) } ||
+      (prisoner.alerts ?: emptyList())
+        .none { it.alertType == "R" && riskAssessmentCodes.contains(it.alertCode) } ||
 
       suitableRiskLevels.contains(
         (prisoner.alerts ?: emptyList())


### PR DESCRIPTION
The previous build assumed that any alert code with type `R` must be one of `RLO, RME or RHI`. This is not the case, and there are other non workplace risk assessment alert codes with type R