### PR TITLE
Feature/saa 1110 decline waiting list records on activity end and expiration of allocated prisoners

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/WaitingListRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/WaitingListRepository.kt
@@ -2,8 +2,10 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingList
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingListStatus
 
 @Repository
 interface WaitingListRepository : JpaRepository<WaitingList, Long> {
@@ -15,5 +17,7 @@ interface WaitingListRepository : JpaRepository<WaitingList, Long> {
 
   fun findByActivitySchedule(activitySchedule: ActivitySchedule): List<WaitingList>
 
-  fun findByPrisonCodeAndPrisonerNumberIn(prisonCode: String, prisonerNumbers: Set<String>): List<WaitingList>
+  fun findByPrisonCodeAndPrisonerNumberAndStatusIn(prisonCode: String, prisonerNumber: String, statuses: Set<WaitingListStatus>): List<WaitingList>
+
+  fun findByActivityAndStatusIn(activity: Activity, statuses: Set<WaitingListStatus>): List<WaitingList>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -111,8 +111,9 @@ class ManageAllocationsService(
               .block()
               ?.filter { it.hasExpired(regime) }
               ?.map { it.prisonerNumber }
+              ?.toSet()
               ?.onEach { waitingListService.declinePendingOrApprovedApplications(prison.code, it, "Released", ServiceName.SERVICE_NAME.value) }
-              ?.toSet() ?: emptySet()
+              ?: emptySet()
           }
 
           candidateExpiredAllocations.filter { expiredPrisoners.contains(it.prisonerNumber) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocati
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonRegime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.enumeration.ServiceName
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
@@ -30,6 +31,7 @@ class ManageAllocationsService(
   private val allocationRepository: AllocationRepository,
   private val prisonRegimeRepository: PrisonRegimeRepository,
   private val prisonerSearch: PrisonerSearchApiApplicationClient,
+  private val waitingListService: WaitingListService,
 ) {
 
   companion object {
@@ -71,6 +73,7 @@ class ManageAllocationsService(
         .flatMap { prison ->
           activityRepository.getAllForPrisonAndDate(prison.code, today).flatMap { activity ->
             if (activity.ends(today)) {
+              waitingListService.declinePendingOrApprovedApplications(activity.activityId, "Activity ended", ServiceName.SERVICE_NAME.value)
               activity.schedules().flatMap { it.allocations().filterNot(Allocation::isEnded) }
             } else {
               activity.schedules().flatMap { it.allocations().ending(today) }
@@ -108,6 +111,7 @@ class ManageAllocationsService(
               .block()
               ?.filter { it.hasExpired(regime) }
               ?.map { it.prisonerNumber }
+              ?.onEach { waitingListService.declinePendingOrApprovedApplications(prison.code, it, "Released", ServiceName.SERVICE_NAME.value) }
               ?.toSet() ?: emptySet()
           }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
@@ -84,9 +84,9 @@ class ActivitiesChangedEventHandler(
   }
 
   private fun deallocatePrisonerAndRemoveFutureAttendances(event: ActivitiesChangedEvent) {
-    waitingListService.declinePendingOrApprovedApplicationsFor(
+    waitingListService.declinePendingOrApprovedApplications(
       event.prisonCode(),
-      setOf(event.prisonerNumber()),
+      event.prisonerNumber(),
       "Released",
       ServiceName.SERVICE_NAME.value,
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandler.kt
@@ -85,9 +85,9 @@ class OffenderReleasedEventHandler(
           .let { null }
       }
     }?.let { reason ->
-      waitingListService.declinePendingOrApprovedApplicationsFor(
+      waitingListService.declinePendingOrApprovedApplications(
         event.prisonCode(),
-        setOf(event.prisonerNumber()),
+        event.prisonerNumber(),
         "Released",
         ServiceName.SERVICE_NAME.value,
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/Assertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/Assertions.kt
@@ -8,7 +8,12 @@ import java.time.temporal.ChronoUnit
 /**
  * Simple helper functions for commonly used assertions
  */
-internal infix fun LocalDateTime.isCloseTo(dateTime: LocalDateTime) {
+
+internal infix fun Boolean.isBool(value: Boolean) {
+  assertThat(this).isEqualTo(value)
+}
+
+internal infix fun LocalDateTime?.isCloseTo(dateTime: LocalDateTime) {
   assertThat(this).isCloseTo(dateTime, within(2, ChronoUnit.SECONDS))
 }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -572,8 +572,8 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
     }
   }
 
-  private fun assertThatWaitingListStatusIs(status: WaitingListStatus, prisonCode: String, vararg prisonerNumbers: String) {
-    waitingListRepository.findByPrisonCodeAndPrisonerNumberIn(prisonCode, prisonerNumbers.asList().toSet()).onEach {
+  private fun assertThatWaitingListStatusIs(status: WaitingListStatus, prisonCode: String, prisonerNumber: String) {
+    waitingListRepository.findByPrisonCodeAndPrisonerNumberAndStatusIn(prisonCode, prisonerNumber, setOf(status)).onEach {
       assertThat(it.status).isEqualTo(status)
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -13,6 +13,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocati
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.WaitingListRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSearchPrisonerFixture
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -23,6 +24,9 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
   @Autowired
   private lateinit var allocationRepository: AllocationRepository
 
+  @Autowired
+  private lateinit var waitingListRepository: WaitingListRepository
+
   @Sql("classpath:test_data/seed-activity-id-11.sql")
   @Test
   fun `deallocate offenders for activity ending today`() {
@@ -30,6 +34,8 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
 
     assertThat(activeAllocations).hasSize(3)
     activeAllocations.forEach { it.assertIs(PrisonerStatus.ACTIVE) }
+
+    waitingListRepository.findAll().also { assertThat(it).hasSize(2) }
 
     webTestClient.manageAllocations(withDeallocate = true)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
@@ -208,7 +208,7 @@ class ActivitiesChangedEventHandlerTest {
         .isCloseTo(LocalDateTime.now(), Assertions.within(60, ChronoUnit.SECONDS))
     }
 
-    verify(waitingListService).declinePendingOrApprovedApplicationsFor(moorlandPrisonCode, setOf("123456"), "Released", "Activities Management Service")
+    verify(waitingListService).declinePendingOrApprovedApplications(moorlandPrisonCode, "123456", "Released", "Activities Management Service")
   }
 
   @Test
@@ -269,7 +269,7 @@ class ActivitiesChangedEventHandlerTest {
     verify(todaysHistoricScheduledInstance, never()).remove(todaysHistoricAttendance)
     verify(todaysFutureScheduledInstance).remove(todaysFutureAttendance)
     verify(tomorrowsScheduledInstance).remove(tomorrowsFutureAttendance)
-    verify(waitingListService).declinePendingOrApprovedApplicationsFor(moorlandPrisonCode, setOf("123456"), "Released", "Activities Management Service")
+    verify(waitingListService).declinePendingOrApprovedApplications(moorlandPrisonCode, "123456", "Released", "Activities Management Service")
   }
 
   private fun scheduledInstanceOn(date: LocalDate, time: LocalTime): ScheduledInstance = mock {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReleasedEventHandlerTest.kt
@@ -170,7 +170,7 @@ class OffenderReleasedEventHandlerTest {
         .isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
     }
 
-    verify(waitingListService).declinePendingOrApprovedApplicationsFor(moorlandPrisonCode, setOf("123456"), "Released", "Activities Management Service")
+    verify(waitingListService).declinePendingOrApprovedApplications(moorlandPrisonCode, "123456", "Released", "Activities Management Service")
   }
 
   @Test
@@ -211,7 +211,7 @@ class OffenderReleasedEventHandlerTest {
         .isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
     }
 
-    verify(waitingListService).declinePendingOrApprovedApplicationsFor(moorlandPrisonCode, setOf("123456"), "Released", "Activities Management Service")
+    verify(waitingListService).declinePendingOrApprovedApplications(moorlandPrisonCode, "123456", "Released", "Activities Management Service")
   }
 
   @Test
@@ -242,7 +242,7 @@ class OffenderReleasedEventHandlerTest {
     assertThat(previouslySuspendedAllocation.status(PrisonerStatus.ENDED)).isTrue
     assertThat(previouslyActiveAllocation.status(PrisonerStatus.ENDED)).isTrue
 
-    verify(waitingListService).declinePendingOrApprovedApplicationsFor(moorlandPrisonCode, setOf("123456"), "Released", "Activities Management Service")
+    verify(waitingListService).declinePendingOrApprovedApplications(moorlandPrisonCode, "123456", "Released", "Activities Management Service")
   }
 
   @Test

--- a/src/test/resources/test_data/seed-activity-id-11.sql
+++ b/src/test/resources/test_data/seed-activity-id-11.sql
@@ -24,3 +24,9 @@ values (3, 1, 'A33333A', 10003, 2, current_date, current_date + 1, '2022-10-10 0
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (4, 1, 'A33333A', 10004, 2, current_date - 1, current_date - 1, '2022-10-10 09:00:00', 'MRS BLOGS', current_timestamp - 1, 'Activities Management Service', 'ENDED', null, null, null, 'ENDED');
+
+insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
+values (1, 'PVI', 'A11111A', 111111, '2023-06-23', 1, 1, 'Fred Bloggs', 'PENDING', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);
+
+insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
+values (2, 'PVI', 'A22222A', 222222, '2023-06-23', 1, 1, 'Fred Bloggs', 'APPROVED', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);

--- a/src/test/resources/test_data/seed-activity-id-11.sql
+++ b/src/test/resources/test_data/seed-activity-id-11.sql
@@ -30,3 +30,6 @@ values (1, 'PVI', 'A11111A', 111111, '2023-06-23', 1, 1, 'Fred Bloggs', 'PENDING
 
 insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
 values (2, 'PVI', 'A22222A', 222222, '2023-06-23', 1, 1, 'Fred Bloggs', 'APPROVED', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);
+
+insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
+values (3, 'PVI', 'A33333A', 333333, '2023-06-23', 1, 1, 'Fred Bloggs', 'PENDING', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);

--- a/src/test/resources/test_data/seed-allocations-due-to-expire.sql
+++ b/src/test/resources/test_data/seed-allocations-due-to-expire.sql
@@ -7,6 +7,9 @@ VALUES('PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
 values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 10, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
 
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
+values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', current_date - 10, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
 
@@ -16,5 +19,11 @@ values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date)
 values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date - 1, null);
 
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date)
+values (2, 2, 'English AM', 1, 'L1', 'Location 1', 10, current_date - 1, null);
+
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (1, 1, 'A11111A', 10001, 1, current_date - 10, null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, current_timestamp - 5, 'Activities Management Service', 'Temporarily released from prison', 'AUTO_SUSPENDED');
+
+insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
+values (1, 'PVI', 'A11111A', 10001, '2023-06-23', 2, 2, 'Fred Bloggs', 'PENDING', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);


### PR DESCRIPTION
This PR handles declining of pending and approved waiting list applications when an activity has reached it's end date or a prisoner is deemed released on the back of their auto suspended allocations expiring. 