### PR TITLE
SAA-1030 intial commit for supporting declining waiting lists.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/WaitingListRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/WaitingListRepository.kt
@@ -14,4 +14,6 @@ interface WaitingListRepository : JpaRepository<WaitingList, Long> {
   ): List<WaitingList>
 
   fun findByActivitySchedule(activitySchedule: ActivitySchedule): List<WaitingList>
+
+  fun findByPrisonCodeAndPrisonerNumberIn(prisonCode: String, prisonerNumbers: Set<String>): List<WaitingList>
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/WaitingListTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/WaitingListTest.kt
@@ -4,6 +4,7 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.waitingList
 
 class WaitingListTest {
@@ -67,5 +68,117 @@ class WaitingListTest {
     }
       .isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Allocation ${allocation.allocationId} prison does not match with waiting list ${waitingList.waitingListId}")
+  }
+
+  @Test
+  fun `can decline pending waiting list`() {
+    val waitingList = waitingList(initialStatus = WaitingListStatus.PENDING)
+    waitingList.status isEqualTo WaitingListStatus.PENDING
+    waitingList.declinedReason isEqualTo null
+
+    waitingList.status = WaitingListStatus.DECLINED
+    waitingList.declinedReason = "Released"
+
+    with(waitingList) {
+      status isEqualTo WaitingListStatus.DECLINED
+      declinedReason isEqualTo "Released"
+    }
+  }
+
+  @Test
+  fun `can decline approved waiting list`() {
+    val waitingList = waitingList(initialStatus = WaitingListStatus.APPROVED)
+    waitingList.status isEqualTo WaitingListStatus.APPROVED
+    waitingList.declinedReason isEqualTo null
+
+    waitingList.status = WaitingListStatus.DECLINED
+    waitingList.declinedReason = "Released"
+
+    with(waitingList) {
+      status isEqualTo WaitingListStatus.DECLINED
+      declinedReason isEqualTo "Released"
+    }
+  }
+
+  @Test
+  fun `cannot decline allocated waiting list`() {
+    val waitingList = waitingList(initialStatus = WaitingListStatus.ALLOCATED)
+    waitingList.status isEqualTo WaitingListStatus.ALLOCATED
+    waitingList.declinedReason isEqualTo null
+
+    assertThatThrownBy {
+      waitingList.status = WaitingListStatus.DECLINED
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Only pending and approved waiting lists can be declined")
+
+    with(waitingList) {
+      status isEqualTo WaitingListStatus.ALLOCATED
+      declinedReason isEqualTo null
+    }
+  }
+
+  @Test
+  fun `can decline removed waiting list`() {
+    val waitingList = waitingList(initialStatus = WaitingListStatus.REMOVED)
+    waitingList.status isEqualTo WaitingListStatus.REMOVED
+    waitingList.declinedReason isEqualTo null
+
+    assertThatThrownBy {
+      waitingList.status = WaitingListStatus.DECLINED
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Only pending and approved waiting lists can be declined")
+
+    with(waitingList) {
+      status isEqualTo WaitingListStatus.REMOVED
+      declinedReason isEqualTo null
+    }
+  }
+
+  @Test
+  fun `can only set declined reason for declined waiting lists`() {
+    val waitingList = waitingList(initialStatus = WaitingListStatus.REMOVED)
+    waitingList.status isEqualTo WaitingListStatus.REMOVED
+    waitingList.declinedReason isEqualTo null
+
+    assertThatThrownBy {
+      waitingList.declinedReason = "This should not be set"
+    }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Cannot set the declined reason when status is not declined")
+
+    with(waitingList) {
+      status isEqualTo WaitingListStatus.REMOVED
+      declinedReason isEqualTo null
+    }
+  }
+
+  @Test
+  fun `can approve declined waiting list`() {
+    val waitingList = waitingList(initialStatus = WaitingListStatus.DECLINED).apply { declinedReason = "Declined" }
+    waitingList.status isEqualTo WaitingListStatus.DECLINED
+    waitingList.declinedReason isEqualTo "Declined"
+
+    waitingList.status = WaitingListStatus.APPROVED
+
+    with(waitingList) {
+      status isEqualTo WaitingListStatus.APPROVED
+      declinedReason isEqualTo null
+    }
+  }
+
+  @Test
+  fun `can change declined waiting list to pending`() {
+    val waitingList = waitingList(initialStatus = WaitingListStatus.DECLINED).apply { declinedReason = "Declined" }
+    waitingList.status isEqualTo WaitingListStatus.DECLINED
+    waitingList.declinedReason isEqualTo "Declined"
+
+    waitingList.status = WaitingListStatus.PENDING
+
+    with(waitingList) {
+      status isEqualTo WaitingListStatus.PENDING
+      declinedReason isEqualTo null
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -345,28 +345,29 @@ internal fun ActivityScheduleSlot.runEveryDayOfWeek() {
 }
 
 fun waitingList(
+  waitingListId: Long = 1,
   prisonCode: String = pentonvillePrisonCode,
   prisonerNumber: String = "123456",
-  status: WaitingListStatus = WaitingListStatus.DECLINED,
+  initialStatus: WaitingListStatus = WaitingListStatus.DECLINED,
+  applicationDate: LocalDate = TimeSource.today(),
+  requestedBy: String = "Fred",
+  comments: String? = null,
 ): WaitingList {
   val schedule = activityEntity(prisonCode = prisonCode).schedules().first()
   val allocation = schedule.allocations().first()
 
   return WaitingList(
-    waitingListId = 99,
+    waitingListId = waitingListId,
     prisonCode = prisonCode,
     activitySchedule = schedule,
     prisonerNumber = prisonerNumber,
     bookingId = 100L,
-    applicationDate = TimeSource.today(),
-    requestedBy = "Fred",
-    comments = "Some random test comments",
-    status = status,
+    applicationDate = applicationDate,
+    requestedBy = requestedBy,
+    comments = comments,
     createdBy = "Bob",
+    initialStatus = initialStatus,
   ).apply {
     this.allocation = allocation
-    this.updatedBy = "Test"
-    this.updatedTime = TimeSource.now()
-    this.declinedReason = "Needs to attend level one activity first"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
@@ -306,7 +306,11 @@ class ActivityScheduleServiceTest {
 
   @Test
   fun `successful allocation is audited`() {
-    val schedule = activitySchedule(activity = activityEntity(activityId = 100, prisonCode = pentonvillePrisonCode), activityScheduleId = 200, noAllocations = true)
+    val schedule = activitySchedule(
+      activity = activityEntity(activityId = 100, prisonCode = pentonvillePrisonCode),
+      activityScheduleId = 200,
+      noAllocations = true,
+    )
     schedule.allocations() hasSize 0
 
     whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
@@ -358,13 +362,18 @@ class ActivityScheduleServiceTest {
 
   @Test
   fun `allocation updates APPROVED waiting list application to ALLOCATED status when present and is audited`() {
-    val schedule = activitySchedule(activity = activityEntity(activityId = 100, prisonCode = pentonvillePrisonCode), activityScheduleId = 200, noAllocations = true)
+    val schedule = activitySchedule(
+      activity = activityEntity(activityId = 100, prisonCode = pentonvillePrisonCode),
+      activityScheduleId = 200,
+      noAllocations = true,
+    )
     schedule.allocations() hasSize 0
 
     val waitingListEntity = waitingList(
       prisonCode = schedule.activity.prisonCode,
-      status = WaitingListStatus.APPROVED,
-    ).copy(waitingListId = 300)
+      initialStatus = WaitingListStatus.APPROVED,
+      waitingListId = 300,
+    )
 
     whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))
     whenever(prisonPayBandRepository.findByPrisonCode(caseLoad)).thenReturn(prisonPayBandsLowMediumHigh(caseLoad))
@@ -417,8 +426,16 @@ class ActivityScheduleServiceTest {
   fun `allocation fails if more than one approved waiting list`() {
     val schedule = activitySchedule(activity = activityEntity(prisonCode = pentonvillePrisonCode))
     val waitingLists = listOf(
-      waitingList(prisonCode = schedule.activity.prisonCode, status = WaitingListStatus.APPROVED).copy(waitingListId = 1),
-      waitingList(prisonCode = schedule.activity.prisonCode, status = WaitingListStatus.APPROVED).copy(waitingListId = 2),
+      waitingList(
+        prisonCode = schedule.activity.prisonCode,
+        initialStatus = WaitingListStatus.APPROVED,
+        waitingListId = 1,
+      ),
+      waitingList(
+        prisonCode = schedule.activity.prisonCode,
+        initialStatus = WaitingListStatus.APPROVED,
+        waitingListId = 2,
+      ),
     )
 
     whenever(repository.findById(schedule.activityScheduleId)).doReturn(Optional.of(schedule))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
@@ -521,7 +521,7 @@ class CandidatesServiceTest {
       val allPrisoners = PrisonerSearchPrisonerFixture.pagedResult(
         prisonerNumber = "A1234BC",
       )
-      val waitingList = listOf(waitingList(activity.prisonCode, "A1234BC", WaitingListStatus.REMOVED))
+      val waitingList = listOf(waitingList(prisonCode = activity.prisonCode, prisonerNumber = "A1234BC", initialStatus = WaitingListStatus.REMOVED))
 
       candidatesSetup(activity, allPrisoners, waitingList)
 
@@ -552,7 +552,7 @@ class CandidatesServiceTest {
       val allPrisoners = PrisonerSearchPrisonerFixture.pagedResult(
         prisonerNumber = "A1234BC",
       )
-      val waitingList = listOf(waitingList(activity.prisonCode, "A1234BC", WaitingListStatus.PENDING))
+      val waitingList = listOf(waitingList(prisonCode = activity.prisonCode, prisonerNumber = "A1234BC", initialStatus = WaitingListStatus.PENDING))
 
       candidatesSetup(activity, allPrisoners, waitingList)
 
@@ -573,7 +573,7 @@ class CandidatesServiceTest {
       val allPrisoners = PrisonerSearchPrisonerFixture.pagedResult(
         prisonerNumber = "A1234BC",
       )
-      val waitingList = listOf(waitingList(activity.prisonCode, "A1234BC", WaitingListStatus.APPROVED))
+      val waitingList = listOf(waitingList(prisonCode = activity.prisonCode, prisonerNumber = "A1234BC", initialStatus = WaitingListStatus.APPROVED))
 
       candidatesSetup(activity, allPrisoners, waitingList)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
@@ -108,11 +108,23 @@ class WaitingListServiceTest {
       status = WaitingListStatus.PENDING,
     )
 
-    assertThatThrownBy { service.addPrisoner(DEFAULT_CASELOAD_PENTONVILLE, request.copy(status = WaitingListStatus.ALLOCATED), "test") }
+    assertThatThrownBy {
+      service.addPrisoner(
+        DEFAULT_CASELOAD_PENTONVILLE,
+        request.copy(status = WaitingListStatus.ALLOCATED),
+        "test",
+      )
+    }
       .isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Only statuses of PENDING, APPROVED and DECLINED are allowed when adding a prisoner to a waiting list")
 
-    assertThatThrownBy { service.addPrisoner(DEFAULT_CASELOAD_PENTONVILLE, request.copy(status = WaitingListStatus.REMOVED), "test") }
+    assertThatThrownBy {
+      service.addPrisoner(
+        DEFAULT_CASELOAD_PENTONVILLE,
+        request.copy(status = WaitingListStatus.REMOVED),
+        "test",
+      )
+    }
       .isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Only statuses of PENDING, APPROVED and DECLINED are allowed when adding a prisoner to a waiting list")
   }
@@ -391,8 +403,8 @@ class WaitingListServiceTest {
       applicationDate = TimeSource.today(),
       requestedBy = "Fred",
       comments = "Some random test comments",
-      status = WaitingListStatus.DECLINED,
       createdBy = "Bob",
+      initialStatus = WaitingListStatus.DECLINED,
     ).apply {
       this.allocation = allocation
       this.updatedBy = "Test"
@@ -442,7 +454,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `get waiting list by id`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(waitingListId = 99)
+    val waitingList = waitingList(waitingListId = 99, prisonCode = pentonvillePrisonCode)
 
     whenever(waitingListRepository.findById(waitingList.waitingListId)) doReturn Optional.of(waitingList)
 
@@ -451,7 +463,12 @@ class WaitingListServiceTest {
 
   @Test
   fun `get waiting list by id fails if does not have case load access`() {
-    whenever(waitingListRepository.findById(99)) doReturn Optional.of(waitingList("WRONG_CASELOAD").copy(waitingListId = 99))
+    whenever(waitingListRepository.findById(99)) doReturn Optional.of(
+      waitingList(
+        waitingListId = 99,
+        prisonCode = "WRONG_CASELOAD",
+      ),
+    )
 
     assertThatThrownBy { service.getWaitingListBy(99) }.isInstanceOf(CaseloadAccessException::class.java)
   }
@@ -467,7 +484,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update the application date`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(applicationDate = TimeSource.today()).also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, applicationDate = TimeSource.today()).also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -488,7 +505,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update the application date no-op if the same`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(applicationDate = TimeSource.today()).also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, applicationDate = TimeSource.today()).also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -509,7 +526,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update the application date fails if after creation date`() {
-    val waitingList = waitingList(pentonvillePrisonCode).also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode).also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -528,7 +545,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update requested by`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(requestedBy = "Fred").also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, requestedBy = "Fred").also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -549,7 +566,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update requested by no-op if the same`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(requestedBy = "Fred").also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, requestedBy = "Fred").also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -570,7 +587,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update requested fails if blank or empty`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(requestedBy = "Fred").also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, requestedBy = "Fred").also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -599,7 +616,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update comments`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(comments = "Initial comments").also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, comments = "Initial comments").also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -620,7 +637,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update comments no-op if the same`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(comments = "Initial comments").also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, comments = "Initial comments").also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -641,7 +658,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update status to APPROVED`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(status = WaitingListStatus.PENDING).also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, initialStatus = WaitingListStatus.PENDING).also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -668,7 +685,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update status to DECLINED`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(status = WaitingListStatus.PENDING).also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, initialStatus = WaitingListStatus.PENDING).also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -695,7 +712,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update status no-op if the same`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(status = WaitingListStatus.PENDING).also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, initialStatus = WaitingListStatus.PENDING).also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -716,9 +733,10 @@ class WaitingListServiceTest {
 
   @Test
   fun `update status fails if already allocated`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(status = WaitingListStatus.ALLOCATED).also {
-      whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
-    }
+    val waitingList =
+      waitingList(prisonCode = pentonvillePrisonCode, initialStatus = WaitingListStatus.ALLOCATED).also {
+        whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
+      }
 
     assertThatThrownBy {
       service.updateWaitingList(
@@ -737,7 +755,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update status fails if already removed`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(status = WaitingListStatus.REMOVED).also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, initialStatus = WaitingListStatus.REMOVED).also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -758,7 +776,7 @@ class WaitingListServiceTest {
 
   @Test
   fun `update status fails if not PENDING, APPROVED or DECLINED`() {
-    val waitingList = waitingList(pentonvillePrisonCode).copy(status = WaitingListStatus.PENDING).also {
+    val waitingList = waitingList(prisonCode = pentonvillePrisonCode, initialStatus = WaitingListStatus.PENDING).also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
@@ -790,13 +808,61 @@ class WaitingListServiceTest {
 
   @Test
   fun `update fails if incorrect caseload`() {
-    val waitingList = waitingList(moorlandPrisonCode).copy(status = WaitingListStatus.PENDING).also {
+    val waitingList = waitingList(prisonCode = moorlandPrisonCode, initialStatus = WaitingListStatus.PENDING).also {
       whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
     }
 
     assertThatThrownBy {
-      service.updateWaitingList(waitingList.waitingListId, WaitingListApplicationUpdateRequest(status = WaitingListStatus.ALLOCATED), "Frank")
+      service.updateWaitingList(
+        waitingList.waitingListId,
+        WaitingListApplicationUpdateRequest(status = WaitingListStatus.ALLOCATED),
+        "Frank",
+      )
     }
       .isInstanceOf(CaseloadAccessException::class.java)
+  }
+
+  @Test
+  fun `declines pending and approved applications only`() {
+    val pending = waitingList(waitingListId = 1, prisonCode = moorlandPrisonCode, prisonerNumber = "A", initialStatus = WaitingListStatus.PENDING)
+    val approved = waitingList(waitingListId = 2, prisonCode = moorlandPrisonCode, prisonerNumber = "B", initialStatus = WaitingListStatus.APPROVED)
+    val allocated = waitingList(waitingListId = 3, prisonCode = moorlandPrisonCode, prisonerNumber = "C", initialStatus = WaitingListStatus.ALLOCATED)
+    val removed = waitingList(waitingListId = 4, prisonCode = moorlandPrisonCode, prisonerNumber = "D", initialStatus = WaitingListStatus.REMOVED)
+
+    whenever(
+      waitingListRepository.findByPrisonCodeAndPrisonerNumberIn(
+        prisonCode = moorlandPrisonCode,
+        setOf("A", "B", "C", "D"),
+      ),
+    ) doReturn listOf(pending, approved, allocated, removed)
+
+    service.declinePendingOrApprovedApplicationsFor(moorlandPrisonCode, setOf("A", "B", "C", "D"), "reason", "Fred")
+
+    verify(waitingListRepository).findByPrisonCodeAndPrisonerNumberIn(moorlandPrisonCode, setOf("A", "B", "C", "D"))
+
+    with(pending) {
+      status isEqualTo WaitingListStatus.DECLINED
+      declinedReason isEqualTo "reason"
+      updatedTime!! isCloseTo TimeSource.now()
+      updatedBy isEqualTo "Fred"
+    }
+    with(approved) {
+      status isEqualTo WaitingListStatus.DECLINED
+      declinedReason isEqualTo "reason"
+      updatedTime!! isCloseTo TimeSource.now()
+      updatedBy isEqualTo "Fred"
+    }
+    with(allocated) {
+      status isEqualTo WaitingListStatus.ALLOCATED
+      declinedReason isEqualTo null
+      updatedTime isEqualTo null
+      updatedBy isEqualTo null
+    }
+    with(removed) {
+      status isEqualTo WaitingListStatus.REMOVED
+      declinedReason isEqualTo null
+      updatedTime isEqualTo null
+      updatedBy isEqualTo null
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/AuditTransformationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/AuditTransformationsTest.kt
@@ -43,7 +43,7 @@ class AuditTransformationsTest {
 
   @Test
   fun `transform to prisoner added to waiting list event`() {
-    val waitingList = waitingList(moorlandPrisonCode)
+    val waitingList = waitingList(prisonCode = moorlandPrisonCode)
 
     with(waitingList.toPrisonerAddedToWaitingListEvent()) {
       activityId isEqualTo waitingList.activity.activityId

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -556,8 +556,8 @@ class TransformFunctionsTest {
         applicationDate = TimeSource.today(),
         requestedBy = "Fred",
         comments = "Some random test comments",
-        status = WaitingListStatus.DECLINED,
         createdBy = "Bob",
+        initialStatus = WaitingListStatus.DECLINED,
       ).apply {
         this.allocation = allocation
         this.updatedBy = "Test"


### PR DESCRIPTION
Providing a reusable service layer function to decline PENDING and/or APPROVED waiting list applications.

This will be used by background jobs e.g. activities ending jobs and event handlers e.g. prisoner release event.