### PR TITLE
Set Time-To-Live on cronjobs, to keep a 4 day history of jobs

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/templates/create-scheduled-instances-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/create-scheduled-instances-cronjob.yaml
@@ -10,6 +10,7 @@ spec:
   successfulJobsHistoryLimit: 5
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 345600 # 4 days
       backoffLimit: 2
       template:
         spec:

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-activate-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-activate-cronjob.yaml
@@ -10,6 +10,7 @@ spec:
   successfulJobsHistoryLimit: 5
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 345600 # 4 days
       backoffLimit: 2
       template:
         spec:

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-cronjob.yaml
@@ -10,6 +10,7 @@ spec:
   successfulJobsHistoryLimit: 5
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 345600 # 4 days
       backoffLimit: 2
       template:
         spec:

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-attendance-records-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-attendance-records-cronjob.yaml
@@ -10,6 +10,7 @@ spec:
   successfulJobsHistoryLimit: 5
   jobTemplate:
     spec:
+      ttlSecondsAfterFinished: 345600 # 4 days
       backoffLimit: 2
       template:
         spec:


### PR DESCRIPTION
4 days is the value CP have gone with for other jobs e.g. preprod database restore