### PR TITLE
SDIT-1039 Workaround Hibernate bug which returned duplicate records

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceSync.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceSync.kt
@@ -40,8 +40,6 @@ data class AttendanceSync(
   val bonusAmount: Int?,
 
   val issuePayment: Boolean?,
-
-  val allocationStartDate: LocalDate,
 ) {
   fun toModel() =
     AttendanceSyncModel(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceSyncRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceSyncRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.stereotype.Repository as RepositoryAnnotation
 
 @RepositoryAnnotation
 interface AttendanceSyncRepository : ReadOnlyRepository<AttendanceSync, Long> {
-  fun findAllByAttendanceId(attendanceId: Long): List<AttendanceSync>
+  fun findAllByAttendanceId(attendanceId: Long): AttendanceSync?
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SynchronisationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SynchronisationService.kt
@@ -10,6 +10,5 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Atte
 class SynchronisationService(private val repository: AttendanceSyncRepository) {
   fun findAttendanceSync(attendanceId: Long): AttendanceSync? =
     repository.findAllByAttendanceId(attendanceId)
-      .maxByOrNull { it.allocationStartDate }
       ?.toModel()
 }

--- a/src/main/resources/migrations/common/V2023.08.22__fix_attendance_sync_view.sql
+++ b/src/main/resources/migrations/common/V2023.08.22__fix_attendance_sync_view.sql
@@ -1,0 +1,26 @@
+-- =============================================
+-- ATTENDANCE SYNC VIEW
+-- =============================================
+
+CREATE OR REPLACE VIEW v_attendance_sync AS
+select a.attendance_id,
+       a.scheduled_instance_id,
+       si.activity_schedule_id,
+       si.session_date,
+       si.start_time as session_start_time,
+       si.end_time   as session_end_time,
+       a.prisoner_number,
+       a2.booking_id,
+       ar.code       as attendance_reason_code,
+       a.comment,
+       a.status,
+       a.pay_amount,
+       a.bonus_amount,
+       a.issue_payment
+from attendance a
+         join scheduled_instance si on a.scheduled_instance_id = si.scheduled_instance_id
+         join allocation a2 on si.activity_schedule_id = a2.activity_schedule_id and
+                               a.prisoner_number = a2.prisoner_number and
+                               si.session_date >= a2.start_date and
+                               (a2.end_date is null or si.session_date <= a2.end_date)
+         left join attendance_reason ar on a.attendance_reason_id = ar.attendance_reason_id;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AttendanceSyncIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AttendanceSyncIntegrationTest.kt
@@ -114,6 +114,28 @@ class AttendanceSyncIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/seed-activity-id-17.sql",
   )
   @Test
+  fun `should return correct booking where prisoner has been allocated, ended and reallocated on a different booking id`() {
+    val attendanceSync =
+      webTestClient.get()
+        .uri("/synchronisation/attendance/4")
+        .accept(MediaType.APPLICATION_JSON)
+        .headers(setAuthorisation(roles = listOf("ROLE_NOMIS_ACTIVITIES")))
+        .exchange()
+        .expectStatus().isOk
+        .expectHeader().contentType(MediaType.APPLICATION_JSON)
+        .expectBody(AttendanceSync::class.java)
+        .returnResult().responseBody!!
+
+    with(attendanceSync) {
+      assertThat(attendanceId).isEqualTo(4)
+      assertThat(bookingId).isEqualTo(10005)
+    }
+  }
+
+  @Sql(
+    "classpath:test_data/seed-activity-id-17.sql",
+  )
+  @Test
   fun `should return unauthorised`() {
     webTestClient.get()
       .uri("/synchronisation/attendance/1")

--- a/src/test/resources/test_data/seed-activity-id-17.sql
+++ b/src/test/resources/test_data/seed-activity-id-17.sql
@@ -40,8 +40,17 @@ values (5, 2, 'A22222A', 10002, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'M
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (6, 1, 'A33333A', 10003, 2, '2022-10-20', null, '2022-10-20 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ENDED');
 
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (7, 2, 'A33333A', 10004, 2, '2022-10-20', '2022-10-21', '2022-10-20 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (8, 2, 'A33333A', 10005, 2, '2022-11-20', null, '2022-11-20 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ENDED');
+
 insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
-values (1, 1, now(), '10:00:00', '11:00:00', true, now(), 'Old Canceller', 'Nobody Available', null);
+values (1, 1, now(), '10:00:00', '11:00:00', false, null, null, null, null);
+
+insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (2, 2, now(), '10:00:00', '11:00:00', false, null, null, null, null);
 
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces, issue_payment)
 values (1, 1, 'A22222A', 1, 'Attendance Comment', now(), 'Old Recorder', 'COMPLETED', 150, 50, null, false);
@@ -51,4 +60,7 @@ values (2, 1, 'A11111A', null, null, now(), 'Old Recorder', 'WAITING', null, nul
 
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces, issue_payment)
 values (3, 1, 'A33333A', 1, null, now(), 'Old Recorder', 'COMPLETED', 200, null, null, null);
+
+insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces, issue_payment)
+values (4, 2, 'A33333A', 1, null, now(), 'Old Recorder', 'WAITING', null, null, null, null);
 


### PR DESCRIPTION
Fixes a problem with attendance sync. that we were experiencing in dev - an offender that was allocated, released, returned to prison on a new booking and reallocated to the same activity always failed attendance sync. because we tried to attend against the old allocation. (A4744DZ).