### PR TITLE
SAA-1055: Refactor update appointment towards DDD

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
@@ -91,6 +91,8 @@ data class Appointment(
 
   fun scheduledOccurrences() = occurrences().filter { it.isScheduled() }.toList()
 
+  fun scheduledOccurrencesAfter(startDateTime: LocalDateTime) = scheduledOccurrences().filter { it.startDateTime() > startDateTime }.toList()
+
   fun occurrenceDetails(
     prisonerMap: Map<String, Prisoner>,
     referenceCodeMap: Map<String, ReferenceCode>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentDetails
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentCategorySummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentLocationSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toAppointmentName
@@ -92,6 +93,28 @@ data class Appointment(
   fun scheduledOccurrences() = occurrences().filter { it.isScheduled() }.toList()
 
   fun scheduledOccurrencesAfter(startDateTime: LocalDateTime) = scheduledOccurrences().filter { it.startDateTime() > startDateTime }.toList()
+
+  fun applyToOccurrences(appointmentOccurrence: AppointmentOccurrence, applyTo: ApplyTo, action: String): List<AppointmentOccurrence> {
+    require(!appointmentOccurrence.isExpired()) {
+      "Cannot $action a past appointment occurrence"
+    }
+
+    require(!appointmentOccurrence.isCancelled()) {
+      "Cannot $action a cancelled appointment occurrence"
+    }
+
+    require(!appointmentOccurrence.isDeleted()) {
+      "Cannot $action a deleted appointment occurrence"
+    }
+
+    return when (applyTo) {
+      ApplyTo.THIS_AND_ALL_FUTURE_OCCURRENCES -> listOf(appointmentOccurrence).union(
+        scheduledOccurrencesAfter(appointmentOccurrence.startDateTime()),
+      ).toList()
+      ApplyTo.ALL_FUTURE_OCCURRENCES -> scheduledOccurrences()
+      else -> listOf(appointmentOccurrence)
+    }
+  }
 
   fun occurrenceDetails(
     prisonerMap: Map<String, Prisoner>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
@@ -88,7 +88,7 @@ data class Appointment(
   @OrderBy("sequenceNumber ASC")
   private val occurrences: MutableList<AppointmentOccurrence> = mutableListOf()
 
-  fun occurrences() = occurrences.filter { !it.isDeleted() }.toList()
+  fun occurrences() = occurrences.filterNot { it.isDeleted() }.toList()
 
   fun scheduledOccurrences() = occurrences().filter { it.isScheduled() }.toList()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
@@ -87,7 +87,9 @@ data class Appointment(
   @OrderBy("sequenceNumber ASC")
   private val occurrences: MutableList<AppointmentOccurrence> = mutableListOf()
 
-  fun occurrences() = occurrences.filter { !it.deleted }.toList()
+  fun occurrences() = occurrences.filter { !it.isDeleted() }.toList()
+
+  fun scheduledOccurrences() = occurrences().filter { it.isScheduled() }.toList()
 
   fun occurrenceDetails(
     prisonerMap: Map<String, Prisoner>,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrence.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
 import jakarta.persistence.CascadeType
 import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
 import jakarta.persistence.FetchType
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
@@ -30,6 +31,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointme
 @Entity
 @Table(name = "appointment_occurrence")
 @Where(clause = "deleted = false")
+@EntityListeners(AppointmentOccurrenceEntityListener::class)
 data class AppointmentOccurrence(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -81,7 +83,9 @@ data class AppointmentOccurrence(
 
   fun prisonerNumbers() = allocations().map { allocation -> allocation.prisonerNumber }.distinct()
 
-  fun startDateTime() = LocalDateTime.of(startDate, startTime)
+  fun startDateTime(): LocalDateTime = LocalDateTime.of(startDate, startTime)
+
+  fun isScheduled() = !isExpired() && !isCancelled() && !isDeleted()
 
   fun isEdited() = updated != null
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceEntityListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceEntityListener.kt
@@ -31,7 +31,7 @@ class AppointmentOccurrenceEntityListener {
    * sync event should be published.
    *
    * The event type is determined by the state of the occurrence at the time. If an occurrence is cancelled or deleted,
-   * the event is those types. A change to an active appointment is therefor an update event.
+   * the event is those types. A change to an active appointment is therefore an update event.
    */
   @PostUpdate
   fun onUpdate(entity: AppointmentOccurrence) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceEntityListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceEntityListener.kt
@@ -1,0 +1,57 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import jakarta.persistence.PostUpdate
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
+
+@Component
+class AppointmentOccurrenceEntityListener {
+
+  @Autowired
+  private lateinit var outboundEventsService: OutboundEventsService
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  /**
+   * Appointment instances are provided by a view that joins allocations, occurrences and appointments to create
+   * a per prisoner per date individual appointment instance. This resulting appointment instance uses the allocation id
+   * as there is a one-to-one relationship between allocations and instances. This is therefore the id that should be
+   * used for the /appointment-instances/:id endpoint. Appointment instances are compatible with NOMIS appointments
+   * stored in the OFFENDER_IND_SCHEDULES table. The appointment instance events and associated endpoint are used
+   * primarily for sync purposes.
+   *
+   * As an appointment occurrence has a child collection of allocations and allocations represent appointment instances,
+   * an update to an appointment occurrence implicitly applies to each child allocation. As a result an appointment instance
+   * sync event should be published.
+   *
+   * The event type is determined by the state of the occurrence at the time. If an occurrence is cancelled or deleted,
+   * the event is those types. A change to an active appointment is therefor an update event.
+   */
+  @PostUpdate
+  fun onUpdate(entity: AppointmentOccurrence) {
+    entity.allocations().forEach { allocation ->
+      runCatching {
+        outboundEventsService.send(
+          when {
+            entity.isCancelled() -> OutboundEvent.APPOINTMENT_INSTANCE_CANCELLED
+            entity.isDeleted() -> OutboundEvent.APPOINTMENT_INSTANCE_DELETED
+
+            else -> { OutboundEvent.APPOINTMENT_INSTANCE_UPDATED }
+          },
+          allocation.appointmentOccurrenceAllocationId,
+        )
+      }.onFailure {
+        log.error(
+          "Failed to send appointment instance updated event for appointment instance id ${allocation.appointmentOccurrenceAllocationId}",
+          it,
+        )
+      }
+    }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceUpdateDomainService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceUpdateDomainService.kt
@@ -1,0 +1,227 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentOccurrenceUpdateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_INSTANCE_COUNT_METRIC_KEY
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.EVENT_TIME_MS_METRIC_KEY
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.TelemetryEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.toTelemetryMetricsMap
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.toTelemetryPropertiesMap
+import java.time.LocalDateTime
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointment as AppointmentModel
+
+@Service
+@Transactional
+class AppointmentOccurrenceUpdateDomainService(
+  private val appointmentRepository: AppointmentRepository,
+  private val telemetryClient: TelemetryClient,
+) {
+  fun updateAppointmentOccurrenceIds(
+    appointmentId: Long,
+    appointmentOccurrenceId: Long,
+    occurrenceIdsToUpdate: List<Long>,
+    request: AppointmentOccurrenceUpdateRequest,
+    prisonerMap: Map<String, Prisoner>,
+    updated: LocalDateTime,
+    updatedBy: String,
+    startTimeInMs: Long,
+  ): AppointmentModel {
+    val appointment = appointmentRepository.findOrThrowNotFound(appointmentId)
+    val occurrencesToUpdate = appointment.occurrences().filter { occurrenceIdsToUpdate.contains(it.appointmentOccurrenceId) }
+    return updateAppointmentOccurrences(appointment, appointmentOccurrenceId, occurrencesToUpdate, request, prisonerMap, updated, updatedBy, startTimeInMs, true)
+  }
+
+  fun updateAppointmentOccurrences(
+    appointment: Appointment,
+    appointmentOccurrenceId: Long,
+    occurrencesToUpdate: Collection<AppointmentOccurrence>,
+    request: AppointmentOccurrenceUpdateRequest,
+    prisonerMap: Map<String, Prisoner>,
+    updated: LocalDateTime,
+    updatedBy: String,
+    startTimeInMs: Long,
+    trackEvent: Boolean,
+  ): AppointmentModel {
+    var instanceCount = getUpdatedInstanceCount(request, appointment, occurrencesToUpdate)
+
+    val telemetryPropertiesMap = request.toTelemetryPropertiesMap(updatedBy, appointment.prisonCode, appointment.appointmentId, appointmentOccurrenceId)
+    val telemetryMetricsMap = request.toTelemetryMetricsMap(occurrencesToUpdate.size)
+
+    applyCategoryCodeUpdate(request, appointment, updated, updatedBy)
+    applyStartDateUpdate(request, appointment, occurrencesToUpdate)
+    applyInternalLocationUpdate(request, occurrencesToUpdate)
+    applyStartEndTimeUpdate(request, occurrencesToUpdate)
+    applyCommentUpdate(request, occurrencesToUpdate)
+    instanceCount += applyRemovePrisonersUpdate(request, appointment, occurrencesToUpdate)
+
+    if (request.isPropertyUpdate()) {
+      occurrencesToUpdate.forEach {
+        it.updated = updated
+        it.updatedBy = updatedBy
+      }
+    }
+
+    var updatedAppointment = appointmentRepository.saveAndFlush(appointment)
+
+    // Adding prisoners creates new allocations on the occurrence and publishes create instance events.
+    // This action must be performed after other updates have been saved and flushed to prevent update events being published as well as the create events
+    applyAddPrisonersUpdate(request, occurrencesToUpdate, prisonerMap).also {
+      if (it > 0) {
+        updatedAppointment = appointmentRepository.saveAndFlush(appointment)
+        instanceCount += it
+      }
+    }
+
+    if (trackEvent) {
+      telemetryMetricsMap[APPOINTMENT_INSTANCE_COUNT_METRIC_KEY] = instanceCount.toDouble()
+      telemetryMetricsMap[EVENT_TIME_MS_METRIC_KEY] = (System.currentTimeMillis() - startTimeInMs).toDouble()
+      telemetryClient.trackEvent(TelemetryEvent.APPOINTMENT_EDITED.value, telemetryPropertiesMap, telemetryMetricsMap)
+    }
+
+    return updatedAppointment.toModel()
+  }
+
+  private fun getUpdatedInstanceCount(
+    request: AppointmentOccurrenceUpdateRequest,
+    appointment: Appointment,
+    occurrencesToUpdate: Collection<AppointmentOccurrence>,
+  ) =
+    if (request.categoryCode != null) {
+      appointment.scheduledOccurrences().flatMap { it.allocations() }.size
+    } else if (request.isPropertyUpdate()) {
+      occurrencesToUpdate.flatMap { it.allocations() }.size
+    } else {
+      0
+    }
+
+  private fun applyCategoryCodeUpdate(
+    request: AppointmentOccurrenceUpdateRequest,
+    appointment: Appointment,
+    updated: LocalDateTime,
+    updatedBy: String,
+  ) {
+    request.categoryCode?.apply {
+      // Category updates are applied at the appointment level
+      appointment.categoryCode = this
+
+      // Mark appointment and occurrences as updated
+      appointment.updated = updated
+      appointment.updatedBy = updatedBy
+
+      appointment.scheduledOccurrences().forEach {
+        it.updated = updated
+        it.updatedBy = updatedBy
+      }
+    }
+  }
+
+  private fun applyInternalLocationUpdate(
+    request: AppointmentOccurrenceUpdateRequest,
+    occurrencesToUpdate: Collection<AppointmentOccurrence>,
+  ) {
+    occurrencesToUpdate.forEach {
+      if (request.inCell == true) {
+        it.internalLocationId = null
+        it.inCell = true
+      } else {
+        request.internalLocationId?.apply {
+          it.internalLocationId = this
+          it.inCell = false
+        }
+      }
+    }
+  }
+
+  private fun applyStartDateUpdate(
+    request: AppointmentOccurrenceUpdateRequest,
+    appointment: Appointment,
+    occurrencesToUpdate: Collection<AppointmentOccurrence>,
+  ) {
+    // Changing the start date of a repeat appointment changes the start date of all affected appointments based on the original schedule using the new start date
+    request.startDate?.apply {
+      val scheduleIterator = appointment.scheduleIterator().apply { startDate = request.startDate }
+      occurrencesToUpdate.sortedBy { it.sequenceNumber }.forEach {
+        it.startDate = scheduleIterator.next()
+      }
+    }
+  }
+
+  private fun applyStartEndTimeUpdate(
+    request: AppointmentOccurrenceUpdateRequest,
+    occurrencesToUpdate: Collection<AppointmentOccurrence>,
+  ) {
+    occurrencesToUpdate.forEach {
+      request.startTime?.apply {
+        it.startTime = this
+      }
+
+      request.endTime?.apply {
+        it.endTime = this
+      }
+    }
+  }
+
+  private fun applyCommentUpdate(
+    request: AppointmentOccurrenceUpdateRequest,
+    occurrencesToUpdate: Collection<AppointmentOccurrence>,
+  ) {
+    occurrencesToUpdate.forEach {
+      request.comment?.apply {
+        it.comment = this
+      }
+    }
+  }
+
+  private fun applyRemovePrisonersUpdate(
+    request: AppointmentOccurrenceUpdateRequest,
+    appointment: Appointment,
+    occurrencesToUpdate: Collection<AppointmentOccurrence>,
+  ): Int {
+    var removedInstanceCount = 0
+    occurrencesToUpdate.forEach { occurrenceToUpdate ->
+      request.removePrisonerNumbers?.forEach { prisonerToRemove ->
+        if (appointment.appointmentType == AppointmentType.INDIVIDUAL && request.removePrisonerNumbers.isNotEmpty()) {
+          throw IllegalArgumentException("Cannot remove prisoners from an individual appointment occurrence")
+        }
+        occurrenceToUpdate.allocations()
+          .filter { it.prisonerNumber == prisonerToRemove }
+          .forEach {
+            occurrenceToUpdate.removeAllocation(it)
+            removedInstanceCount++
+          }
+      }
+    }
+    return removedInstanceCount
+  }
+
+  private fun applyAddPrisonersUpdate(
+    request: AppointmentOccurrenceUpdateRequest,
+    occurrencesToUpdate: Collection<AppointmentOccurrence>,
+    prisonerMap: Map<String, Prisoner>,
+  ): Int {
+    var newInstanceCount = 0
+    occurrencesToUpdate.forEach { occurrenceToUpdate ->
+      request.addPrisonerNumbers?.apply {
+        val prisonerAllocationMap = occurrenceToUpdate.allocations().associateBy { allocation -> allocation.prisonerNumber }
+        val newPrisoners = prisonerMap.filter { !prisonerAllocationMap.containsKey(it.key) }.values
+          .also { newInstanceCount += it.size }
+
+        newPrisoners.forEach { prisoner ->
+          occurrenceToUpdate.addAllocation(
+            AppointmentOccurrenceAllocation(
+              appointmentOccurrence = occurrenceToUpdate,
+              prisonerNumber = prisoner.prisonerNumber,
+              bookingId = prisoner.bookingId!!.toLong(),
+            ),
+          )
+        }
+      }
+    }
+    return newInstanceCount
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceUpdateDomainService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceUpdateDomainService.kt
@@ -39,7 +39,7 @@ class AppointmentOccurrenceUpdateDomainService(
   fun updateAppointmentOccurrences(
     appointment: Appointment,
     appointmentOccurrenceId: Long,
-    occurrencesToUpdate: Collection<AppointmentOccurrence>,
+    occurrencesToUpdate: List<AppointmentOccurrence>,
     request: AppointmentOccurrenceUpdateRequest,
     prisonerMap: Map<String, Prisoner>,
     updated: LocalDateTime,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentOccurrenceUpdateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentOccurrenceUpdateRequest.kt
@@ -102,6 +102,8 @@ data class AppointmentOccurrenceUpdateRequest(
   )
   val applyTo: ApplyTo = ApplyTo.THIS_OCCURRENCE,
 ) {
+  fun isPropertyUpdate() = categoryCode != null || internalLocationId != null || inCell != null || startDate != null || startTime != null || endTime != null || comment != null
+
   @AssertTrue(message = "Internal location id must be supplied if in cell = false")
   private fun isInternalLocationId() = inCell != false || internalLocationId != null
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceService.kt
@@ -90,7 +90,7 @@ class AppointmentOccurrenceService(
     return appointmentOccurrenceUpdateDomainService.updateAppointmentOccurrences(
       appointment,
       appointmentOccurrenceId,
-      occurrencesToUpdate,
+      occurrencesToUpdate.toSet(),
       request,
       prisonerMap,
       now,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceService.kt
@@ -23,18 +23,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOI
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_ID_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_INSTANCE_COUNT_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_SERIES_ID_PROPERTY_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.CATEGORY_CHANGED_PROPERTY_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.END_TIME_CHANGED_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.EVENT_TIME_MS_METRIC_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.EXTRA_INFORMATION_CHANGED_PROPERTY_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.INTERNAL_LOCATION_CHANGED_PROPERTY_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.PRISONERS_ADDED_COUNT_METRIC_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.PRISONERS_REMOVED_COUNT_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.PRISON_CODE_PROPERTY_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.START_DATE_CHANGED_PROPERTY_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.START_TIME_CHANGED_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.TelemetryEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.USER_PROPERTY_KEY
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.toTelemetryMetricsMap
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.toTelemetryPropertiesMap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.checkCaseloadAccess
 import java.security.Principal
 import java.time.LocalDateTime
@@ -52,13 +46,12 @@ class AppointmentOccurrenceService(
   private val telemetryClient: TelemetryClient,
 ) {
   fun updateAppointmentOccurrence(appointmentOccurrenceId: Long, request: AppointmentOccurrenceUpdateRequest, principal: Principal): AppointmentModel {
-    val startTime = System.currentTimeMillis()
+    val startTimeInMs = System.currentTimeMillis()
+    val now = LocalDateTime.now()
 
     val appointmentOccurrence = appointmentOccurrenceRepository.findOrThrowNotFound(appointmentOccurrenceId)
     val appointment = appointmentOccurrence.appointment
     checkCaseloadAccess(appointment.prisonCode)
-
-    val now = LocalDateTime.now()
 
     require(!appointmentOccurrence.isCancelled()) {
       "Cannot update a cancelled appointment occurrence"
@@ -87,18 +80,26 @@ class AppointmentOccurrenceService(
         }
     }
 
-    val occurrencesToUpdate = determineOccurrencesToApplyTo(appointmentOccurrence, request.applyTo, now)
+    val occurrencesToUpdate = determineOccurrencesToApplyTo(appointment, appointmentOccurrence, request.applyTo)
     var instanceCount = getUpdatedInstanceCount(request, appointment, occurrencesToUpdate)
 
-    val telemetryPropertiesMap = createEditAppointmentTelemetryPropertiesMap()
-    val telemetryMetricsMap = createEditAppointmentTelemetryMetricsMap()
+    val telemetryPropertiesMap = request.toTelemetryPropertiesMap(principal.name, appointment.prisonCode, appointment.appointmentId, appointmentOccurrence.appointmentOccurrenceId)
+    val telemetryMetricsMap = request.toTelemetryMetricsMap(occurrencesToUpdate.size)
 
-    applyCategoryCodeUpdate(request, appointment, categoryMap, now, principal.name, telemetryPropertiesMap)
-    applyStartDateUpdate(request, appointment, occurrencesToUpdate, now, principal.name, telemetryPropertiesMap)
-    applyInternalLocationUpdate(request, appointment, occurrencesToUpdate, locationMap, now, principal.name, telemetryPropertiesMap)
-    applyStartEndTimeUpdate(request, occurrencesToUpdate, now, principal.name, telemetryPropertiesMap)
-    applyCommentUpdate(request, occurrencesToUpdate, now, principal.name, telemetryPropertiesMap)
+    applyCategoryCodeUpdate(request, appointment, categoryMap, now, principal.name)
+    applyStartDateUpdate(request, appointment, occurrencesToUpdate)
+    applyInternalLocationUpdate(request, appointment, occurrencesToUpdate, locationMap)
+    applyStartEndTimeUpdate(request, occurrencesToUpdate)
+    applyCommentUpdate(request, occurrencesToUpdate)
     instanceCount += applyRemovePrisonersUpdate(request, appointment, occurrencesToUpdate)
+
+    if (request.isPropertyUpdate()) {
+      occurrencesToUpdate.forEach {
+        it.updated = now
+        it.updatedBy = principal.name
+      }
+    }
+
     var updatedAppointment = appointmentRepository.saveAndFlush(appointment)
 
     // Adding prisoners creates new allocations on the occurrence and publishes create instance events.
@@ -111,15 +112,17 @@ class AppointmentOccurrenceService(
     }
 
     telemetryMetricsMap[APPOINTMENT_INSTANCE_COUNT_METRIC_KEY] = instanceCount.toDouble()
-    telemetryMetricsMap[APPOINTMENT_COUNT_METRIC_KEY] = occurrencesToUpdate.size.toDouble()
-    logAppointmentEditedMetric(principal, appointmentOccurrenceId, request, updatedAppointment, telemetryPropertiesMap, telemetryMetricsMap, startTime)
+    telemetryMetricsMap[EVENT_TIME_MS_METRIC_KEY] = (System.currentTimeMillis() - startTimeInMs).toDouble()
+    telemetryClient.trackEvent(TelemetryEvent.APPOINTMENT_EDITED.value, telemetryPropertiesMap, telemetryMetricsMap)
+
     return updatedAppointment.toModel()
   }
 
   fun cancelAppointmentOccurrence(appointmentOccurrenceId: Long, request: AppointmentOccurrenceCancelRequest, principal: Principal): AppointmentModel {
     val startTime = System.currentTimeMillis()
     val appointmentOccurrence = appointmentOccurrenceRepository.findOrThrowNotFound(appointmentOccurrenceId)
-    checkCaseloadAccess(appointmentOccurrence.appointment.prisonCode)
+    val appointment = appointmentOccurrence.appointment
+    checkCaseloadAccess(appointment.prisonCode)
 
     val cancellationReason = appointmentCancellationReasonRepository.findOrThrowNotFound(request.cancellationReasonId)
 
@@ -128,7 +131,7 @@ class AppointmentOccurrenceService(
       throw IllegalArgumentException("Cannot cancel a past appointment occurrence")
     }
 
-    val occurrencesToUpdate = determineOccurrencesToApplyTo(appointmentOccurrence, request.applyTo, now)
+    val occurrencesToUpdate = determineOccurrencesToApplyTo(appointment, appointmentOccurrence, request.applyTo)
 
     occurrencesToUpdate.forEach {
       it.cancellationReason = cancellationReason
@@ -137,7 +140,7 @@ class AppointmentOccurrenceService(
       it.deleted = cancellationReason.isDelete
     }
 
-    val updatedAppointment = appointmentRepository.saveAndFlush(appointmentOccurrence.appointment)
+    val updatedAppointment = appointmentRepository.saveAndFlush(appointment)
 
     occurrencesToUpdate.filter { it.isDeleted() }
       .flatMap { it.allocations().map { alloc -> alloc.appointmentOccurrenceAllocationId } }
@@ -177,7 +180,7 @@ class AppointmentOccurrenceService(
   ) =
     if (request.categoryCode != null) {
       appointment.scheduledOccurrences().flatMap { it.allocations() }.size
-    } else if (request.internalLocationId != null || request.inCell != null || request.startDate != null || request.startTime != null || request.endTime != null || request.comment != null) {
+    } else if (request.isPropertyUpdate()) {
       occurrencesToUpdate.flatMap { it.allocations() }.size
     } else {
       0
@@ -189,7 +192,6 @@ class AppointmentOccurrenceService(
     categoryMap: Map<String, ReferenceCode>,
     updated: LocalDateTime,
     updatedBy: String,
-    telemetryPropertiesMap: MutableMap<String, String>,
   ) {
     request.categoryCode?.apply {
       require(categoryMap.containsKey(this)) {
@@ -202,9 +204,11 @@ class AppointmentOccurrenceService(
       // Mark appointment and occurrences as updated
       appointment.updated = updated
       appointment.updatedBy = updatedBy
-      appointment.occurrences()
-        .forEach { it.markAsUpdated(updated, updatedBy) }
-        .also { telemetryPropertiesMap[CATEGORY_CHANGED_PROPERTY_KEY] = true.toString() }
+
+      appointment.scheduledOccurrences().forEach {
+        it.updated = updated
+        it.updatedBy = updatedBy
+      }
     }
   }
 
@@ -213,15 +217,11 @@ class AppointmentOccurrenceService(
     appointment: Appointment,
     occurrencesToUpdate: Collection<AppointmentOccurrence>,
     locationMap: Map<Long, Location>,
-    updated: LocalDateTime,
-    updatedBy: String,
-    telemetryPropertiesMap: MutableMap<String, String>,
   ) {
     occurrencesToUpdate.forEach {
       if (request.inCell == true) {
         it.internalLocationId = null
         it.inCell = true
-        it.markAsUpdated(updated, updatedBy)
       } else {
         request.internalLocationId?.apply {
           require(locationMap.containsKey(this)) {
@@ -229,8 +229,6 @@ class AppointmentOccurrenceService(
           }
           it.internalLocationId = this
           it.inCell = false
-          it.markAsUpdated(updated, updatedBy)
-          telemetryPropertiesMap[INTERNAL_LOCATION_CHANGED_PROPERTY_KEY] = true.toString()
         }
       }
     }
@@ -240,38 +238,27 @@ class AppointmentOccurrenceService(
     request: AppointmentOccurrenceUpdateRequest,
     appointment: Appointment,
     occurrencesToUpdate: Collection<AppointmentOccurrence>,
-    updated: LocalDateTime,
-    updatedBy: String,
-    telemetryPropertiesMap: MutableMap<String, String>,
   ) {
     // Changing the start date of a repeat appointment changes the start date of all affected appointments based on the original schedule using the new start date
     request.startDate?.apply {
       val scheduleIterator = appointment.scheduleIterator().apply { startDate = request.startDate }
       occurrencesToUpdate.sortedBy { it.sequenceNumber }.forEach {
         it.startDate = scheduleIterator.next()
-        it.markAsUpdated(updated, updatedBy)
-      }.also { telemetryPropertiesMap[START_DATE_CHANGED_PROPERTY_KEY] = true.toString() }
+      }
     }
   }
 
   private fun applyStartEndTimeUpdate(
     request: AppointmentOccurrenceUpdateRequest,
     occurrencesToUpdate: Collection<AppointmentOccurrence>,
-    updated: LocalDateTime,
-    updatedBy: String,
-    telemetryPropertiesMap: MutableMap<String, String>,
   ) {
     occurrencesToUpdate.forEach {
       request.startTime?.apply {
         it.startTime = this
-        it.markAsUpdated(updated, updatedBy)
-        telemetryPropertiesMap[START_TIME_CHANGED_PROPERTY_KEY] = true.toString()
       }
 
       request.endTime?.apply {
         it.endTime = this
-        it.markAsUpdated(updated, updatedBy)
-        telemetryPropertiesMap[END_TIME_CHANGED_PROPERTY_KEY] = true.toString()
       }
     }
   }
@@ -279,15 +266,10 @@ class AppointmentOccurrenceService(
   private fun applyCommentUpdate(
     request: AppointmentOccurrenceUpdateRequest,
     occurrencesToUpdate: Collection<AppointmentOccurrence>,
-    updated: LocalDateTime,
-    updatedBy: String,
-    telemetryPropertiesMap: MutableMap<String, String>,
   ) {
     occurrencesToUpdate.forEach {
       request.comment?.apply {
         it.comment = this
-        it.markAsUpdated(updated, updatedBy)
-        telemetryPropertiesMap[EXTRA_INFORMATION_CHANGED_PROPERTY_KEY] = true.toString()
       }
     }
   }
@@ -340,44 +322,14 @@ class AppointmentOccurrenceService(
     return newInstanceCount
   }
 
-  private fun AppointmentOccurrence.markAsUpdated(
-    updated: LocalDateTime,
-    updatedBy: String,
-  ) {
-    this.updated = updated
-    this.updatedBy = updatedBy
-  }
-
-  private fun determineOccurrencesToApplyTo(appointmentOccurrence: AppointmentOccurrence, applyTo: ApplyTo, currentTime: LocalDateTime) =
+  private fun determineOccurrencesToApplyTo(appointment: Appointment, appointmentOccurrence: AppointmentOccurrence, applyTo: ApplyTo) =
     when (applyTo) {
       ApplyTo.THIS_AND_ALL_FUTURE_OCCURRENCES -> listOf(appointmentOccurrence).union(
-        appointmentOccurrence.appointment.occurrences().filter { LocalDateTime.of(it.startDate, it.startTime) > LocalDateTime.of(appointmentOccurrence.startDate, appointmentOccurrence.startTime) },
+        appointment.scheduledOccurrencesAfter(appointmentOccurrence.startDateTime()),
       )
-      ApplyTo.ALL_FUTURE_OCCURRENCES -> appointmentOccurrence.appointment.occurrences().filter { LocalDateTime.of(it.startDate, it.startTime) > currentTime }
+      ApplyTo.ALL_FUTURE_OCCURRENCES -> appointment.scheduledOccurrences()
       else -> listOf(appointmentOccurrence)
-    }.filter { !it.isCancelled() }
-
-  private fun logAppointmentEditedMetric(
-    principal: Principal,
-    appointmentOccurrenceId: Long,
-    request: AppointmentOccurrenceUpdateRequest,
-    appointment: Appointment,
-    telemetryPropertiesMap: MutableMap<String, String>,
-    telemetryMetricsMap: MutableMap<String, Double>,
-    startTimeInMs: Long,
-  ) {
-    telemetryPropertiesMap[USER_PROPERTY_KEY] = principal.name
-    telemetryPropertiesMap[PRISON_CODE_PROPERTY_KEY] = appointment.prisonCode
-    telemetryPropertiesMap[APPOINTMENT_SERIES_ID_PROPERTY_KEY] = appointment.appointmentId.toString()
-    telemetryPropertiesMap[APPOINTMENT_ID_PROPERTY_KEY] = appointmentOccurrenceId.toString()
-    telemetryPropertiesMap[APPLY_TO_PROPERTY_KEY] = request.applyTo.toString()
-
-    telemetryMetricsMap[PRISONERS_ADDED_COUNT_METRIC_KEY] = request.addPrisonerNumbers?.size?.toDouble() ?: 0.0
-    telemetryMetricsMap[PRISONERS_REMOVED_COUNT_METRIC_KEY] = request.removePrisonerNumbers?.size?.toDouble() ?: 0.0
-    telemetryMetricsMap[EVENT_TIME_MS_METRIC_KEY] = (System.currentTimeMillis() - startTimeInMs).toDouble()
-
-    telemetryClient.trackEvent(TelemetryEvent.APPOINTMENT_EDITED.value, telemetryPropertiesMap, telemetryMetricsMap)
-  }
+    }
 
   private fun logAppointmentCancelledMetric(
     principal: Principal,
@@ -430,28 +382,4 @@ class AppointmentOccurrenceService(
 
     telemetryClient.trackEvent(TelemetryEvent.APPOINTMENT_DELETED.value, propertiesMap, metricsMap)
   }
-
-  private fun createEditAppointmentTelemetryPropertiesMap() =
-    mutableMapOf(
-      USER_PROPERTY_KEY to "",
-      PRISON_CODE_PROPERTY_KEY to "",
-      APPOINTMENT_SERIES_ID_PROPERTY_KEY to "",
-      APPOINTMENT_ID_PROPERTY_KEY to "",
-      CATEGORY_CHANGED_PROPERTY_KEY to false.toString(),
-      INTERNAL_LOCATION_CHANGED_PROPERTY_KEY to false.toString(),
-      START_DATE_CHANGED_PROPERTY_KEY to false.toString(),
-      START_TIME_CHANGED_PROPERTY_KEY to false.toString(),
-      END_TIME_CHANGED_PROPERTY_KEY to false.toString(),
-      EXTRA_INFORMATION_CHANGED_PROPERTY_KEY to false.toString(),
-      APPLY_TO_PROPERTY_KEY to "",
-    )
-
-  private fun createEditAppointmentTelemetryMetricsMap() =
-    mutableMapOf(
-      PRISONERS_REMOVED_COUNT_METRIC_KEY to 0.0,
-      PRISONERS_ADDED_COUNT_METRIC_KEY to 0.0,
-      APPOINTMENT_COUNT_METRIC_KEY to 0.0,
-      APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 0.0,
-      EVENT_TIME_MS_METRIC_KEY to 0.0,
-    )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceService.kt
@@ -3,13 +3,10 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 import com.microsoft.applicationinsights.TelemetryClient
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrence
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceAllocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceUpdateDomainService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentOccurrenceCancelRequest
@@ -27,8 +24,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.EVENT
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.PRISON_CODE_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.TelemetryEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.USER_PROPERTY_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.toTelemetryMetricsMap
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.toTelemetryPropertiesMap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.checkCaseloadAccess
 import java.security.Principal
 import java.time.LocalDateTime
@@ -43,6 +38,7 @@ class AppointmentOccurrenceService(
   private val referenceCodeService: ReferenceCodeService,
   private val locationService: LocationService,
   private val prisonerSearchApiClient: PrisonerSearchApiClient,
+  private val appointmentOccurrenceUpdateDomainService: AppointmentOccurrenceUpdateDomainService,
   private val telemetryClient: TelemetryClient,
 ) {
   fun updateAppointmentOccurrence(appointmentOccurrenceId: Long, request: AppointmentOccurrenceUpdateRequest, principal: Principal): AppointmentModel {
@@ -61,8 +57,24 @@ class AppointmentOccurrenceService(
       "Cannot update a past appointment occurrence"
     }
 
-    val categoryMap = if (request.categoryCode?.isEmpty() == true) emptyMap() else referenceCodeService.getScheduleReasonsMap(ScheduleReasonEventType.APPOINTMENT)
-    val locationMap = if (request.internalLocationId == null) emptyMap() else locationService.getLocationsForAppointmentsMap(appointment.prisonCode)
+    if (request.categoryCode != null) {
+      referenceCodeService.getScheduleReasonsMap(ScheduleReasonEventType.APPOINTMENT)
+        .also {
+          require(it.containsKey(request.categoryCode)) {
+            "Appointment Category with code ${request.categoryCode} not found or is not active"
+          }
+        }
+    }
+
+    if (request.internalLocationId != null) {
+      locationService.getLocationsForAppointmentsMap(appointment.prisonCode)
+        .also {
+          require(it.containsKey(request.internalLocationId)) {
+            "Appointment location with id ${request.internalLocationId} not found in prison '${appointment.prisonCode}'"
+          }
+        }
+    }
+
     val prisonerMap = if (request.addPrisonerNumbers.isNullOrEmpty()) {
       emptyMap()
     } else {
@@ -80,42 +92,17 @@ class AppointmentOccurrenceService(
         }
     }
 
-    val occurrencesToUpdate = determineOccurrencesToApplyTo(appointment, appointmentOccurrence, request.applyTo)
-    var instanceCount = getUpdatedInstanceCount(request, appointment, occurrencesToUpdate)
-
-    val telemetryPropertiesMap = request.toTelemetryPropertiesMap(principal.name, appointment.prisonCode, appointment.appointmentId, appointmentOccurrence.appointmentOccurrenceId)
-    val telemetryMetricsMap = request.toTelemetryMetricsMap(occurrencesToUpdate.size)
-
-    applyCategoryCodeUpdate(request, appointment, categoryMap, now, principal.name)
-    applyStartDateUpdate(request, appointment, occurrencesToUpdate)
-    applyInternalLocationUpdate(request, appointment, occurrencesToUpdate, locationMap)
-    applyStartEndTimeUpdate(request, occurrencesToUpdate)
-    applyCommentUpdate(request, occurrencesToUpdate)
-    instanceCount += applyRemovePrisonersUpdate(request, appointment, occurrencesToUpdate)
-
-    if (request.isPropertyUpdate()) {
-      occurrencesToUpdate.forEach {
-        it.updated = now
-        it.updatedBy = principal.name
-      }
-    }
-
-    var updatedAppointment = appointmentRepository.saveAndFlush(appointment)
-
-    // Adding prisoners creates new allocations on the occurrence and publishes create instance events.
-    // This action must be performed after other updates have been saved and flushed to prevent update events being published as well as the create events
-    applyAddPrisonersUpdate(request, occurrencesToUpdate, prisonerMap).also {
-      if (it > 0) {
-        updatedAppointment = appointmentRepository.saveAndFlush(appointment)
-        instanceCount += it
-      }
-    }
-
-    telemetryMetricsMap[APPOINTMENT_INSTANCE_COUNT_METRIC_KEY] = instanceCount.toDouble()
-    telemetryMetricsMap[EVENT_TIME_MS_METRIC_KEY] = (System.currentTimeMillis() - startTimeInMs).toDouble()
-    telemetryClient.trackEvent(TelemetryEvent.APPOINTMENT_EDITED.value, telemetryPropertiesMap, telemetryMetricsMap)
-
-    return updatedAppointment.toModel()
+    return appointmentOccurrenceUpdateDomainService.updateAppointmentOccurrences(
+      appointment,
+      appointmentOccurrenceId,
+      determineOccurrencesToApplyTo(appointment, appointmentOccurrence, request.applyTo),
+      request,
+      prisonerMap,
+      now,
+      principal.name,
+      startTimeInMs,
+      true,
+    )
   }
 
   fun cancelAppointmentOccurrence(appointmentOccurrenceId: Long, request: AppointmentOccurrenceCancelRequest, principal: Principal): AppointmentModel {
@@ -171,155 +158,6 @@ class AppointmentOccurrenceService(
       }
 
     return updatedAppointment.toModel()
-  }
-
-  private fun getUpdatedInstanceCount(
-    request: AppointmentOccurrenceUpdateRequest,
-    appointment: Appointment,
-    occurrencesToUpdate: Collection<AppointmentOccurrence>,
-  ) =
-    if (request.categoryCode != null) {
-      appointment.scheduledOccurrences().flatMap { it.allocations() }.size
-    } else if (request.isPropertyUpdate()) {
-      occurrencesToUpdate.flatMap { it.allocations() }.size
-    } else {
-      0
-    }
-
-  private fun applyCategoryCodeUpdate(
-    request: AppointmentOccurrenceUpdateRequest,
-    appointment: Appointment,
-    categoryMap: Map<String, ReferenceCode>,
-    updated: LocalDateTime,
-    updatedBy: String,
-  ) {
-    request.categoryCode?.apply {
-      require(categoryMap.containsKey(this)) {
-        "Appointment Category with code $this not found or is not active"
-      }
-
-      // Category updates are applied at the appointment level
-      appointment.categoryCode = this
-
-      // Mark appointment and occurrences as updated
-      appointment.updated = updated
-      appointment.updatedBy = updatedBy
-
-      appointment.scheduledOccurrences().forEach {
-        it.updated = updated
-        it.updatedBy = updatedBy
-      }
-    }
-  }
-
-  private fun applyInternalLocationUpdate(
-    request: AppointmentOccurrenceUpdateRequest,
-    appointment: Appointment,
-    occurrencesToUpdate: Collection<AppointmentOccurrence>,
-    locationMap: Map<Long, Location>,
-  ) {
-    occurrencesToUpdate.forEach {
-      if (request.inCell == true) {
-        it.internalLocationId = null
-        it.inCell = true
-      } else {
-        request.internalLocationId?.apply {
-          require(locationMap.containsKey(this)) {
-            "Appointment location with id $this not found in prison '${appointment.prisonCode}'"
-          }
-          it.internalLocationId = this
-          it.inCell = false
-        }
-      }
-    }
-  }
-
-  private fun applyStartDateUpdate(
-    request: AppointmentOccurrenceUpdateRequest,
-    appointment: Appointment,
-    occurrencesToUpdate: Collection<AppointmentOccurrence>,
-  ) {
-    // Changing the start date of a repeat appointment changes the start date of all affected appointments based on the original schedule using the new start date
-    request.startDate?.apply {
-      val scheduleIterator = appointment.scheduleIterator().apply { startDate = request.startDate }
-      occurrencesToUpdate.sortedBy { it.sequenceNumber }.forEach {
-        it.startDate = scheduleIterator.next()
-      }
-    }
-  }
-
-  private fun applyStartEndTimeUpdate(
-    request: AppointmentOccurrenceUpdateRequest,
-    occurrencesToUpdate: Collection<AppointmentOccurrence>,
-  ) {
-    occurrencesToUpdate.forEach {
-      request.startTime?.apply {
-        it.startTime = this
-      }
-
-      request.endTime?.apply {
-        it.endTime = this
-      }
-    }
-  }
-
-  private fun applyCommentUpdate(
-    request: AppointmentOccurrenceUpdateRequest,
-    occurrencesToUpdate: Collection<AppointmentOccurrence>,
-  ) {
-    occurrencesToUpdate.forEach {
-      request.comment?.apply {
-        it.comment = this
-      }
-    }
-  }
-
-  private fun applyRemovePrisonersUpdate(
-    request: AppointmentOccurrenceUpdateRequest,
-    appointment: Appointment,
-    occurrencesToUpdate: Collection<AppointmentOccurrence>,
-  ): Int {
-    var removedInstanceCount = 0
-    occurrencesToUpdate.forEach { occurrenceToUpdate ->
-      request.removePrisonerNumbers?.forEach { prisonerToRemove ->
-        if (appointment.appointmentType == AppointmentType.INDIVIDUAL && request.removePrisonerNumbers.isNotEmpty()) {
-          throw IllegalArgumentException("Cannot remove prisoners from an individual appointment occurrence")
-        }
-        occurrenceToUpdate.allocations()
-          .filter { it.prisonerNumber == prisonerToRemove }
-          .forEach {
-            occurrenceToUpdate.removeAllocation(it)
-            removedInstanceCount++
-          }
-      }
-    }
-    return removedInstanceCount
-  }
-
-  private fun applyAddPrisonersUpdate(
-    request: AppointmentOccurrenceUpdateRequest,
-    occurrencesToUpdate: Collection<AppointmentOccurrence>,
-    prisonerMap: Map<String, Prisoner>,
-  ): Int {
-    var newInstanceCount = 0
-    occurrencesToUpdate.forEach { occurrenceToUpdate ->
-      request.addPrisonerNumbers?.apply {
-        val prisonerAllocationMap = occurrenceToUpdate.allocations().associateBy { allocation -> allocation.prisonerNumber }
-        val newPrisoners = prisonerMap.filter { !prisonerAllocationMap.containsKey(it.key) }.values
-          .also { newInstanceCount += it.size }
-
-        newPrisoners.forEach { prisoner ->
-          occurrenceToUpdate.addAllocation(
-            AppointmentOccurrenceAllocation(
-              appointmentOccurrence = occurrenceToUpdate,
-              prisonerNumber = prisoner.prisonerNumber,
-              bookingId = prisoner.bookingId!!.toLong(),
-            ),
-          )
-        }
-      }
-    }
-    return newInstanceCount
   }
 
   private fun determineOccurrencesToApplyTo(appointment: Appointment, appointmentOccurrence: AppointmentOccurrence, applyTo: ApplyTo) =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceService.kt
@@ -5,10 +5,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointment
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrence
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceUpdateDomainService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentType
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentOccurrenceCancelRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentOccurrenceUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentCancellationReasonRepository
@@ -66,6 +64,10 @@ class AppointmentOccurrenceService(
             "Appointment location with id ${request.internalLocationId} not found in prison '${appointment.prisonCode}'"
           }
         }
+    }
+
+    require(request.removePrisonerNumbers.isNullOrEmpty() || appointment.appointmentType != AppointmentType.INDIVIDUAL) {
+      "Cannot remove prisoners from an individual appointment occurrence"
     }
 
     val prisonerMap = if (request.addPrisonerNumbers.isNullOrEmpty()) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/telemetry/TelemetryTransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/telemetry/TelemetryTransformFunctions.kt
@@ -1,0 +1,32 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry
+
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentOccurrenceUpdateRequest
+
+fun AppointmentOccurrenceUpdateRequest.toTelemetryPropertiesMap(
+  user: String,
+  prisonCode: String,
+  appointmentId: Long,
+  appointmentOccurrenceId: Long,
+) =
+  mutableMapOf(
+    USER_PROPERTY_KEY to user,
+    PRISON_CODE_PROPERTY_KEY to prisonCode,
+    APPOINTMENT_SERIES_ID_PROPERTY_KEY to appointmentId.toString(),
+    APPOINTMENT_ID_PROPERTY_KEY to appointmentOccurrenceId.toString(),
+    CATEGORY_CHANGED_PROPERTY_KEY to (this.categoryCode != null).toString(),
+    INTERNAL_LOCATION_CHANGED_PROPERTY_KEY to (this.internalLocationId != null).toString(),
+    START_DATE_CHANGED_PROPERTY_KEY to (this.startDate != null).toString(),
+    START_TIME_CHANGED_PROPERTY_KEY to (this.startTime != null).toString(),
+    END_TIME_CHANGED_PROPERTY_KEY to (this.endTime != null).toString(),
+    EXTRA_INFORMATION_CHANGED_PROPERTY_KEY to (this.comment != null).toString(),
+    APPLY_TO_PROPERTY_KEY to this.applyTo.toString(),
+  )
+
+fun AppointmentOccurrenceUpdateRequest.toTelemetryMetricsMap(appointmentOccurrenceCount: Int) =
+  mutableMapOf(
+    APPOINTMENT_COUNT_METRIC_KEY to appointmentOccurrenceCount.toDouble(),
+    APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 0.0,
+    PRISONERS_REMOVED_COUNT_METRIC_KEY to (this.removePrisonerNumbers?.size?.toDouble() ?: 0.0),
+    PRISONERS_ADDED_COUNT_METRIC_KEY to (this.addPrisonerNumbers?.size?.toDouble() ?: 0.0),
+    EVENT_TIME_MS_METRIC_KEY to 0.0,
+  )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/telemetry/TelemetryTransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/telemetry/TelemetryTransformFunctions.kt
@@ -22,10 +22,10 @@ fun AppointmentOccurrenceUpdateRequest.toTelemetryPropertiesMap(
     APPLY_TO_PROPERTY_KEY to this.applyTo.toString(),
   )
 
-fun AppointmentOccurrenceUpdateRequest.toTelemetryMetricsMap(appointmentOccurrenceCount: Int) =
+fun AppointmentOccurrenceUpdateRequest.toTelemetryMetricsMap(appointmentOccurrenceCount: Int, appointmentInstanceCount: Int) =
   mutableMapOf(
     APPOINTMENT_COUNT_METRIC_KEY to appointmentOccurrenceCount.toDouble(),
-    APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 0.0,
+    APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to appointmentInstanceCount.toDouble(),
     PRISONERS_REMOVED_COUNT_METRIC_KEY to (this.removePrisonerNumbers?.size?.toDouble() ?: 0.0),
     PRISONERS_ADDED_COUNT_METRIC_KEY to (this.addPrisonerNumbers?.size?.toDouble() ?: 0.0),
     EVENT_TIME_MS_METRIC_KEY to 0.0,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceEntityListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceEntityListenerTest.kt
@@ -1,0 +1,59 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCancelledReason
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentDeletedReason
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@ActiveProfiles("test")
+class AppointmentOccurrenceEntityListenerTest(@Autowired private val listener: AppointmentOccurrenceEntityListener) {
+
+  @MockBean
+  private lateinit var outboundEventsService: OutboundEventsService
+
+  private val appointment = appointmentEntity(
+    prisonerNumberToBookingIdMap = mapOf("A1234BC" to 456, "B2345CD" to 457, "C3456DE" to 457),
+  )
+  private var appointmentOccurrence = appointment.occurrences().first()
+
+  @Test
+  fun `appointment instance updated events raised on occurrence update`() {
+    listener.onUpdate(appointmentOccurrence)
+
+    appointmentOccurrence.allocations().forEach {
+      verify(outboundEventsService).send(OutboundEvent.APPOINTMENT_INSTANCE_UPDATED, it.appointmentOccurrenceAllocationId)
+    }
+    verifyNoMoreInteractions(outboundEventsService)
+  }
+
+  @Test
+  fun `appointment instance cancelled events raised on occurrence update when occurrence is cancelled`() {
+    appointmentOccurrence.cancellationReason = appointmentCancelledReason()
+    listener.onUpdate(appointmentOccurrence)
+
+    appointmentOccurrence.allocations().forEach {
+      verify(outboundEventsService).send(OutboundEvent.APPOINTMENT_INSTANCE_CANCELLED, it.appointmentOccurrenceAllocationId)
+    }
+    verifyNoMoreInteractions(outboundEventsService)
+  }
+
+  @Test
+  fun `appointment instance deleted events raised on occurrence update when occurrence is deleted`() {
+    appointmentOccurrence.cancellationReason = appointmentDeletedReason()
+    listener.onUpdate(appointmentOccurrence)
+
+    appointmentOccurrence.allocations().forEach {
+      verify(outboundEventsService).send(OutboundEvent.APPOINTMENT_INSTANCE_DELETED, it.appointmentOccurrenceAllocationId)
+    }
+    verifyNoMoreInteractions(outboundEventsService)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceTest.kt
@@ -32,77 +32,86 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointm
 class AppointmentOccurrenceTest {
   @Test
   fun `not cancelled or deleted when cancellation reason is null`() {
-    val entity = appointmentEntity().occurrences().first()
-    entity.cancellationReason = null
+    val entity = appointmentEntity().occurrences().first().apply {
+      cancellationReason = null
+    }
     entity.isCancelled() isEqualTo false
     entity.isDeleted() isEqualTo false
   }
 
   @Test
   fun `cancelled but not deleted when cancellation reason is not deleted`() {
-    val entity = appointmentEntity().occurrences().first()
-    entity.cancellationReason = appointmentCancelledReason()
+    val entity = appointmentEntity().occurrences().first().apply {
+      cancellationReason = appointmentCancelledReason()
+    }
     entity.isCancelled() isEqualTo true
     entity.isDeleted() isEqualTo false
   }
 
   @Test
   fun `deleted but not cancelled when cancellation reason is deleted`() {
-    val entity = appointmentEntity().occurrences().first()
-    entity.cancellationReason = appointmentDeletedReason()
+    val entity = appointmentEntity().occurrences().first().apply {
+      cancellationReason = appointmentDeletedReason()
+    }
     entity.isCancelled() isEqualTo false
     entity.isDeleted() isEqualTo true
   }
 
   @Test
   fun `expired when start date time is in the past`() {
-    val entity = appointmentEntity().occurrences().first()
-    entity.startDate = LocalDate.now()
-    entity.startTime = LocalTime.now().minusMinutes(1)
+    val entity = appointmentEntity().occurrences().first().apply {
+      startDate = LocalDate.now()
+      startTime = LocalTime.now().minusMinutes(1)
+    }
     entity.isExpired() isEqualTo true
   }
 
   @Test
   fun `not expired when start date time is in the future`() {
-    val entity = appointmentEntity().occurrences().first()
-    entity.startDate = LocalDate.now()
-    entity.startTime = LocalTime.now().plusMinutes(1)
+    val entity = appointmentEntity().occurrences().first().apply {
+      startDate = LocalDate.now()
+      startTime = LocalTime.now().plusMinutes(1)
+    }
     entity.isExpired() isEqualTo false
   }
 
   @Test
   fun `scheduled when start date time is in the future, not cancelled or deleted`() {
-    val entity = appointmentEntity().occurrences().first()
-    entity.startDate = LocalDate.now()
-    entity.startTime = LocalTime.now().plusMinutes(1)
-    entity.cancellationReason = null
+    val entity = appointmentEntity().occurrences().first().apply {
+      startDate = LocalDate.now()
+      startTime = LocalTime.now().plusMinutes(1)
+      cancellationReason = null
+    }
     entity.isScheduled() isEqualTo true
   }
 
   @Test
   fun `not scheduled when start date time is in the past, not cancelled or deleted`() {
-    val entity = appointmentEntity().occurrences().first()
-    entity.startDate = LocalDate.now()
-    entity.startTime = LocalTime.now().minusMinutes(1)
-    entity.cancellationReason = null
+    val entity = appointmentEntity().occurrences().first().apply {
+      startDate = LocalDate.now()
+      startTime = LocalTime.now().minusMinutes(1)
+      cancellationReason = null
+    }
     entity.isScheduled() isEqualTo false
   }
 
   @Test
   fun `not scheduled when start date time is in the future but is cancelled`() {
-    val entity = appointmentEntity().occurrences().first()
-    entity.startDate = LocalDate.now()
-    entity.startTime = LocalTime.now().plusMinutes(1)
-    entity.cancellationReason = appointmentCancelledReason()
+    val entity = appointmentEntity().occurrences().first().apply {
+      startDate = LocalDate.now()
+      startTime = LocalTime.now().plusMinutes(1)
+      cancellationReason = appointmentCancelledReason()
+    }
     entity.isScheduled() isEqualTo false
   }
 
   @Test
   fun `not scheduled when start date time is in the future but is deleted`() {
-    val entity = appointmentEntity().occurrences().first()
-    entity.startDate = LocalDate.now()
-    entity.startTime = LocalTime.now().plusMinutes(1)
-    entity.cancellationReason = appointmentDeletedReason()
+    val entity = appointmentEntity().occurrences().first().apply {
+      startDate = LocalDate.now()
+      startTime = LocalTime.now().plusMinutes(1)
+      cancellationReason = appointmentDeletedReason()
+    }
     entity.isScheduled() isEqualTo false
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceTest.kt
@@ -7,12 +7,15 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCancelledReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCategoryReferenceCode
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentDeletedReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentOccurrenceDetails
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentOccurrenceModel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.bulkAppointmentEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentLocationSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentOccurrenceSummary
@@ -24,9 +27,85 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.Prisone
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentRepeatPeriod as AppointmentRepeatPeriodEnity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentRepeatPeriod as AppointmentRepeatPeriodEntity
 
 class AppointmentOccurrenceTest {
+  @Test
+  fun `not cancelled or deleted when cancellation reason is null`() {
+    val entity = appointmentEntity().occurrences().first()
+    entity.cancellationReason = null
+    entity.isCancelled() isEqualTo false
+    entity.isDeleted() isEqualTo false
+  }
+
+  @Test
+  fun `cancelled but not deleted when cancellation reason is not deleted`() {
+    val entity = appointmentEntity().occurrences().first()
+    entity.cancellationReason = appointmentCancelledReason()
+    entity.isCancelled() isEqualTo true
+    entity.isDeleted() isEqualTo false
+  }
+
+  @Test
+  fun `deleted but not cancelled when cancellation reason is deleted`() {
+    val entity = appointmentEntity().occurrences().first()
+    entity.cancellationReason = appointmentDeletedReason()
+    entity.isCancelled() isEqualTo false
+    entity.isDeleted() isEqualTo true
+  }
+
+  @Test
+  fun `expired when start date time is in the past`() {
+    val entity = appointmentEntity().occurrences().first()
+    entity.startDate = LocalDate.now()
+    entity.startTime = LocalTime.now().minusMinutes(1)
+    entity.isExpired() isEqualTo true
+  }
+
+  @Test
+  fun `not expired when start date time is in the future`() {
+    val entity = appointmentEntity().occurrences().first()
+    entity.startDate = LocalDate.now()
+    entity.startTime = LocalTime.now().plusMinutes(1)
+    entity.isExpired() isEqualTo false
+  }
+
+  @Test
+  fun `scheduled when start date time is in the future, not cancelled or deleted`() {
+    val entity = appointmentEntity().occurrences().first()
+    entity.startDate = LocalDate.now()
+    entity.startTime = LocalTime.now().plusMinutes(1)
+    entity.cancellationReason = null
+    entity.isScheduled() isEqualTo true
+  }
+
+  @Test
+  fun `not scheduled when start date time is in the past, not cancelled or deleted`() {
+    val entity = appointmentEntity().occurrences().first()
+    entity.startDate = LocalDate.now()
+    entity.startTime = LocalTime.now().minusMinutes(1)
+    entity.cancellationReason = null
+    entity.isScheduled() isEqualTo false
+  }
+
+  @Test
+  fun `not scheduled when start date time is in the future but is cancelled`() {
+    val entity = appointmentEntity().occurrences().first()
+    entity.startDate = LocalDate.now()
+    entity.startTime = LocalTime.now().plusMinutes(1)
+    entity.cancellationReason = appointmentCancelledReason()
+    entity.isScheduled() isEqualTo false
+  }
+
+  @Test
+  fun `not scheduled when start date time is in the future but is deleted`() {
+    val entity = appointmentEntity().occurrences().first()
+    entity.startDate = LocalDate.now()
+    entity.startTime = LocalTime.now().plusMinutes(1)
+    entity.cancellationReason = appointmentDeletedReason()
+    entity.isScheduled() isEqualTo false
+  }
+
   @Test
   fun `entity to model mapping`() {
     val entity = appointmentEntity().occurrences().first()
@@ -505,7 +584,7 @@ class AppointmentOccurrenceTest {
 
   @Test
   fun `entity to details mapping repeat appointment`() {
-    val appointment = appointmentEntity(repeatPeriod = AppointmentRepeatPeriodEnity.WEEKLY, numberOfOccurrences = 4)
+    val appointment = appointmentEntity(repeatPeriod = AppointmentRepeatPeriodEntity.WEEKLY, numberOfOccurrences = 4)
     val entity = appointment.occurrences().first()
     val referenceCodeMap = mapOf(appointment.categoryCode to appointmentCategoryReferenceCode(appointment.categoryCode))
     val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceUpdateDomainServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceUpdateDomainServiceTest.kt
@@ -1,0 +1,84 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import com.microsoft.applicationinsights.TelemetryClient
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.mock
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentOccurrenceUpdateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentRepository
+import java.time.LocalTime
+
+class AppointmentOccurrenceUpdateDomainServiceTest {
+  private val appointmentRepository: AppointmentRepository = mock()
+  private val telemetryClient: TelemetryClient = mock()
+
+  private val telemetryPropertyMap = argumentCaptor<Map<String, String>>()
+  private val telemetryMetricsMap = argumentCaptor<Map<String, Double>>()
+
+  private val service = AppointmentOccurrenceUpdateDomainService(appointmentRepository, telemetryClient)
+
+  private val prisonerNumberToBookingIdMap = mapOf("A1234BC" to 1L, "B2345CD" to 2L, "C3456DE" to 3L)
+  private val appointment = appointmentEntity(prisonerNumberToBookingIdMap = prisonerNumberToBookingIdMap, repeatPeriod = AppointmentRepeatPeriod.DAILY, numberOfOccurrences = 4)
+  private val appointmentOccurrence = appointment.occurrences()[1]
+  private val applyToThis = appointment.applyToOccurrences(appointmentOccurrence, ApplyTo.THIS_OCCURRENCE, "")
+  private val applyToThisAndAllFuture = appointment.applyToOccurrences(appointmentOccurrence, ApplyTo.THIS_AND_ALL_FUTURE_OCCURRENCES, "")
+  private val applyToAllFuture = appointment.applyToOccurrences(appointmentOccurrence, ApplyTo.ALL_FUTURE_OCCURRENCES, "")
+
+  @Test
+  fun `no updates`() {
+    val request = AppointmentOccurrenceUpdateRequest()
+    val appointment = appointmentEntity()
+    service.getUpdatedInstanceCount(request, appointment, appointment.occurrences()) isEqualTo 0
+  }
+
+  @Test
+  fun `update category code`() {
+    val request = AppointmentOccurrenceUpdateRequest(categoryCode = "NEW")
+    service.getUpdatedInstanceCount(request, appointment, applyToThis) isEqualTo 12
+  }
+
+  @Test
+  fun `update location`() {
+    val request = AppointmentOccurrenceUpdateRequest(internalLocationId = 456)
+    service.getUpdatedInstanceCount(request, appointment, applyToThisAndAllFuture) isEqualTo applyToThisAndAllFuture.flatMap { it.allocations() }.size
+  }
+
+  @Test
+  fun `remove prisoners`() {
+    // Only A1234BC is currently allocated
+    val request = AppointmentOccurrenceUpdateRequest(removePrisonerNumbers = listOf("A1234BC", "D4567EF"))
+    service.getUpdatedInstanceCount(request, appointment, applyToAllFuture) isEqualTo applyToAllFuture.size
+  }
+
+  @Test
+  fun `add prisoners`() {
+    // C3456DE is already allocated
+    val request = AppointmentOccurrenceUpdateRequest(addPrisonerNumbers = listOf("C3456DE", "D4567EF", "E5678FG"))
+    service.getUpdatedInstanceCount(request, appointment, applyToThis) isEqualTo applyToThis.size * 2
+  }
+
+  @Test
+  fun `instance count does not include removed prisoners when a property is also updated`() {
+    val request = AppointmentOccurrenceUpdateRequest(startTime = LocalTime.of(8, 30), removePrisonerNumbers = listOf("A1234BC", "D4567EF"))
+    service.getUpdatedInstanceCount(request, appointment, applyToThisAndAllFuture) isEqualTo applyToThisAndAllFuture.flatMap { it.allocations() }.size
+  }
+
+  @Test
+  fun `instance count includes added prisoners when a property is also updated`() {
+    val request = AppointmentOccurrenceUpdateRequest(endTime = LocalTime.of(11, 0), addPrisonerNumbers = listOf("D4567EF", "E5678FG"))
+    service.getUpdatedInstanceCount(request, appointment, applyToAllFuture) isEqualTo applyToAllFuture.flatMap { it.allocations() }.size + (applyToAllFuture.size * 2)
+  }
+
+  @Test
+  fun `update a property, remove a prisoner and add two prisoners`() {
+    val request = AppointmentOccurrenceUpdateRequest(
+      comment = "New",
+      removePrisonerNumbers = listOf("A1234BC", "D4567EF"),
+      addPrisonerNumbers = listOf("C3456DE", "D4567EF", "E5678FG"),
+    )
+    service.getUpdatedInstanceCount(request, appointment, applyToAllFuture) isEqualTo applyToAllFuture.flatMap { it.allocations() }.size + (applyToAllFuture.size * 2)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCategoryReferenceCode
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentDeletedReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentDetails
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
@@ -36,7 +37,7 @@ class AppointmentTest {
 
   @Test
   fun `occurrences filters out soft deleted occurrences`() {
-    val entity = appointmentEntity(repeatPeriod = AppointmentRepeatPeriod.WEEKLY, numberOfOccurrences = 3).apply { occurrences().first().deleted = true }
+    val entity = appointmentEntity(repeatPeriod = AppointmentRepeatPeriod.WEEKLY, numberOfOccurrences = 3).apply { occurrences().first().cancellationReason = appointmentDeletedReason() }
     with(entity.occurrences()) {
       assertThat(size).isEqualTo(2)
       assertThat(this.map { it.appointmentOccurrenceId }).isEqualTo(listOf(2L, 3L))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers
 
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointment
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentCancellationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrence
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceAllocation
@@ -198,6 +199,20 @@ internal fun bulkAppointmentEntity(
       count++
     }
   }
+
+internal fun appointmentCancelledReason() =
+  AppointmentCancellationReason(
+    2,
+    "Cancelled",
+    false,
+  )
+
+internal fun appointmentDeletedReason() =
+  AppointmentCancellationReason(
+    1,
+    "Created in error",
+    true,
+  )
 
 private fun appointmentOccurrenceAllocationSearchEntity(appointmentOccurrenceSearch: AppointmentOccurrenceSearch, appointmentOccurrenceAllocationId: Long = 1, prisonerNumber: String = "A1234BC", bookingId: Long = 456) =
   AppointmentOccurrenceAllocationSearch(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentOccurrenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentOccurrenceIntegrationTest.kt
@@ -304,21 +304,34 @@ class AppointmentOccurrenceIntegrationTest : IntegrationTestBase() {
       assertThat(occurrences[1].startDate).isEqualTo(LocalDate.now().minusDays(3).plusWeeks(1))
       assertThat(occurrences[2].startDate).isEqualTo(request.startDate)
       assertThat(occurrences[3].startDate).isEqualTo(request.startDate!!.plusWeeks(1))
-      with(occurrences.subList(0, 2)) {
-        assertThat(map { it.internalLocationId }.distinct().single()).isEqualTo(123)
-        assertThat(map { it.inCell }.distinct().single()).isFalse
-        assertThat(map { it.startTime }.distinct().single()).isEqualTo(LocalTime.of(9, 0))
-        assertThat(map { it.endTime }.distinct().single()).isEqualTo(LocalTime.of(10, 30))
-        assertThat(map { it.comment }.distinct().single()).isEqualTo("Appointment occurrence level comment")
-        assertThat(map { it.updated }.distinct().single()).isCloseTo(
+      with(occurrences[0]) {
+        assertThat(internalLocationId).isEqualTo(123)
+        assertThat(inCell).isFalse
+        assertThat(startTime).isEqualTo(LocalTime.of(9, 0))
+        assertThat(endTime).isEqualTo(LocalTime.of(10, 30))
+        assertThat(comment).isEqualTo("Appointment occurrence level comment")
+        assertThat(updated).isNull()
+        assertThat(updatedBy).isNull()
+        assertThat(allocations[0].prisonerNumber).isEqualTo("A1234BC")
+        assertThat(allocations[0].bookingId).isEqualTo(456)
+        assertThat(allocations[1].prisonerNumber).isEqualTo("B2345CD")
+        assertThat(allocations[1].bookingId).isEqualTo(457)
+      }
+      with(occurrences[1]) {
+        assertThat(internalLocationId).isEqualTo(123)
+        assertThat(inCell).isFalse
+        assertThat(startTime).isEqualTo(LocalTime.of(9, 0))
+        assertThat(endTime).isEqualTo(LocalTime.of(10, 30))
+        assertThat(comment).isEqualTo("Appointment occurrence level comment")
+        assertThat(updated).isCloseTo(
           LocalDateTime.now(),
           within(60, ChronoUnit.SECONDS),
         )
-        assertThat(map { it.updatedBy }.distinct().single()).isEqualTo("test-client")
-        assertThat(map { it.allocations[0].prisonerNumber }.distinct().single()).isEqualTo("A1234BC")
-        assertThat(map { it.allocations[0].bookingId }.distinct().single()).isEqualTo(456)
-        assertThat(map { it.allocations[1].prisonerNumber }.distinct().single()).isEqualTo("B2345CD")
-        assertThat(map { it.allocations[1].bookingId }.distinct().single()).isEqualTo(457)
+        assertThat(updatedBy).isEqualTo("test-client")
+        assertThat(allocations[0].prisonerNumber).isEqualTo("A1234BC")
+        assertThat(allocations[0].bookingId).isEqualTo(456)
+        assertThat(allocations[1].prisonerNumber).isEqualTo("B2345CD")
+        assertThat(allocations[1].bookingId).isEqualTo(457)
       }
       with(occurrences.subList(2, occurrences.size)) {
         assertThat(map { it.internalLocationId }.distinct().single()).isEqualTo(request.internalLocationId)
@@ -338,7 +351,7 @@ class AppointmentOccurrenceIntegrationTest : IntegrationTestBase() {
       }
     }
 
-    verify(eventsPublisher, times(10)).send(eventCaptor.capture())
+    verify(eventsPublisher, times(8)).send(eventCaptor.capture())
 
     with(eventCaptor.allValues.filter { it.eventType == "appointments.appointment-instance.created" }) {
       assertThat(size).isEqualTo(2)
@@ -357,10 +370,8 @@ class AppointmentOccurrenceIntegrationTest : IntegrationTestBase() {
     }
 
     with(eventCaptor.allValues.filter { it.eventType == "appointments.appointment-instance.updated" }) {
-      assertThat(size).isEqualTo(6)
+      assertThat(size).isEqualTo(4)
       assertThat(map { it.additionalInformation }).contains(
-        AppointmentInstanceInformation(20),
-        AppointmentInstanceInformation(21),
         AppointmentInstanceInformation(22),
         AppointmentInstanceInformation(23),
         AppointmentInstanceInformation(25),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentOccurrenceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentOccurrenceIntegrationTest.kt
@@ -105,7 +105,7 @@ class AppointmentOccurrenceIntegrationTest : IntegrationTestBase() {
       }
     }
 
-    verify(eventsPublisher).send(eventCaptor.capture())
+    verify(eventsPublisher, times(1)).send(eventCaptor.capture())
 
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo("appointments.appointment-instance.updated")
@@ -136,7 +136,7 @@ class AppointmentOccurrenceIntegrationTest : IntegrationTestBase() {
       }
     }
 
-    verify(eventsPublisher).send(eventCaptor.capture())
+    verify(eventsPublisher, times(1)).send(eventCaptor.capture())
 
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo("appointments.appointment-instance.cancelled")
@@ -164,7 +164,7 @@ class AppointmentOccurrenceIntegrationTest : IntegrationTestBase() {
 
     assertThat(updatedAppointment.occurrences).isEmpty()
 
-    verify(eventsPublisher).send(eventCaptor.capture())
+    verify(eventsPublisher, times(1)).send(eventCaptor.capture())
 
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo("appointments.appointment-instance.deleted")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -246,7 +246,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
 
   @Test
   @Sql("classpath:test_data/seed-appointments-changed-event.sql")
-  fun `appointments cancelled when appointments changed event received with action set to YES`() {
+  fun `appointments deleted when appointments changed event received with action set to YES`() {
     val appointmentOccurrenceIds = listOf(200L, 201L, 202L, 203L, 210L, 211L, 212L)
     prisonApiMockServer.stubGetPrisonerDetails(
       prisonerNumber = "A1234BC",
@@ -303,7 +303,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
 
   @Test
   @Sql("classpath:test_data/seed-appointments-changed-event.sql")
-  fun `appointments cancelled when offender released event received`() {
+  fun `appointments deleted when offender released event received`() {
     val appointmentOccurrenceIds = listOf(200L, 201L, 202L, 203L, 210L, 211L, 212L)
     prisonApiMockServer.stubGetPrisonerDetails(
       prisonerNumber = "A1234BC",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentOccurrenceUpdateRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentOccurrenceUpdateRequestTest.kt
@@ -6,6 +6,7 @@ import jakarta.validation.Validator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCreateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import java.time.LocalDate
 import java.time.LocalTime
 
@@ -46,6 +47,54 @@ class AppointmentOccurrenceUpdateRequestTest {
   fun `cannot update start date for all future occurrences`() {
     val request = AppointmentOccurrenceUpdateRequest(startDate = LocalDate.now().plusDays(1), applyTo = ApplyTo.ALL_FUTURE_OCCURRENCES)
     assertSingleValidationError(validator.validate(request), "applyTo", "Cannot update start date for all future occurrences")
+  }
+
+  @Test
+  fun `is property update false when no property update is supplied`() {
+    val request = AppointmentOccurrenceUpdateRequest()
+    request.isPropertyUpdate() isEqualTo false
+  }
+
+  @Test
+  fun `is property update true when category code update is supplied`() {
+    val request = AppointmentOccurrenceUpdateRequest(categoryCode = "NEW")
+    request.isPropertyUpdate() isEqualTo true
+  }
+
+  @Test
+  fun `is property update true when internal location update is supplied`() {
+    val request = AppointmentOccurrenceUpdateRequest(internalLocationId = 123)
+    request.isPropertyUpdate() isEqualTo true
+  }
+
+  @Test
+  fun `is property update true when in cell update is supplied`() {
+    val request = AppointmentOccurrenceUpdateRequest(inCell = true)
+    request.isPropertyUpdate() isEqualTo true
+  }
+
+  @Test
+  fun `is property update true when start date update is supplied`() {
+    val request = AppointmentOccurrenceUpdateRequest(startDate = LocalDate.now().plusDays(1))
+    request.isPropertyUpdate() isEqualTo true
+  }
+
+  @Test
+  fun `is property update true when start time update is supplied`() {
+    val request = AppointmentOccurrenceUpdateRequest(startTime = LocalTime.of(11, 30))
+    request.isPropertyUpdate() isEqualTo true
+  }
+
+  @Test
+  fun `is property update true when end time update is supplied`() {
+    val request = AppointmentOccurrenceUpdateRequest(endTime = LocalTime.of(14, 0))
+    request.isPropertyUpdate() isEqualTo true
+  }
+
+  @Test
+  fun `is property update true when comment update is supplied`() {
+    val request = AppointmentOccurrenceUpdateRequest(comment = "New")
+    request.isPropertyUpdate() isEqualTo true
   }
 
   private fun assertSingleValidationError(validate: MutableSet<ConstraintViolation<AppointmentOccurrenceUpdateRequest>>, propertyName: String, message: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentOccurrenceUpdateRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentOccurrenceUpdateRequestTest.kt
@@ -5,7 +5,6 @@ import jakarta.validation.Validation
 import jakarta.validation.Validator
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import java.time.LocalDate
 import java.time.LocalTime
@@ -15,7 +14,7 @@ class AppointmentOccurrenceUpdateRequestTest {
 
   @Test
   fun `valid request`() {
-    val request = appointmentCreateRequest()
+    val request = AppointmentOccurrenceUpdateRequest()
     assertThat(validator.validate(request)).isEmpty()
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceCancelTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceCancelTest.kt
@@ -21,6 +21,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentCancellationReason
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceUpdateDomainService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentRepeatPeriod
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
@@ -69,6 +70,7 @@ class AppointmentOccurrenceServiceCancelTest {
     referenceCodeService,
     locationService,
     prisonerSearchApiClient,
+    AppointmentOccurrenceUpdateDomainService(appointmentRepository, telemetryClient),
     telemetryClient,
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceUpdateTest.kt
@@ -783,7 +783,11 @@ class AppointmentOccurrenceServiceUpdateTest {
         assertThat(categoryCode).isEqualTo(request.categoryCode)
         assertThat(updated).isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
         assertThat(updatedBy).isEqualTo("TEST.USER")
-        with(occurrences) {
+        with(occurrences[0]) {
+          assertThat(updated).isNull()
+          assertThat(updatedBy).isNull()
+        }
+        with(occurrences.subList(1, response.occurrences.size)) {
           assertThat(map { it.updated }.distinct().single()).isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
           assertThat(map { it.updatedBy }.distinct().single()).isEqualTo("TEST.USER")
         }
@@ -1959,20 +1963,20 @@ class AppointmentOccurrenceServiceUpdateTest {
         assertThat(occurrences[1].startDate).isEqualTo(LocalDate.now().minusDays(3).plusWeeks(1))
         assertThat(occurrences[2].startDate).isEqualTo(request.startDate)
         assertThat(occurrences[3].startDate).isEqualTo(request.startDate!!.plusWeeks(1))
-        with(occurrences.subList(0, 2)) {
-          assertThat(map { it.internalLocationId }.distinct().single()).isEqualTo(123)
-          assertThat(map { it.inCell }.distinct().single()).isFalse
-          assertThat(map { it.startTime }.distinct().single()).isEqualTo(LocalTime.of(9, 0))
-          assertThat(map { it.endTime }.distinct().single()).isEqualTo(LocalTime.of(10, 30))
-          assertThat(map { it.comment }.distinct().single()).isEqualTo("Appointment occurrence level comment")
-          assertThat(map { it.updated }.distinct().single()).isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
-          assertThat(map { it.updatedBy }.distinct().single()).isEqualTo("TEST.USER")
-          assertThat(map { it.allocations[0].prisonerNumber }.distinct().single()).isEqualTo("A1234BC")
-          assertThat(map { it.allocations[0].bookingId }.distinct().single()).isEqualTo(456)
-          assertThat(map { it.allocations[1].prisonerNumber }.distinct().single()).isEqualTo("B2345CD")
-          assertThat(map { it.allocations[1].bookingId }.distinct().single()).isEqualTo(457)
+        with(occurrences[0]) {
+          assertThat(internalLocationId).isEqualTo(123)
+          assertThat(inCell).isFalse
+          assertThat(startTime).isEqualTo(LocalTime.of(9, 0))
+          assertThat(endTime).isEqualTo(LocalTime.of(10, 30))
+          assertThat(comment).isEqualTo("Appointment occurrence level comment")
+          assertThat(updated).isNull()
+          assertThat(updatedBy).isNull()
+          assertThat(allocations[0].prisonerNumber).isEqualTo("A1234BC")
+          assertThat(allocations[0].bookingId).isEqualTo(456)
+          assertThat(allocations[1].prisonerNumber).isEqualTo("B2345CD")
+          assertThat(allocations[1].bookingId).isEqualTo(457)
         }
-        with(occurrences.subList(2, occurrences.size)) {
+        with(occurrences.subList(3, occurrences.size)) {
           assertThat(map { it.internalLocationId }.distinct().single()).isEqualTo(request.internalLocationId)
           assertThat(map { it.inCell }.distinct().single()).isFalse
           assertThat(map { it.startTime }.distinct().single()).isEqualTo(request.startTime)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceUpdateTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentCancellationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrence
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceUpdateDomainService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentRepeatPeriod
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCategoryReferenceCode
@@ -84,6 +85,7 @@ class AppointmentOccurrenceServiceUpdateTest {
     referenceCodeService,
     locationService,
     prisonerSearchApiClient,
+    AppointmentOccurrenceUpdateDomainService(appointmentRepository, telemetryClient),
     telemetryClient,
   )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceUpdateTest.kt
@@ -137,38 +137,12 @@ class AppointmentOccurrenceServiceUpdateTest {
     }
 
     @Test
-    fun `update category code throws illegal argument exception when appointment occurrence is in the past`() {
-      val request = AppointmentOccurrenceUpdateRequest()
-
-      val appointment = appointmentEntity(appointmentId = 2, startDate = LocalDate.now(), startTime = LocalTime.now().minusMinutes(1), endTime = LocalTime.now().plusHours(1))
-      val appointmentOccurrence = appointment.occurrences().first()
-
-      whenever(appointmentOccurrenceRepository.findById(appointmentOccurrence.appointmentOccurrenceId)).thenReturn(
-        Optional.of(appointmentOccurrence),
-      )
-
-      assertThatThrownBy { service.updateAppointmentOccurrence(appointmentOccurrence.appointmentOccurrenceId, request, principal) }.isInstanceOf(IllegalArgumentException::class.java)
-        .hasMessage("Cannot update a past appointment occurrence")
-
-      verify(appointmentRepository, never()).saveAndFlush(any())
-    }
-
-    @Test
-    fun `update category code throws illegal argument exception when appointment occurrence is cancelled`() {
-      val request = AppointmentOccurrenceUpdateRequest()
-
-      val appointment = appointmentEntity()
-      val appointmentOccurrence = appointment.occurrences().first()
-      appointmentOccurrence.cancellationReason = AppointmentCancellationReason(2L, "Cancelled", false)
-
-      whenever(appointmentOccurrenceRepository.findById(appointmentOccurrence.appointmentOccurrenceId)).thenReturn(
-        Optional.of(appointmentOccurrence),
-      )
-
-      assertThatThrownBy { service.updateAppointmentOccurrence(appointmentOccurrence.appointmentOccurrenceId, request, principal) }.isInstanceOf(IllegalArgumentException::class.java)
-        .hasMessage("Cannot update a cancelled appointment occurrence")
-
-      verify(appointmentRepository, never()).saveAndFlush(any())
+    fun `update appointment throws caseload access exception if caseload id header does not match`() {
+      val appointmentOccurrence = expectIndividualAppointment()
+      addCaseloadIdToRequestHeader("WRONG")
+      val request = AppointmentOccurrenceUpdateRequest(internalLocationId = 456, applyTo = ApplyTo.ALL_FUTURE_OCCURRENCES)
+      assertThatThrownBy { service.updateAppointmentOccurrence(appointmentOccurrence.appointmentOccurrenceId, request, principal) }
+        .isInstanceOf(CaseloadAccessException::class.java)
     }
 
     @Test
@@ -1992,44 +1966,6 @@ class AppointmentOccurrenceServiceUpdateTest {
           assertThat(map { it.allocations[1].bookingId }.distinct().single()).isEqualTo(458)
         }
       }
-    }
-
-    @Test
-    fun `update should filter out cancelled occurrences`() {
-      val request = AppointmentOccurrenceUpdateRequest(internalLocationId = 456, applyTo = ApplyTo.ALL_FUTURE_OCCURRENCES)
-      appointment.occurrences()[1].cancellationReason = AppointmentCancellationReason(2L, "Cancelled", false)
-
-      whenever(locationService.getLocationsForAppointmentsMap(appointment.prisonCode))
-        .thenReturn(mapOf(request.internalLocationId!! to appointmentLocation(request.internalLocationId!!, appointment.prisonCode)))
-
-      val response = service.updateAppointmentOccurrence(appointmentOccurrence.appointmentOccurrenceId, request, principal)
-
-      with(response) {
-        assertThat(internalLocationId).isEqualTo(123)
-        assertThat(inCell).isFalse
-        assertThat(updated).isNull()
-        assertThat(updatedBy).isNull()
-        with(occurrences.subList(0, 1)) {
-          assertThat(map { it.internalLocationId }.distinct().single()).isEqualTo(123)
-          assertThat(map { it.inCell }.distinct().single()).isFalse
-          assertThat(map { it.updated }.distinct().single()).isNull()
-          assertThat(map { it.updatedBy }.distinct().single()).isNull()
-        }
-        with(occurrences.subList(2, response.occurrences.size)) {
-          assertThat(map { it.internalLocationId }.distinct().single()).isEqualTo(request.internalLocationId)
-          assertThat(map { it.inCell }.distinct().single()).isFalse
-          assertThat(map { it.updated }.distinct().single()).isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
-          assertThat(map { it.updatedBy }.distinct().single()).isEqualTo("TEST.USER")
-        }
-      }
-    }
-
-    @Test
-    fun `update appointment throws caseload access exception if caseload id header does not match`() {
-      addCaseloadIdToRequestHeader("WRONG")
-      val request = AppointmentOccurrenceUpdateRequest(internalLocationId = 456, applyTo = ApplyTo.ALL_FUTURE_OCCURRENCES)
-      assertThatThrownBy { service.updateAppointmentOccurrence(appointmentOccurrence.appointmentOccurrenceId, request, principal) }
-        .isInstanceOf(CaseloadAccessException::class.java)
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceUpdateTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceServiceUpdateTest.kt
@@ -23,7 +23,6 @@ import org.mockito.kotlin.whenever
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointment
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentCancellationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrence
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceUpdateDomainService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentRepeatPeriod

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/telemetry/AppointmentOccurrenceTelemetryTransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/telemetry/AppointmentOccurrenceTelemetryTransformFunctionsTest.kt
@@ -1,0 +1,211 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentOccurrenceUpdateRequest
+import java.time.LocalDate
+import java.time.LocalTime
+
+class AppointmentOccurrenceTelemetryTransformFunctionsTest {
+  @Test
+  fun `to telemetry properties no property changed`() {
+    AppointmentOccurrenceUpdateRequest().toTelemetryPropertiesMap(
+      "TEST.USER",
+      "MDI",
+      1,
+      2,
+    ) isEqualTo mutableMapOf(
+      USER_PROPERTY_KEY to "TEST.USER",
+      PRISON_CODE_PROPERTY_KEY to "MDI",
+      APPOINTMENT_SERIES_ID_PROPERTY_KEY to "1",
+      APPOINTMENT_ID_PROPERTY_KEY to "2",
+      CATEGORY_CHANGED_PROPERTY_KEY to false.toString(),
+      INTERNAL_LOCATION_CHANGED_PROPERTY_KEY to false.toString(),
+      START_DATE_CHANGED_PROPERTY_KEY to false.toString(),
+      START_TIME_CHANGED_PROPERTY_KEY to false.toString(),
+      END_TIME_CHANGED_PROPERTY_KEY to false.toString(),
+      EXTRA_INFORMATION_CHANGED_PROPERTY_KEY to false.toString(),
+      APPLY_TO_PROPERTY_KEY to ApplyTo.THIS_OCCURRENCE.toString(),
+    )
+  }
+
+  @Test
+  fun `to telemetry properties category code changed`() {
+    with(
+      AppointmentOccurrenceUpdateRequest(categoryCode = "NEW").toTelemetryPropertiesMap(
+        "TEST.USER",
+        "MDI",
+        1,
+        2,
+      ),
+    ) {
+      this[CATEGORY_CHANGED_PROPERTY_KEY] isEqualTo true.toString()
+      this[INTERNAL_LOCATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_DATE_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[END_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[EXTRA_INFORMATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+    }
+  }
+
+  @Test
+  fun `to telemetry properties internal location changed`() {
+    with(
+      AppointmentOccurrenceUpdateRequest(internalLocationId = 123).toTelemetryPropertiesMap(
+        "TEST.USER",
+        "MDI",
+        1,
+        2,
+      ),
+    ) {
+      this[CATEGORY_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[INTERNAL_LOCATION_CHANGED_PROPERTY_KEY] isEqualTo true.toString()
+      this[START_DATE_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[END_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[EXTRA_INFORMATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+    }
+  }
+
+  @Test
+  fun `to telemetry properties start date changed`() {
+    with(
+      AppointmentOccurrenceUpdateRequest(startDate = LocalDate.now().plusDays(1)).toTelemetryPropertiesMap(
+        "TEST.USER",
+        "MDI",
+        1,
+        2,
+      ),
+    ) {
+      this[CATEGORY_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[INTERNAL_LOCATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_DATE_CHANGED_PROPERTY_KEY] isEqualTo true.toString()
+      this[START_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[END_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[EXTRA_INFORMATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+    }
+  }
+
+  @Test
+  fun `to telemetry properties start time changed`() {
+    with(
+      AppointmentOccurrenceUpdateRequest(startTime = LocalTime.of(9, 30)).toTelemetryPropertiesMap(
+        "TEST.USER",
+        "MDI",
+        1,
+        2,
+      ),
+    ) {
+      this[CATEGORY_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[INTERNAL_LOCATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_DATE_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_TIME_CHANGED_PROPERTY_KEY] isEqualTo true.toString()
+      this[END_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[EXTRA_INFORMATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+    }
+  }
+
+  @Test
+  fun `to telemetry properties end time changed`() {
+    with(
+      AppointmentOccurrenceUpdateRequest(endTime = LocalTime.of(15, 0)).toTelemetryPropertiesMap(
+        "TEST.USER",
+        "MDI",
+        1,
+        2,
+      ),
+    ) {
+      this[CATEGORY_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[INTERNAL_LOCATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_DATE_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[END_TIME_CHANGED_PROPERTY_KEY] isEqualTo true.toString()
+      this[EXTRA_INFORMATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+    }
+  }
+
+  @Test
+  fun `to telemetry properties extra information changed`() {
+    with(
+      AppointmentOccurrenceUpdateRequest(comment = "New").toTelemetryPropertiesMap(
+        "TEST.USER",
+        "MDI",
+        1,
+        2,
+      ),
+    ) {
+      this[CATEGORY_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[INTERNAL_LOCATION_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_DATE_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[START_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[END_TIME_CHANGED_PROPERTY_KEY] isEqualTo false.toString()
+      this[EXTRA_INFORMATION_CHANGED_PROPERTY_KEY] isEqualTo true.toString()
+    }
+  }
+
+  @Test
+  fun `to telemetry properties apply to this and all future occurrences`() {
+    with(
+      AppointmentOccurrenceUpdateRequest(applyTo = ApplyTo.THIS_AND_ALL_FUTURE_OCCURRENCES).toTelemetryPropertiesMap(
+        "TEST.USER",
+        "MDI",
+        1,
+        2,
+      ),
+    ) {
+      this[APPLY_TO_PROPERTY_KEY] isEqualTo ApplyTo.THIS_AND_ALL_FUTURE_OCCURRENCES.toString()
+    }
+  }
+
+  @Test
+  fun `to telemetry properties apply to all future occurrences`() {
+    with(
+      AppointmentOccurrenceUpdateRequest(applyTo = ApplyTo.ALL_FUTURE_OCCURRENCES).toTelemetryPropertiesMap(
+        "TEST.USER",
+        "MDI",
+        1,
+        2,
+      ),
+    ) {
+      this[APPLY_TO_PROPERTY_KEY] isEqualTo ApplyTo.ALL_FUTURE_OCCURRENCES.toString()
+    }
+  }
+
+  @Test
+  fun `to telemetry metrics no property changed`() {
+    AppointmentOccurrenceUpdateRequest().toTelemetryMetricsMap(3) isEqualTo mutableMapOf(
+      APPOINTMENT_COUNT_METRIC_KEY to 3.0,
+      APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 0.0,
+      PRISONERS_REMOVED_COUNT_METRIC_KEY to 0.0,
+      PRISONERS_ADDED_COUNT_METRIC_KEY to 0.0,
+      EVENT_TIME_MS_METRIC_KEY to 0.0,
+    )
+  }
+
+  @Test
+  fun `to telemetry metrics remove prisoners`() {
+    AppointmentOccurrenceUpdateRequest(
+      removePrisonerNumbers = listOf("A1234BC", "B2345CD"),
+    ).toTelemetryMetricsMap(3) isEqualTo mutableMapOf(
+      APPOINTMENT_COUNT_METRIC_KEY to 3.0,
+      APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 0.0,
+      PRISONERS_REMOVED_COUNT_METRIC_KEY to 2.0,
+      PRISONERS_ADDED_COUNT_METRIC_KEY to 0.0,
+      EVENT_TIME_MS_METRIC_KEY to 0.0,
+    )
+  }
+
+  @Test
+  fun `to telemetry metrics add prisoners`() {
+    AppointmentOccurrenceUpdateRequest(
+      addPrisonerNumbers = listOf("A1234BC", "B2345CD", "C3456DE"),
+    ).toTelemetryMetricsMap(3) isEqualTo mutableMapOf(
+      APPOINTMENT_COUNT_METRIC_KEY to 3.0,
+      APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 0.0,
+      PRISONERS_REMOVED_COUNT_METRIC_KEY to 0.0,
+      PRISONERS_ADDED_COUNT_METRIC_KEY to 3.0,
+      EVENT_TIME_MS_METRIC_KEY to 0.0,
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/telemetry/AppointmentOccurrenceTelemetryTransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/telemetry/AppointmentOccurrenceTelemetryTransformFunctionsTest.kt
@@ -174,7 +174,7 @@ class AppointmentOccurrenceTelemetryTransformFunctionsTest {
 
   @Test
   fun `to telemetry metrics no property changed`() {
-    AppointmentOccurrenceUpdateRequest().toTelemetryMetricsMap(3) isEqualTo mutableMapOf(
+    AppointmentOccurrenceUpdateRequest().toTelemetryMetricsMap(3, 0) isEqualTo mutableMapOf(
       APPOINTMENT_COUNT_METRIC_KEY to 3.0,
       APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 0.0,
       PRISONERS_REMOVED_COUNT_METRIC_KEY to 0.0,
@@ -187,9 +187,9 @@ class AppointmentOccurrenceTelemetryTransformFunctionsTest {
   fun `to telemetry metrics remove prisoners`() {
     AppointmentOccurrenceUpdateRequest(
       removePrisonerNumbers = listOf("A1234BC", "B2345CD"),
-    ).toTelemetryMetricsMap(3) isEqualTo mutableMapOf(
+    ).toTelemetryMetricsMap(3, 6) isEqualTo mutableMapOf(
       APPOINTMENT_COUNT_METRIC_KEY to 3.0,
-      APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 0.0,
+      APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 6.0,
       PRISONERS_REMOVED_COUNT_METRIC_KEY to 2.0,
       PRISONERS_ADDED_COUNT_METRIC_KEY to 0.0,
       EVENT_TIME_MS_METRIC_KEY to 0.0,
@@ -200,9 +200,9 @@ class AppointmentOccurrenceTelemetryTransformFunctionsTest {
   fun `to telemetry metrics add prisoners`() {
     AppointmentOccurrenceUpdateRequest(
       addPrisonerNumbers = listOf("A1234BC", "B2345CD", "C3456DE"),
-    ).toTelemetryMetricsMap(3) isEqualTo mutableMapOf(
+    ).toTelemetryMetricsMap(3, 9) isEqualTo mutableMapOf(
       APPOINTMENT_COUNT_METRIC_KEY to 3.0,
-      APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 0.0,
+      APPOINTMENT_INSTANCE_COUNT_METRIC_KEY to 9.0,
       PRISONERS_REMOVED_COUNT_METRIC_KEY to 0.0,
       PRISONERS_ADDED_COUNT_METRIC_KEY to 3.0,
       EVENT_TIME_MS_METRIC_KEY to 0.0,


### PR DESCRIPTION
SAA-1055 requires all operations on very large group appointments, those represented by more than 500 instances in NOMIS, to follow a partial async pattern. The requested operation is applied synchronously to the first occurrence in the appointment and the remaining occurrence operations are actioned asynchronously.

This proved to be challenging for updating appointments without significant code duplication. In order to prevent this, the existing occurrence service was refactored and split into a smaller service responsible for validating and coordinating the update along with a domain service containing the business logic to action the update. This pattern supports reusing the domain service in an asynchronous job.

As part of this refactor, the approach to publishing the sync events was simplified and brought in line with the wider entity listener pattern. Removing manual publishing of events from the service. Finally, the metrics gathering and publishing was also simplified.

The intention is that the same refactor will be applied to cancelling an appointment.