### PR TITLE
SAA-1081 auditing the associated waiting list identifier with the prisoner allocated audit event if there is one.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -95,6 +95,8 @@ data class Allocation(
   var suspendedReason: String? = null
     private set
 
+  fun prisonCode() = activitySchedule.activity.prisonCode
+
   private fun activitySummary() = activitySchedule.activity.summary
 
   /**

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AuditableEntityListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AuditableEntityListener.kt
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Component
 import toActivityCreatedEvent
 import toActivityUpdatedEvent
 import toPrisonerAddedToWaitingListEvent
-import toPrisonerAllocatedEvent
 import toPrisonerDeallocatedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.AuditableEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AuditService
@@ -30,7 +29,6 @@ class AuditableEntityListener {
   fun onCreate(entity: Any) {
     when (entity) {
       is Activity -> audit(entity.toActivityCreatedEvent(), "Failed to audit activity creation event for activity id ${entity.activityId}")
-      is Allocation -> audit(entity.toPrisonerAllocatedEvent(), "Failed to audit prisoner allocation event for allocation id ${entity.allocationId}")
       is WaitingList -> audit(entity.toPrisonerAddedToWaitingListEvent(), "Failed to audit prisoner added to waiting list id ${entity.waitingListId}")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/WaitingList.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/WaitingList.kt
@@ -62,10 +62,23 @@ data class WaitingList(
 
   fun isStatus(vararg s: WaitingListStatus) = s.any { it == status }
 
-  fun allocated(allocation: Allocation) {
-    this.status = WaitingListStatus.ALLOCATED
-    this.allocation = allocation
-  }
+  fun allocated(allocation: Allocation) =
+    apply {
+      require(allocation.prisonCode() == prisonCode) {
+        "Allocation ${allocation.allocationId} prison does not match with waiting list $waitingListId"
+      }
+
+      require(allocation.prisonerNumber == prisonerNumber) {
+        "Allocation ${allocation.allocationId} prisoner number does not match with waiting list $waitingListId"
+      }
+
+      require(status != WaitingListStatus.ALLOCATED) {
+        "Waiting list $waitingListId is already allocated"
+      }
+
+      this.status = WaitingListStatus.ALLOCATED
+      this.allocation = allocation
+    }
 }
 
 enum class WaitingListStatus {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/audit/AuditableEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/audit/AuditableEvent.kt
@@ -32,7 +32,7 @@ abstract class AuditableEvent(
     endTime: LocalTime? = null,
     createdAt: LocalDateTime? = null,
     createdBy: String? = null,
-  ) = JSONObject.toJSONString(
+  ): String = JSONObject.toJSONString(
     buildMap<String, Any> {
       activityId?.let { put("activityId", it) }
       activityName?.let { put("activityName", it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/audit/PrisonerAllocatedEvent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/audit/PrisonerAllocatedEvent.kt
@@ -10,13 +10,14 @@ class PrisonerAllocatedEvent(
   val prisonerNumber: String,
   val scheduleId: Long,
   val scheduleDescription: String,
+  val waitingListId: Long? = null,
   createdAt: LocalDateTime,
-
 ) : AuditableEvent(
   auditType = AuditType.PRISONER,
   auditEventType = AuditEventType.PRISONER_ALLOCATED,
   details = "Prisoner $prisonerNumber was allocated to " +
-    "activity '$activityName'($activityId) and schedule $scheduleDescription($scheduleId)",
+    "activity '$activityName'($activityId) and schedule $scheduleDescription($scheduleId)" +
+    (waitingListId?.let { " for waiting list '$it'" } ?: ""),
   createdAt = createdAt,
 ),
   HmppsAuditable,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/AuditTransformations.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/AuditTransformations.kt
@@ -25,13 +25,14 @@ fun EntityActivity.toActivityUpdatedEvent() = ActivityUpdatedEvent(
   createdAt = updatedTime!!,
 )
 
-fun EntityAllocation.toPrisonerAllocatedEvent() = PrisonerAllocatedEvent(
+fun EntityAllocation.toPrisonerAllocatedEvent(waitingListId: Long? = null) = PrisonerAllocatedEvent(
   activityId = activitySchedule.activity.activityId,
   activityName = activitySchedule.activity.summary,
   prisonCode = activitySchedule.activity.prisonCode,
   prisonerNumber = prisonerNumber,
   scheduleId = activitySchedule.activityScheduleId,
   scheduleDescription = activitySchedule.description,
+  waitingListId = waitingListId,
   createdAt = allocatedTime,
 )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AuditableEntityListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AuditableEntityListenerTest.kt
@@ -70,24 +70,6 @@ class AuditableEntityListenerTest(@Autowired private val listener: AuditableEnti
   }
 
   @Test
-  fun `prisoner allocation audit event raised on creation`() {
-    listener.onCreate(allocation)
-
-    verify(auditService).logEvent(prisonerAllocatedCaptor.capture())
-    verifyNoMoreInteractions(auditService)
-
-    with(prisonerAllocatedCaptor.firstValue) {
-      assertThat(activityId).isEqualTo(1)
-      assertThat(activityName).isEqualTo("Maths")
-      assertThat(prisonCode).isEqualTo(caseLoad)
-      assertThat(prisonerNumber).isEqualTo("A1234AA")
-      assertThat(scheduleId).isEqualTo(1)
-      assertThat(scheduleDescription).isNotNull
-      assertThat(createdAt).isNotNull
-    }
-  }
-
-  @Test
   fun `prisoner deallocation audit event raised on update`() {
     listener.onUpdate(allocation.deallocateNow())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/WaitingListTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/WaitingListTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.waitingList
@@ -19,9 +20,52 @@ class WaitingListTest {
   fun `allocated sets the status of a waiting list application to ALLOCATED and sets the allocation`() {
     val allocation = allocation()
 
-    with(waitingList().apply { allocated(allocation) }) {
+    with(
+      waitingList(
+        prisonCode = allocation.prisonCode(),
+        prisonerNumber = allocation.prisonerNumber,
+      ).apply { allocated(allocation) },
+    ) {
       assertThat(this.status).isEqualTo(WaitingListStatus.ALLOCATED)
       assertThat(this.allocation).isEqualTo(allocation)
     }
+  }
+
+  @Test
+  fun `allocated fails if already allocated`() {
+    val allocation = allocation()
+
+    val waitingList =
+      waitingList(prisonCode = allocation.prisonCode(), prisonerNumber = allocation.prisonerNumber).apply {
+        allocated(allocation)
+      }
+
+    assertThatThrownBy { waitingList.allocated(allocation) }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Waiting list ${waitingList.waitingListId} is already allocated")
+  }
+
+  @Test
+  fun `allocated fails if allocation belongs to a different prisoner`() {
+    val allocation = allocation().copy(prisonerNumber = "XYZ")
+    val waitingList = waitingList(prisonerNumber = "ABC", prisonCode = allocation.prisonCode())
+
+    assertThatThrownBy {
+      waitingList.allocated(allocation)
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Allocation ${allocation.allocationId} prisoner number does not match with waiting list ${waitingList.waitingListId}")
+  }
+
+  @Test
+  fun `allocated fails if allocation belongs to a different prison`() {
+    val allocation = allocation().copy(prisonerNumber = "ABC")
+    val waitingList = waitingList(prisonCode = allocation.prisonCode().plus("X"), prisonerNumber = "ABC")
+
+    assertThatThrownBy {
+      waitingList.allocated(allocation)
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Allocation ${allocation.allocationId} prison does not match with waiting list ${waitingList.waitingListId}")
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -117,7 +117,7 @@ internal fun activityCategory2(code: String = "category code 2") =
     description = "category description 2",
   )
 
-internal fun schedule() = activityEntity().schedules().first()
+internal fun schedule(prisonCode: String = moorlandPrisonCode) = activityEntity(prisonCode = prisonCode).schedules().first()
 
 internal fun attendanceReasons() = mapOf(
   "SICK" to AttendanceReason(1, AttendanceReasonEnum.SICK, "Sick", false, true, true, false, false, false, true, 1, "Maps to ACCAB in NOMIS"),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/audit/PrisonerAllocatedEventTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/audit/PrisonerAllocatedEventTest.kt
@@ -9,29 +9,32 @@ class PrisonerAllocatedEventTest : AuditableEventTestBase() {
 
   @Test
   fun `returns correct type`() {
-    val event = createEvent()
-    assertThat(event.auditEventType).isEqualTo(AuditEventType.PRISONER_ALLOCATED)
+    assertThat(createEvent().auditEventType).isEqualTo(AuditEventType.PRISONER_ALLOCATED)
   }
 
   @Test
   fun `returns correct string representation`() {
-    val event = createEvent()
     val expectedToString = "Prisoner AA12346 was allocated to activity 'Some Activity'(1) and schedule " +
       "Some schedule(42). Event created on 2023-03-22 at 09:00:03 by Bob."
-    assertThat(event.toString()).isEqualTo(expectedToString)
+    assertThat(createEvent().toString()).isEqualTo(expectedToString)
+  }
+
+  @Test
+  fun `returns correct string representation when on waiting list`() {
+    val expectedToString = "Prisoner AA12346 was allocated to activity 'Some Activity'(1) and schedule " +
+      "Some schedule(42) for waiting list '100'. Event created on 2023-03-22 at 09:00:03 by Bob."
+    assertThat(createEvent(withWaitingListId = 100).toString()).isEqualTo(expectedToString)
   }
 
   @Test
   fun `returns the correct json representation`() {
-    val event = createEvent()
     val expectedJson =
       """{"activityId":1,"activityName":"Some Activity","prisonCode":"PBI","prisonerNumber":"AA12346","scheduleId":42,"createdAt":"2023-03-22T09:00:03","createdBy":"Bob"}"""
-    assertThat(event.toJson()).isEqualTo(expectedJson)
+    assertThat(createEvent().toJson()).isEqualTo(expectedJson)
   }
 
   @Test
   fun `returns the correct LocalAuditRecord representation`() {
-    val event = createEvent()
     val expectedLocalAuditRecord = LocalAuditRecord(
       username = "Bob",
       auditType = AuditType.PRISONER,
@@ -45,20 +48,20 @@ class PrisonerAllocatedEventTest : AuditableEventTestBase() {
         "Event created on 2023-03-22 at 09:00:03 by Bob.",
     )
 
-    assertThat(event.toLocalAuditRecord()).isEqualTo(expectedLocalAuditRecord)
+    assertThat(createEvent().toLocalAuditRecord()).isEqualTo(expectedLocalAuditRecord)
   }
 
-  private fun createEvent(): PrisonerAllocatedEvent {
+  private fun createEvent(withWaitingListId: Long? = null): PrisonerAllocatedEvent {
     val createdAt = LocalDateTime.of(2023, 3, 22, 9, 0, 3)
     return PrisonerAllocatedEvent(
-      1,
-      "Some Activity",
-      "PBI",
-      "AA12346",
-      42,
-      "Some schedule",
-      createdAt,
-
+      activityId = 1,
+      activityName = "Some Activity",
+      prisonCode = "PBI",
+      prisonerNumber = "AA12346",
+      scheduleId = 42,
+      scheduleDescription = "Some schedule",
+      waitingListId = withWaitingListId,
+      createdAt = createdAt,
     )
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
@@ -3,10 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -23,29 +23,40 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSou
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activeAllocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activitySchedule
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.prisonPayBandsLowMediumHigh
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.schedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.waitingList
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.PrisonerAllocatedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.PrisonerAllocationRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.PrisonerDeallocationRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonPayBandRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.WaitingListRepository
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.addCaseloadIdToRequestHeader
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.clearCaseloadIdFromRequestHeader
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.FakeCaseLoad
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.FakeSecurityContext
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelAllocations
 import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.temporal.ChronoUnit
 import java.util.Optional
 
+@ExtendWith(FakeSecurityContext::class, FakeCaseLoad::class)
 class ActivityScheduleServiceTest {
 
   private val repository: ActivityScheduleRepository = mock()
   private val prisonApiClient: PrisonApiClient = mock()
   private val prisonPayBandRepository: PrisonPayBandRepository = mock()
   private val waitingListRepository: WaitingListRepository = mock()
-  private val service = ActivityScheduleService(repository, prisonApiClient, prisonPayBandRepository, waitingListRepository)
+  private val auditService: AuditService = mock()
+  private val auditCaptor = argumentCaptor<PrisonerAllocatedEvent>()
+  private val service =
+    ActivityScheduleService(repository, prisonApiClient, prisonPayBandRepository, waitingListRepository, auditService)
 
-  private val caseLoad = "MDI"
+  private val caseLoad = pentonvillePrisonCode
 
   private val prisoner = InmateDetail(
     agencyId = caseLoad,
@@ -61,20 +72,9 @@ class ActivityScheduleServiceTest {
     bookingId = 1,
   )
 
-  @BeforeEach
-  fun setUp() {
-    addCaseloadIdToRequestHeader(caseLoad)
-  }
-
-  @AfterEach
-  fun tearDown() {
-    clearCaseloadIdFromRequestHeader()
-  }
-
   @Test
   fun `current allocations for a given schedule are returned for current date`() {
-    addCaseloadIdToRequestHeader(caseLoad)
-    val schedule = schedule().apply {
+    val schedule = schedule(pentonvillePrisonCode).apply {
       allocations().first().startDate = LocalDate.now()
     }
 
@@ -88,8 +88,7 @@ class ActivityScheduleServiceTest {
 
   @Test
   fun `ended allocations for a given schedule are not returned`() {
-    addCaseloadIdToRequestHeader(caseLoad)
-    val schedule = schedule().apply {
+    val schedule = schedule(pentonvillePrisonCode).apply {
       allocations().first().apply { deallocateNowWithReason(DeallocationReason.ENDED) }
     }
 
@@ -109,7 +108,6 @@ class ActivityScheduleServiceTest {
     val schedule = mock<ActivitySchedule>()
     val activity = mock<Activity>()
 
-    addCaseloadIdToRequestHeader(caseLoad)
     whenever(schedule.activity).thenReturn(activity)
     whenever(activity.prisonCode).thenReturn(caseLoad)
     whenever(schedule.allocations()).thenReturn(listOf(active, suspended, ended, future))
@@ -188,7 +186,7 @@ class ActivityScheduleServiceTest {
 
     whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
 
-    DeallocationReason.values().filter { !it.displayed }.map { it.name }.forEach { reasonCode ->
+    DeallocationReason.entries.filter { !it.displayed }.map { it.name }.forEach { reasonCode ->
       assertThatThrownBy {
         service.deallocatePrisoners(
           schedule.activityScheduleId,
@@ -206,7 +204,7 @@ class ActivityScheduleServiceTest {
 
   @Test
   fun `allocate throws exception for start date before activity start date`() {
-    val schedule = activitySchedule(activityEntity())
+    val schedule = activitySchedule(activityEntity(prisonCode = pentonvillePrisonCode))
     schedule.activity.startDate = LocalDate.now().plusDays(2)
 
     whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
@@ -229,7 +227,7 @@ class ActivityScheduleServiceTest {
 
   @Test
   fun `allocate throws exception for end date after activity end date`() {
-    val schedule = activitySchedule(activityEntity())
+    val schedule = activitySchedule(activityEntity(prisonCode = pentonvillePrisonCode))
     schedule.activity.endDate = TimeSource.tomorrow()
 
     whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
@@ -253,7 +251,7 @@ class ActivityScheduleServiceTest {
 
   @Test
   fun `allocate throws exception for end date before activity start date`() {
-    val schedule = activitySchedule(activityEntity())
+    val schedule = activitySchedule(activityEntity(prisonCode = pentonvillePrisonCode))
 
     whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
     whenever(prisonPayBandRepository.findByPrisonCode(caseLoad)).thenReturn(prisonPayBandsLowMediumHigh(caseLoad))
@@ -297,16 +295,73 @@ class ActivityScheduleServiceTest {
   }
 
   @Test
-  fun `allocate updates any APPROVED waitlist applications to ALLOCATED status`() {
-    val schedule = activitySchedule(activityEntity())
-    val waitingListEntity = waitingList(status = WaitingListStatus.APPROVED)
+  fun `successful allocation is audited`() {
+    val schedule = activitySchedule(activity = activityEntity(activityId = 100, prisonCode = pentonvillePrisonCode), activityScheduleId = 200, noAllocations = true)
+    schedule.allocations() hasSize 0
+
+    whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
+    whenever(prisonPayBandRepository.findByPrisonCode(caseLoad)).thenReturn(prisonPayBandsLowMediumHigh(caseLoad))
+    whenever(prisonApiClient.getPrisonerDetails("654321", fullInfo = false)).doReturn(Mono.just(prisoner))
+    whenever(prisonApiClient.getPrisonerDetails("654321", fullInfo = false)).doReturn(Mono.just(prisoner))
+    whenever(repository.saveAndFlush(any())).doReturn(schedule)
+    whenever(
+      waitingListRepository.findByPrisonCodeAndPrisonerNumberAndActivitySchedule(
+        caseLoad,
+        "654321",
+        schedule,
+      ),
+    ).thenReturn(emptyList())
+
+    service.allocatePrisoner(
+      schedule.activityScheduleId,
+      PrisonerAllocationRequest(
+        "654321",
+        1,
+        TimeSource.tomorrow(),
+      ),
+      "by test",
+    )
+
+    with(schedule.allocations().single()) {
+      prisonerNumber isEqualTo "654321"
+    }
+
+    verify(auditService).logEvent(auditCaptor.capture())
+
+    with(auditCaptor.firstValue) {
+      activityId isEqualTo 100
+      activityName isEqualTo schedule.activity.summary
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "654321"
+      scheduleId isEqualTo 200
+      scheduleDescription isEqualTo schedule.description
+      waitingListId isEqualTo null
+      createdAt isCloseTo LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)
+    }
+  }
+
+  @Test
+  fun `allocation updates APPROVED waiting list application to ALLOCATED status when present and is audited`() {
+    val schedule = activitySchedule(activity = activityEntity(activityId = 100, prisonCode = pentonvillePrisonCode), activityScheduleId = 200, noAllocations = true)
+    schedule.allocations() hasSize 0
+
+    val waitingListEntity = waitingList(
+      prisonCode = schedule.activity.prisonCode,
+      status = WaitingListStatus.APPROVED,
+    ).copy(waitingListId = 300)
 
     whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
     whenever(prisonPayBandRepository.findByPrisonCode(caseLoad)).thenReturn(prisonPayBandsLowMediumHigh(caseLoad))
     whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = false)).doReturn(Mono.just(prisoner))
     whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = false)).doReturn(Mono.just(prisoner))
     whenever(repository.saveAndFlush(any())).doReturn(schedule)
-    whenever(waitingListRepository.findByPrisonCodeAndPrisonerNumberAndActivitySchedule(caseLoad, "123456", schedule)).thenReturn(listOf(waitingListEntity))
+    whenever(
+      waitingListRepository.findByPrisonCodeAndPrisonerNumberAndActivitySchedule(
+        caseLoad,
+        "123456",
+        schedule,
+      ),
+    ).thenReturn(listOf(waitingListEntity))
 
     service.allocatePrisoner(
       schedule.activityScheduleId,
@@ -318,10 +373,63 @@ class ActivityScheduleServiceTest {
       "by test",
     )
 
+    with(schedule.allocations().single()) {
+      prisonerNumber isEqualTo "123456"
+    }
+
     with(waitingListEntity) {
       assertThat(status).isEqualTo(WaitingListStatus.ALLOCATED)
       assertThat(allocation?.allocatedBy).isEqualTo("by test")
       assertThat(allocation?.prisonerNumber).isEqualTo("123456")
     }
+
+    verify(auditService).logEvent(auditCaptor.capture())
+
+    with(auditCaptor.firstValue) {
+      activityId isEqualTo 100
+      activityName isEqualTo schedule.activity.summary
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "123456"
+      scheduleId isEqualTo 200
+      scheduleDescription isEqualTo schedule.description
+      waitingListId isEqualTo 300
+      createdAt isCloseTo LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES)
+    }
+  }
+
+  @Test
+  fun `allocation fails if more than one approved waiting list`() {
+    val schedule = activitySchedule(activity = activityEntity(prisonCode = pentonvillePrisonCode))
+    val waitingLists = listOf(
+      waitingList(prisonCode = schedule.activity.prisonCode, status = WaitingListStatus.APPROVED).copy(waitingListId = 1),
+      waitingList(prisonCode = schedule.activity.prisonCode, status = WaitingListStatus.APPROVED).copy(waitingListId = 2),
+    )
+
+    whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
+    whenever(prisonPayBandRepository.findByPrisonCode(caseLoad)).thenReturn(prisonPayBandsLowMediumHigh(caseLoad))
+    whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = false)).doReturn(Mono.just(prisoner))
+    whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = false)).doReturn(Mono.just(prisoner))
+    whenever(repository.saveAndFlush(any())).doReturn(schedule)
+    whenever(
+      waitingListRepository.findByPrisonCodeAndPrisonerNumberAndActivitySchedule(
+        caseLoad,
+        "123456",
+        schedule,
+      ),
+    ).thenReturn(waitingLists)
+
+    assertThatThrownBy {
+      service.allocatePrisoner(
+        schedule.activityScheduleId,
+        PrisonerAllocationRequest(
+          "123456",
+          1,
+          TimeSource.tomorrow(),
+        ),
+        "by test",
+      )
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Prisoner has more than one APPROVED waiting list. A prisoner can only have one approved waiting list")
   }
 }


### PR DESCRIPTION
This change moves away from using the audit event listener. The main reason being it is getting too difficult to determine the nature of the audit event.

Note: there is no integration test change here as part of this PR, the events raised stays the same the prisoner allocated event.