### PR TITLE
SAA-1061: Filters any pay rates which contain incentive levels not in our "common" list.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
@@ -68,7 +68,7 @@ class MigrateActivityService(
     val payBands = prisonPayBandRepository.findByPrisonCode(request.prisonCode)
 
     // Add the pay rates to the activity but ignore any pay rates with an incentive level code not in our common list
-    request.payRates.filter { rate -> commonIncentiveLevels.any { it == rate.incentiveLevel }}.forEach {
+    request.payRates.filter { rate -> commonIncentiveLevels.any { it == rate.incentiveLevel } }.forEach {
       val payBand = payBands.find { pb -> pb.nomisPayBand.toString() == it.nomisPayBand }
       if (payBand != null) {
         activity.addPay(it.incentiveLevel, mapIncentiveLevel(it.incentiveLevel), payBand, it.rate, null, null)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
@@ -67,8 +67,8 @@ class MigrateActivityService(
     // Get pay bands defined for this prison
     val payBands = prisonPayBandRepository.findByPrisonCode(request.prisonCode)
 
-    // Add the pay rates to the activity
-    request.payRates.forEach {
+    // Add the pay rates to the activity but ignore any pay rates with an incentive level code not in our common list
+    request.payRates.filter { rate -> commonIncentiveLevels.any { it == rate.incentiveLevel }}.forEach {
       val payBand = payBands.find { pb -> pb.nomisPayBand.toString() == it.nomisPayBand }
       if (payBand != null) {
         activity.addPay(it.incentiveLevel, mapIncentiveLevel(it.incentiveLevel), payBand, it.rate, null, null)
@@ -77,8 +77,8 @@ class MigrateActivityService(
       }
     }
 
-    // If no pay rates are provided create flat rate of 0.00 for all pay bands and incentive levels
-    if (request.payRates.isEmpty()) {
+    // If no pay rates are present then create flat rate of 0.00 for all pay bands and common incentive levels
+    if (activity.activityPay().isEmpty()) {
       payBands.forEach { pb ->
         commonIncentiveLevels.forEach { incentive ->
           activity.addPay(incentive, mapIncentiveLevel(incentive), pb, 0, null, null)
@@ -155,7 +155,6 @@ class MigrateActivityService(
       "BAS" -> "Basic"
       "STD" -> "Standard"
       "ENH" -> "Enhanced"
-      "EN2" -> "Enhanced2"
       else -> "Unknown"
     }
     return incentiveLevel

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
@@ -551,6 +551,40 @@ class MigrateActivityServiceTest {
       verify(activityScheduleRepository, times(0)).saveAndFlush(any())
     }
 
+    @Test
+    fun `Any unrecognised or invalid incentive level codes in pay rates will be silently ignored`() {
+      val nomisPayRates = listOf(
+        NomisPayRate(incentiveLevel = "BAS", nomisPayBand = "1", rate = 100),
+        NomisPayRate(incentiveLevel = "XXX", nomisPayBand = "1", rate = 110),
+        NomisPayRate(incentiveLevel = "ENT", nomisPayBand = "1", rate = 120),
+        NomisPayRate(incentiveLevel = "EN2", nomisPayBand = "1", rate = 130),
+      )
+
+      val nomisScheduleRules = listOf(
+        NomisScheduleRule(
+          startTime = LocalTime.of(10, 0),
+          endTime = LocalTime.of(11, 0),
+          monday = true,
+        ),
+      )
+
+      whenever(activityRepository.saveAndFlush(any())).thenReturn(activityEntity())
+
+      val request = buildActivityMigrateRequest(nomisPayRates, nomisScheduleRules)
+
+      val response = service.migrateActivity(request)
+
+      assertThat(response.activityId).isEqualTo(1)
+      assertThat(response.splitRegimeActivityId).isNull()
+
+      verify(activityRepository).saveAndFlush(activityCaptor.capture())
+
+      with(activityCaptor.firstValue) {
+        assertThat(activityPay().size).isEqualTo(1)
+        assertThat(activityPay().first().rate).isEqualTo(100)
+      }
+    }
+
     private fun buildActivityMigrateRequest(
       payRates: List<NomisPayRate> = emptyList(),
       scheduleRules: List<NomisScheduleRule> = emptyList(),


### PR DESCRIPTION
For now, because Risley use only levels BAS, STD and ENH, this means we will filter pay rates that contain any other incentive levels. For example, EN2 or ENT rates will be discarded in the migration.