### PR TITLE
SAA-1142: Keep description and summary the same.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
@@ -102,7 +102,7 @@ class MigrateActivityService(
       activityTier = mapProgramToTier(request.programServiceCode),
       attendanceRequired = true,
       summary = request.description,
-      description = "Migrated from NOMIS with program service code ${request.programServiceCode}",
+      description = request.description,
       inCell = (request.internalLocationId == null && !request.outsideWork) || request.programServiceCode == TIER2_IN_CELL_ACTIVITY,
       onWing = request.internalLocationCode?.contains(ON_WING_LOCATION) ?: false,
       outsideWork = request.outsideWork,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
@@ -143,7 +143,7 @@ class MigrateActivityServiceTest {
       // Check the content of the Activity entity that was passed into saveAndFlush
       with(activityCaptor.firstValue) {
         assertThat(summary).isEqualTo("An activity")
-        assertThat(description).contains("Migrated from NOMIS")
+        assertThat(description).isEqualTo("An activity")
         assertThat(inCell).isFalse
         assertThat(onWing).isFalse
         assertThat(startDate).isEqualTo(LocalDate.now().plusDays(1))


### PR DESCRIPTION
For migrated activities.
This keeps them consistent with other activities and prevents an odd description showing on forms that use this field.