### PR TITLE
SAA-1150 removes pending allocations prior to deallocation on prisoner release event.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -341,6 +341,18 @@ data class ActivitySchedule(
       addSlot(it.first, it.second.first, it.second.second, updates[it]!!)
     }
   }
+
+  fun removePending(allocation: Allocation) {
+    require(allocations.contains(allocation)) {
+      "Allocation ${allocation.allocationId} cannot be removed. It is not associated with the schedule."
+    }
+
+    require(allocation.status(PrisonerStatus.PENDING)) {
+      "Allocation ${allocation.allocationId} cannot be removed. Only pending allocations can be removed."
+    }
+
+    allocations.remove(allocation)
+  }
 }
 
 fun List<ActivitySchedule>.toModelLite() = map { it.toModelLite() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -253,7 +253,11 @@ data class Allocation(
 }
 
 enum class PrisonerStatus {
-  ACTIVE, PENDING, SUSPENDED, AUTO_SUSPENDED, ENDED
+  ACTIVE, PENDING, SUSPENDED, AUTO_SUSPENDED, ENDED;
+
+  companion object {
+    fun allExcuding(vararg status: PrisonerStatus) = entries.filterNot { status.contains(it) }.toTypedArray()
+  }
 }
 
 enum class DeallocationReason(val description: String, val displayed: Boolean = false) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AllocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AllocationRepository.kt
@@ -29,6 +29,15 @@ interface AllocationRepository : JpaRepository<Allocation, Long> {
   @Query(
     value =
     "FROM Allocation a " +
+      "WHERE a.prisonerNumber = :prisonerNumber " +
+      "  AND a.prisonerStatus IN (:prisonerStatus) " +
+      "  AND a.activitySchedule.activity.prisonCode = :prisonCode",
+  )
+  fun findByPrisonCodePrisonerNumberPrisonerStatus(prisonCode: String, prisonerNumber: String, vararg prisonerStatus: PrisonerStatus): List<Allocation>
+
+  @Query(
+    value =
+    "FROM Allocation a " +
       "WHERE a.prisonerStatus = :prisonerStatus " +
       "  AND a.activitySchedule.activity.prisonCode = :prisonCode",
   )

--- a/src/test/resources/test_data/seed-offender-for-release.sql
+++ b/src/test/resources/test_data/seed-offender-for-release.sql
@@ -52,6 +52,9 @@ values (4, 2, 'A11111A', 10001, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'M
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (5, 2, 'A22222A', 10002, 3, '2022-10-10', null, '2022-10-10 10:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (6, 3, 'A11111A', 10001, 3, current_date + 1, null, '2022-10-10 10:00:00', 'MR BLOGS', null, null, null, null, null, null, 'PENDING');
+
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
 values (1, '2022-10-10', '10:00:00', '11:00:00', false, null, null, null, null);
 


### PR DESCRIPTION
The is the first of several tickets related to removal of pending allocations prior to deallocation of prisoners.