### PR TITLE
SAA-1086 changes to fix API spec generation with the caseload header when using the Open API gen tool.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -91,7 +90,7 @@ class ActivityController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getActivityById(@PathVariable("activityId") activityId: Long): Activity =
     activityService.getActivityById(activityId)
 
@@ -306,7 +305,7 @@ class ActivityController(
     ],
   )
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN')")
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun create(
     principal: Principal,
     @Valid
@@ -431,7 +430,7 @@ class ActivityController(
     ],
   )
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN')")
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun update(
     @PathVariable("prisonCode") prisonCode: String,
     @PathVariable("activityId") activityId: Long,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -99,7 +98,7 @@ class ActivityScheduleController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getAllocationsBy(
     @PathVariable("scheduleId") scheduleId: Long,
     @RequestParam(
@@ -160,7 +159,7 @@ class ActivityScheduleController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getScheduleId(@PathVariable("scheduleId") scheduleId: Long) =
     scheduleService.getScheduleById(scheduleId)
 
@@ -287,7 +286,7 @@ class ActivityScheduleController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN')")
   fun candidates(
     @PathVariable("scheduleId") scheduleId: Long,
@@ -442,6 +441,7 @@ class ActivityScheduleController(
       ),
     ],
   )
+  @CaseloadHeader
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN')")
   fun deallocate(
     principal: Principal,
@@ -507,7 +507,7 @@ class ActivityScheduleController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getWaitingListApplicationsBy(@PathVariable("scheduleId") scheduleId: Long) =
     waitingListService.getWaitingListsBySchedule(scheduleId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationController.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -89,7 +88,7 @@ class AllocationController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getAllocationById(@PathVariable("allocationId") allocationId: Long) =
     allocationsService.getAllocationById(allocationId)
 
@@ -236,7 +235,7 @@ class AllocationController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_HUB_LEAD', 'ACTIVITY_ADMIN')")
   fun addToWaitingList(
     @PathVariable("prisonCode") prisonCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentController.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -69,7 +68,7 @@ class AppointmentController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getAppointmentById(@PathVariable("appointmentId") appointmentId: Long): Appointment =
     appointmentService.getAppointmentById(appointmentId)
 
@@ -117,7 +116,7 @@ class AppointmentController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun createAppointment(
     principal: Principal,
     @Valid

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentDetailsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentDetailsController.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -62,7 +60,7 @@ class AppointmentDetailsController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getAppointmentDetailsById(@PathVariable("appointmentId") appointmentId: Long): AppointmentDetails =
     appointmentDetailsService.getAppointmentDetailsById(appointmentId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentInstanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentInstanceController.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -62,7 +60,7 @@ class AppointmentInstanceController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getAppointmentInstanceById(@PathVariable("appointmentInstanceId") appointmentInstanceId: Long): AppointmentInstance =
     appointmentInstanceService.getAppointmentInstanceById(appointmentInstanceId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentOccurrenceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentOccurrenceController.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -89,7 +88,7 @@ class AppointmentOccurrenceController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun updateAppointmentOccurrence(
     @PathVariable("appointmentOccurrenceId") appointmentOccurrenceId: Long,
     @Valid
@@ -156,7 +155,7 @@ class AppointmentOccurrenceController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun cancelAppointmentOccurrence(
     @PathVariable("appointmentOccurrenceId") appointmentOccurrenceId: Long,
     @Valid
@@ -213,7 +212,7 @@ class AppointmentOccurrenceController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun searchAppointmentOccurrences(
     @PathVariable("prisonCode") prisonCode: String,
     @Valid

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentOccurrenceDetailsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentOccurrenceDetailsController.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -62,7 +60,7 @@ class AppointmentOccurrenceDetailsController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getAppointmentOccurrenceDetailsById(@PathVariable("appointmentOccurrenceId") appointmentOccurrenceId: Long): AppointmentOccurrenceDetails =
     appointmentOccurrenceDetailsService.getAppointmentOccurrenceDetailsById(appointmentOccurrenceId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/BulkAppointmentController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/BulkAppointmentController.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -70,7 +69,7 @@ class BulkAppointmentController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun bulkCreateAppointment(
     principal: Principal,
     @Valid

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/BulkAppointmentDetailsController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/BulkAppointmentDetailsController.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -62,7 +60,7 @@ class BulkAppointmentDetailsController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getBulkAppointmentDetailsById(@PathVariable("bulkAppointmentId") bulkAppointmentId: Long): BulkAppointmentDetails =
     bulkAppointmentDetailsService.getBulkAppointmentDetailsById(bulkAppointmentId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/CaseloadHeader.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/CaseloadHeader.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
+
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.enums.ParameterIn
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Parameter(
+  name = CASELOAD_ID,
+  `in` = ParameterIn.HEADER,
+  content = [Content(schema = Schema(implementation = String::class))],
+)
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+internal annotation class CaseloadHeader

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledInstanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledInstanceController.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -88,7 +87,7 @@ class ScheduledInstanceController(
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getScheduledInstanceById(
     @PathVariable("instanceId") instanceId: Long,
   ): ActivityScheduleInstance = scheduledInstanceService.getActivityScheduleInstanceById(instanceId)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/WaitingListApplicationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/WaitingListApplicationController.kt
@@ -1,8 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.Parameter
-import io.swagger.v3.oas.annotations.enums.ParameterIn
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -73,6 +71,6 @@ class WaitingListApplicationController(private val waitingListService: WaitingLi
       ),
     ],
   )
-  @Parameter(name = CASELOAD_ID, `in` = ParameterIn.HEADER)
+  @CaseloadHeader
   fun getWaitingListById(@PathVariable("waitingListId") id: Long) = waitingListService.getWaitingListBy(id)
 }


### PR DESCRIPTION
As part of this fix I have pulled the caseload header parameter out into its own annotation to save repetition/duplication.

Example before:

![image](https://github.com/ministryofjustice/hmpps-activities-management-api/assets/60104344/c6284fef-44cb-49db-9e78-82452583cb07)

Example after (note `string` now showing under caseload-id):

![image](https://github.com/ministryofjustice/hmpps-activities-management-api/assets/60104344/5623b538-c7bf-4cea-9f0b-076ac1364f96)
