### PR TITLE
SAA-1162: Rename database tables and columns and add MVP+ columns

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
 import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -31,15 +32,16 @@ import java.time.LocalTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointment as AppointmentModel
 
 @Entity
-@Table(name = "appointment")
+@Table(name = "appointment_series")
 data class Appointment(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "appointment_series_id")
   val appointmentId: Long = 0,
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinTable(
-    name = "bulk_appointment_appointment",
+    name = "appointment_set_appointment_series",
     joinColumns = [JoinColumn(name = "appointmentId")],
     inverseJoinColumns = [JoinColumn(name = "bulkAppointmentId")],
   )
@@ -52,6 +54,7 @@ data class Appointment(
 
   val categoryCode: String,
 
+  @Column(name = "custom_name")
   val appointmentDescription: String?,
 
   val internalLocationId: Long?,
@@ -65,15 +68,18 @@ data class Appointment(
   val endTime: LocalTime?,
 
   @OneToOne(fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
-  @JoinColumn(name = "appointment_schedule_id")
+  @JoinColumn(name = "appointment_series_schedule_id")
   var schedule: AppointmentSchedule? = null,
 
+  @Column(name = "extra_information")
   val comment: String?,
 
+  @Column(name = "created_time")
   val created: LocalDateTime = LocalDateTime.now(),
 
   val createdBy: String,
 
+  @Column(name = "updated_time")
   var updated: LocalDateTime? = null,
 
   var updatedBy: String? = null,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentCancellationReason.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentCancellationReason.kt
@@ -18,7 +18,6 @@ data class AppointmentCancellationReason(
 
   val isDelete: Boolean,
 ) {
-
   fun toModel() = ModelAppointmentCancellationReason(
     appointmentCancellationReasonId = appointmentCancellationReasonId,
     description = description,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentHost.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentHost.kt
@@ -1,0 +1,24 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentHost as ModelAppointmentHost
+
+@Entity
+@Table(name = "appointment_host")
+data class AppointmentHost(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val appointmentHostId: Long = 0,
+
+  val description: String,
+
+) {
+  fun toModel() = ModelAppointmentHost(
+    appointmentHostId = appointmentHostId,
+    description = description,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentHost.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentHost.kt
@@ -18,7 +18,7 @@ data class AppointmentHost(
 
 ) {
   fun toModel() = ModelAppointmentHost(
-    appointmentHostId = appointmentHostId,
+    id = appointmentHostId,
     description = description,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentInstance.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -18,10 +19,13 @@ data class AppointmentInstance(
   @Id
   val appointmentInstanceId: Long,
 
+  @Column(name = "appointment_series_id")
   val appointmentId: Long,
 
+  @Column(name = "appointment_id")
   val appointmentOccurrenceId: Long,
 
+  @Column(name = "appointment_attendee_id")
   val appointmentOccurrenceAllocationId: Long,
 
   @Enumerated(EnumType.STRING)
@@ -35,6 +39,7 @@ data class AppointmentInstance(
 
   val categoryCode: String,
 
+  @Column(name = "custom_name")
   val appointmentDescription: String?,
 
   val internalLocationId: Long?,
@@ -47,17 +52,20 @@ data class AppointmentInstance(
 
   val endTime: LocalTime?,
 
+  @Column(name = "extra_information")
   val comment: String?,
 
+  @Column(name = "created_time")
   val created: LocalDateTime = LocalDateTime.now(),
 
   val createdBy: String,
 
-  val isCancelled: Boolean,
-
+  @Column(name = "updated_time")
   val updated: LocalDateTime?,
 
   val updatedBy: String?,
+
+  val isCancelled: Boolean,
 ) {
   fun toModel() = AppointmentInstanceModel(
     id = appointmentInstanceId,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrence.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrence.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
 import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.FetchType
@@ -30,21 +31,23 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointme
 
 @Entity
 @Table(name = "appointment_occurrence")
-@Where(clause = "deleted = false")
+@Where(clause = "NOT is_deleted")
 @EntityListeners(AppointmentOccurrenceEntityListener::class)
 data class AppointmentOccurrence(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "appointment_id")
   val appointmentOccurrenceId: Long = 0,
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "appointment_id", nullable = false)
+  @JoinColumn(name = "appointment_series_id", nullable = false)
   val appointment: Appointment,
 
   val sequenceNumber: Int,
 
   var categoryCode: String,
 
+  @Column(name = "custom_name")
   var appointmentDescription: String?,
 
   var internalLocationId: Long?,
@@ -57,12 +60,15 @@ data class AppointmentOccurrence(
 
   var endTime: LocalTime?,
 
+  @Column(name = "extra_information")
   var comment: String?,
 
+  @Column(name = "updated_time")
   var updated: LocalDateTime? = null,
 
   var updatedBy: String? = null,
 ) {
+  @Column(name = "cancelled_time")
   var cancelled: LocalDateTime? = null
 
   @OneToOne(fetch = FetchType.EAGER)
@@ -71,6 +77,7 @@ data class AppointmentOccurrence(
 
   var cancelledBy: String? = null
 
+  @Column(name = "is_deleted")
   var deleted: Boolean = false
 
   @OneToMany(mappedBy = "appointmentOccurrence", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceAllocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceAllocation.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EntityListeners
 import jakarta.persistence.FetchType
@@ -12,15 +13,16 @@ import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentOccurrenceAllocation as AppointmentOccurrenceAllocationModel
 
 @Entity
-@Table(name = "appointment_occurrence_allocation")
+@Table(name = "appointment_attendee")
 @EntityListeners(AppointmentOccurrenceAllocationEntityListener::class)
 data class AppointmentOccurrenceAllocation(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "appointment_attendee_id")
   val appointmentOccurrenceAllocationId: Long = 0,
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "appointment_occurrence_id", nullable = false)
+  @JoinColumn(name = "appointment_id", nullable = false)
   val appointmentOccurrence: AppointmentOccurrence,
 
   val prisonerNumber: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceAllocationSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceAllocationSearch.kt
@@ -1,26 +1,19 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
-import jakarta.persistence.Entity
-import jakarta.persistence.EntityListeners
-import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentOccurrenceAllocation as AppointmentOccurrenceAllocationModel
 
 @Entity
-@Table(name = "appointment_occurrence_allocation")
+@Table(name = "appointment_attendee")
 @EntityListeners(AppointmentOccurrenceAllocationEntityListener::class)
 data class AppointmentOccurrenceAllocationSearch(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "appointment_attendee_id")
   val appointmentOccurrenceAllocationId: Long = 0,
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "appointment_occurrence_id", nullable = false)
+  @JoinColumn(name = "appointment_id", nullable = false)
   val appointmentOccurrenceSearch: AppointmentOccurrenceSearch,
 
   val prisonerNumber: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceAllocationSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceAllocationSearch.kt
@@ -1,6 +1,15 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentOccurrenceAllocation as AppointmentOccurrenceAllocationModel
 
 @Entity

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceSearch.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -18,11 +19,13 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 
 @Entity
-@Table(name = "v_appointment_occurrence_search")
+@Table(name = "v_appointment_search")
 data class AppointmentOccurrenceSearch(
+  @Column(name = "appointment_series_id")
   val appointmentId: Long,
 
   @Id
+  @Column(name = "appointment_id")
   val appointmentOccurrenceId: Long,
 
   @Enumerated(EnumType.STRING)
@@ -32,6 +35,7 @@ data class AppointmentOccurrenceSearch(
 
   val categoryCode: String,
 
+  @Column(name = "custom_name")
   val appointmentDescription: String?,
 
   var internalLocationId: Long?,
@@ -50,6 +54,7 @@ data class AppointmentOccurrenceSearch(
 
   val maxSequenceNumber: Int,
 
+  @Column(name = "extra_information")
   val comment: String?,
 
   val createdBy: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSchedule.kt
@@ -1,5 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
+import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
 import jakarta.persistence.Enumerated
@@ -14,18 +15,21 @@ import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentRepeatPeriod as AppointmentRepeatPeriodModel
 
 @Entity
-@Table(name = "appointment_schedule")
+@Table(name = "appointment_series_schedule")
 data class AppointmentSchedule(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "appointment_series_schedule_id")
   val appointmentScheduleId: Long = 0,
 
   @OneToOne(mappedBy = "schedule", fetch = FetchType.EAGER)
   val appointment: Appointment,
 
   @Enumerated(EnumType.STRING)
+  @Column(name = "frequency")
   var repeatPeriod: AppointmentRepeatPeriod,
 
+  @Column(name = "number_of_appointments")
   var repeatCount: Int,
 ) {
   fun toRepeat() = AppointmentRepeat(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTier.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentTier as ModelAppointmentTier
+
+@Entity
+@Table(name = "appointment_tier")
+data class AppointmentTier(
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  val appointmentTierId: Long = 0,
+
+  val description: String,
+) {
+  fun toModel() = ModelAppointmentTier(
+    appointmentTierId = appointmentTierId,
+    description = description,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTier.kt
@@ -17,7 +17,7 @@ data class AppointmentTier(
   val description: String,
 ) {
   fun toModel() = ModelAppointmentTier(
-    appointmentTierId = appointmentTierId,
+    id = appointmentTierId,
     description = description,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointment.kt
@@ -30,6 +30,14 @@ data class BulkAppointment(
   @Column(name = "custom_name")
   var appointmentDescription: String?,
 
+  @OneToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "appointment_tier_id")
+  var appointmentTier: AppointmentTier,
+
+  @OneToOne(fetch = FetchType.EAGER)
+  @JoinColumn(name = "appointment_host_id")
+  var appointmentHost: AppointmentHost? = null,
+
   var internalLocationId: Long?,
 
   var inCell: Boolean,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointment.kt
@@ -1,15 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
-import jakarta.persistence.CascadeType
-import jakarta.persistence.Entity
-import jakarta.persistence.FetchType
-import jakarta.persistence.GeneratedValue
-import jakarta.persistence.GenerationType
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.JoinTable
-import jakarta.persistence.OneToMany
-import jakarta.persistence.Table
+import jakarta.persistence.*
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail
@@ -25,16 +16,18 @@ import java.time.LocalDateTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.BulkAppointment as BulkAppointmentModel
 
 @Entity
-@Table(name = "bulk_appointment")
+@Table(name = "appointment_set")
 data class BulkAppointment(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "appointment_set_id")
   val bulkAppointmentId: Long = 0,
 
   val prisonCode: String,
 
   var categoryCode: String,
 
+  @Column(name = "custom_name")
   var appointmentDescription: String?,
 
   var internalLocationId: Long?,
@@ -43,13 +36,14 @@ data class BulkAppointment(
 
   var startDate: LocalDate,
 
+  @Column(name = "created_time")
   val created: LocalDateTime = LocalDateTime.now(),
 
   val createdBy: String,
 ) {
   @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinTable(
-    name = "bulk_appointment_appointment",
+    name = "appointment_set_appointment_series",
     joinColumns = [JoinColumn(name = "bulkAppointmentId")],
     inverseJoinColumns = [JoinColumn(name = "appointmentId")],
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/BulkAppointment.kt
@@ -1,6 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
-import jakarta.persistence.*
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.JoinTable
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail
@@ -52,8 +63,8 @@ data class BulkAppointment(
   @OneToMany(fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   @JoinTable(
     name = "appointment_set_appointment_series",
-    joinColumns = [JoinColumn(name = "bulkAppointmentId")],
-    inverseJoinColumns = [JoinColumn(name = "appointmentId")],
+    joinColumns = [JoinColumn(name = "appointment_set_id")],
+    inverseJoinColumns = [JoinColumn(name = "appointment_series_id")],
   )
   private val appointments: MutableList<Appointment> = mutableListOf()
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateAppointmentOccurrencesJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateAppointmentOccurrencesJob.kt
@@ -63,14 +63,19 @@ class CreateAppointmentOccurrencesJob(
               AppointmentOccurrence(
                 appointment = appointment,
                 sequenceNumber = sequenceNumber,
+                prisonCode = appointment.prisonCode,
                 categoryCode = appointment.categoryCode,
                 appointmentDescription = appointment.appointmentDescription,
+                appointmentTier = appointment.appointmentTier,
+                appointmentHost = appointment.appointmentHost,
                 internalLocationId = appointment.internalLocationId,
                 inCell = appointment.inCell,
                 startDate = it.value,
                 startTime = appointment.startTime,
                 endTime = appointment.endTime,
                 comment = appointment.comment,
+                created = appointment.created,
+                createdBy = appointment.createdBy,
               ).apply {
                 prisonerBookings.forEach { prisonerBooking ->
                   this.addAllocation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentHost.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentHost.kt
@@ -13,7 +13,7 @@ data class AppointmentHost(
     description = "The internally generated identifier for this appointment host",
     example = "12345",
   )
-  val appointmentHostId: Long,
+  val id: Long,
 
   @Schema(
     description = "The description of the appointment host",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentHost.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentHost.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+  description =
+  """
+  The type of host for an appointment
+  """,
+)
+data class AppointmentHost(
+  @Schema(
+    description = "The internally generated identifier for this appointment host",
+    example = "12345",
+  )
+  val appointmentHostId: Long,
+
+  @Schema(
+    description = "The description of the appointment host",
+    example = "Prison staff",
+  )
+  val description: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentTier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentTier.kt
@@ -1,0 +1,23 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+  description =
+  """
+  The tier of the appointment
+  """,
+)
+data class AppointmentTier(
+  @Schema(
+    description = "The internally generated identifier for this appointment tier",
+    example = "12345",
+  )
+  val appointmentTierId: Long,
+
+  @Schema(
+    description = "The description of the appointment tier",
+    example = "Tier 2",
+  )
+  val description: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentTier.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentTier.kt
@@ -13,7 +13,7 @@ data class AppointmentTier(
     description = "The internally generated identifier for this appointment tier",
     example = "12345",
   )
-  val appointmentTierId: Long,
+  val id: Long,
 
   @Schema(
     description = "The description of the appointment tier",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentHostRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentHostRepository.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentHost
+
+const val PRISON_STAFF_APPOINTMENT_HOST_ID = 1L
+const val PRISONER_OR_PRISONERS_APPOINTMENT_HOST_ID = 2L
+const val EXTERNAL_PROVIDER_APPOINTMENT_HOST_ID = 3L
+const val SOMEONE_ELSE_APPOINTMENT_HOST_ID = 4L
+
+@Repository
+interface AppointmentHostRepository : JpaRepository<AppointmentHost, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentTierRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentTierRepository.kt
@@ -1,0 +1,13 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentTier
+
+const val TIER_1_APPOINTMENT_TIER_ID = 1L
+const val TIER_2_APPOINTMENT_TIER_ID = 2L
+const val NO_TIER_APPOINTMENT_TIER_ID = 3L
+const val NOT_SPECIFIED_APPOINTMENT_TIER_ID = 4L
+
+@Repository
+interface AppointmentTierRepository : JpaRepository<AppointmentTier, Long>

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceDetailsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentOccurrenceDetailsService.kt
@@ -22,16 +22,14 @@ class AppointmentOccurrenceDetailsService(
     val appointmentOccurrence = appointmentOccurrenceRepository.findOrThrowNotFound(appointmentOccurrenceId)
     checkCaseloadAccess(appointmentOccurrence.appointment.prisonCode)
 
-    val appointment = appointmentOccurrence.appointment
-
     val prisonerMap = prisonerSearchApiClient.findByPrisonerNumbersMap(appointmentOccurrence.prisonerNumbers())
 
     val referenceCodeMap = referenceCodeService.getReferenceCodesMap(ReferenceCodeDomain.APPOINTMENT_CATEGORY)
 
-    val locationMap = locationService.getLocationsForAppointmentsMap(appointment.prisonCode)
+    val locationMap = locationService.getLocationsForAppointmentsMap(appointmentOccurrence.prisonCode)
 
-    val userMap = prisonApiClient.getUserDetailsList(appointment.usernames()).associateBy { it.username }
+    val userMap = prisonApiClient.getUserDetailsList(appointmentOccurrence.usernames()).associateBy { it.username }
 
-    return appointmentOccurrence.toDetails(appointment.prisonCode, prisonerMap, referenceCodeMap, locationMap, userMap)
+    return appointmentOccurrence.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
@@ -18,14 +18,14 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.Bul
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentMigrateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.BulkAppointmentsRequest
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentHostRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentCancellationReasonRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentHostRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentTierRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.BulkAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.CANCELLED_APPOINTMENT_CANCELLATION_REASON_ID
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NOT_SPECIFIED_APPOINTMENT_TIER_ID
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_COUNT_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_INSTANCE_COUNT_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_SERIES_ID_PROPERTY_KEY

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
@@ -7,6 +7,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentRepeatPeriod
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentSchedule
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentTier
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.CreateAppointmentOccurrencesJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointment
@@ -17,11 +18,14 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.Bul
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentMigrateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.BulkAppointmentsRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentHostRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentCancellationReasonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentTierRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.BulkAppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.CANCELLED_APPOINTMENT_CANCELLATION_REASON_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NOT_SPECIFIED_APPOINTMENT_TIER_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_COUNT_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_INSTANCE_COUNT_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_SERIES_ID_PROPERTY_KEY
@@ -59,6 +63,8 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.BulkAppo
 @Service
 class AppointmentService(
   private val appointmentRepository: AppointmentRepository,
+  private val appointmentTierRepository: AppointmentTierRepository,
+  private val appointmentHostRepository: AppointmentHostRepository,
   private val appointmentCancellationReasonRepository: AppointmentCancellationReasonRepository,
   private val bulkAppointmentRepository: BulkAppointmentRepository,
   private val referenceCodeService: ReferenceCodeService,
@@ -80,12 +86,16 @@ class AppointmentService(
 
   fun bulkCreateAppointments(request: BulkAppointmentsRequest, principal: Principal): BulkAppointment {
     val startTime = System.currentTimeMillis()
+
+    val appointmentTier = appointmentTierRepository.findOrThrowNotFound(NOT_SPECIFIED_APPOINTMENT_TIER_ID)
+
     return require(request.appointments.isNotEmpty()) { "One or more appointments must be supplied." }.run {
       createPrisonerMap(request.appointments.map { it.prisonerNumber }, request.prisonCode).let { prisonerBookings ->
         BulkAppointmentEntity(
           prisonCode = request.prisonCode,
           categoryCode = request.categoryCode,
           appointmentDescription = request.appointmentDescription,
+          appointmentTier = appointmentTier,
           internalLocationId = request.internalLocationId,
           inCell = request.inCell,
           startDate = request.startDate,
@@ -99,6 +109,7 @@ class AppointmentService(
               prisonerBookings = prisonerBookings.filterKeys { k -> k == it.prisonerNumber },
               categoryCode = request.categoryCode,
               appointmentDescription = request.appointmentDescription,
+              appointmentTier = appointmentTier,
               internalLocationId = request.internalLocationId,
               inCell = request.inCell,
               startDate = request.startDate,
@@ -119,6 +130,9 @@ class AppointmentService(
 
   fun createAppointment(request: AppointmentCreateRequest, principal: Principal): Appointment {
     val startTime = System.currentTimeMillis()
+
+    val appointmentTier = appointmentTierRepository.findOrThrowNotFound(NOT_SPECIFIED_APPOINTMENT_TIER_ID)
+
     val prisonerBookings = createPrisonerMap(request.prisonerNumbers, request.prisonCode)
     // Determine if this is a create request for a very large appointment. If it is, this function will only create the first occurrence
     val createFirstOccurrenceOnly = request.repeat?.count?.let { it > 1 && it * prisonerBookings.size > maxSyncAppointmentInstanceActions } ?: false
@@ -132,6 +146,7 @@ class AppointmentService(
         inCell = request.inCell,
         categoryCode = request.categoryCode!!,
         appointmentDescription = request.appointmentDescription,
+        appointmentTier = appointmentTier,
         internalLocationId = request.internalLocationId,
         startDate = request.startDate,
         startTime = request.startTime,
@@ -154,28 +169,30 @@ class AppointmentService(
     }
   }
 
-  fun migrateAppointment(request: AppointmentMigrateRequest, principal: Principal) =
-    mapOf(request.prisonerNumber!! to request.bookingId.toString()).let { prisonerBookings ->
-      buildValidAppointmentEntity(
-        appointmentType = AppointmentType.INDIVIDUAL,
-        prisonCode = request.prisonCode!!,
-        prisonerNumbers = listOf(request.prisonerNumber),
-        prisonerBookings = prisonerBookings,
-        categoryCode = request.categoryCode!!,
-        internalLocationId = request.internalLocationId,
-        inCell = false,
-        startDate = request.startDate,
-        startTime = request.startTime,
-        endTime = request.endTime,
-        comment = request.comment,
-        created = request.created!!,
-        createdBy = request.createdBy!!,
-        updated = request.updated,
-        updatedBy = request.updatedBy,
-        isCancelled = request.isCancelled ?: false,
-        isMigrated = true,
-      ).let { (appointmentRepository.saveAndFlush(it)).toModel() }
-    }
+  fun migrateAppointment(request: AppointmentMigrateRequest, principal: Principal): Appointment {
+    val appointmentTier = appointmentTierRepository.findOrThrowNotFound(NOT_SPECIFIED_APPOINTMENT_TIER_ID)
+    val prisonerBookings = mapOf(request.prisonerNumber!! to request.bookingId.toString())
+    return buildValidAppointmentEntity(
+      appointmentType = AppointmentType.INDIVIDUAL,
+      prisonCode = request.prisonCode!!,
+      prisonerNumbers = listOf(request.prisonerNumber),
+      prisonerBookings = prisonerBookings,
+      categoryCode = request.categoryCode!!,
+      appointmentTier = appointmentTier,
+      internalLocationId = request.internalLocationId,
+      inCell = false,
+      startDate = request.startDate,
+      startTime = request.startTime,
+      endTime = request.endTime,
+      comment = request.comment,
+      created = request.created!!,
+      createdBy = request.createdBy!!,
+      updated = request.updated,
+      updatedBy = request.updatedBy,
+      isCancelled = request.isCancelled ?: false,
+      isMigrated = true,
+    ).let { (appointmentRepository.saveAndFlush(it)).toModel() }
+  }
 
   private fun failIfCategoryNotFound(categoryCode: String) {
     referenceCodeService.getScheduleReasonsMap(ScheduleReasonEventType.APPOINTMENT)[categoryCode]
@@ -211,6 +228,7 @@ class AppointmentService(
     prisonerBookings: Map<String, String?>,
     categoryCode: String,
     appointmentDescription: String? = null,
+    appointmentTier: AppointmentTier,
     internalLocationId: Long? = null,
     inCell: Boolean = false,
     startDate: LocalDate?,
@@ -240,6 +258,7 @@ class AppointmentService(
       prisonCode = prisonCode,
       categoryCode = categoryCode,
       appointmentDescription = appointmentDescription?.takeUnless(String::isBlank),
+      appointmentTier = appointmentTier,
       internalLocationId = if (inCell) null else internalLocationId,
       inCell = inCell,
       startDate = startDate!!,
@@ -267,16 +286,20 @@ class AppointmentService(
           AppointmentOccurrenceEntity(
             appointment = this,
             sequenceNumber = it.index + 1,
-            categoryCode = categoryCode,
-            appointmentDescription = appointmentDescription?.takeUnless(String::isBlank),
+            prisonCode = this.prisonCode,
+            categoryCode = this.categoryCode,
+            appointmentDescription = this.appointmentDescription,
             internalLocationId = this.internalLocationId,
+            appointmentTier = this.appointmentTier,
             inCell = this.inCell,
             startDate = it.value,
             startTime = this.startTime,
             endTime = this.endTime,
-            comment = comment,
-            updated = updated,
-            updatedBy = updatedBy,
+            comment = this.comment,
+            created = this.created,
+            createdBy = this.createdBy,
+            updated = this.updated,
+            updatedBy = this.updatedBy,
           ).apply {
             prisonerBookings.forEach { prisonerBooking ->
               this.addAllocation(
@@ -287,6 +310,7 @@ class AppointmentService(
                 ),
               )
             }
+
             if (isCancelled) {
               cancelled = updated ?: created
               cancellationReason =

--- a/src/main/resources/migrations/common/V2023.09.06__rename_appointment_tables.sql
+++ b/src/main/resources/migrations/common/V2023.09.06__rename_appointment_tables.sql
@@ -181,6 +181,7 @@ CREATE INDEX idx_appointment_set_appointment_series_id ON appointment_set_appoin
 -- UPDATED VIEWS USING NEW TABLES AND COLUMNS
 -- =============================================
 
+DROP VIEW v_appointment_instance;
 CREATE OR REPLACE VIEW v_appointment_instance AS
 SELECT aa.appointment_attendee_id                                                    AS appointment_instance_id,
        a.appointment_series_id,

--- a/src/main/resources/migrations/common/V2023.09.06__rename_appointment_tables.sql
+++ b/src/main/resources/migrations/common/V2023.09.06__rename_appointment_tables.sql
@@ -1,0 +1,414 @@
+-- =============================================
+-- APPOINTMENT TABLES WITH CORRECT NAMES
+-- =============================================
+
+CREATE TABLE appointment_tier
+(
+    appointment_tier_id bigserial   NOT NULL CONSTRAINT appointment_tier_pk PRIMARY KEY,
+    description                     varchar(100) NOT NULL
+);
+INSERT INTO appointment_tier
+VALUES   (1, 'Tier 1'),
+         (2, 'Tier 2'),
+         (3, 'No tier, this activity is not considered ''purposeful'' for reporting');
+
+CREATE TABLE appointment_host
+(
+    appointment_host_id bigserial   NOT NULL CONSTRAINT appointment_host_pk PRIMARY KEY,
+    description                     varchar(100) NOT NULL
+);
+INSERT INTO appointment_host
+VALUES   (1, 'Prison staff'),
+         (2, 'A prisoner or group of prisoners'),
+         (3, 'An external provider'),
+         (4, 'Someone else');
+
+CREATE TABLE appointment_series_schedule
+(
+    appointment_series_schedule_id  bigserial    NOT NULL CONSTRAINT appointment_series_schedule_pk PRIMARY KEY,
+    frequency                       varchar(20)  NOT NULL,
+    number_of_appointments          integer      NOT NULL
+);
+CREATE INDEX idx_appointment_series_schedule_frequency ON appointment_series_schedule (frequency);
+
+CREATE TABLE appointment_series
+(
+    appointment_series_id           bigserial    NOT NULL CONSTRAINT appointment_series_pk PRIMARY KEY,
+    appointment_type                varchar(10)  NOT NULL,
+    prison_code                     varchar(6)   NOT NULL,
+    category_code                   varchar(12)  NOT NULL,
+    custom_name                     varchar(40)  DEFAULT NULL,
+    appointment_tier_id             bigint       NOT NULL REFERENCES appointment_tier (appointment_tier_id),
+    appointment_host_id             bigint       DEFAULT NULL REFERENCES appointment_host (appointment_host_id),
+    internal_location_id            bigint,
+    custom_location                 varchar(40)  DEFAULT NULL,
+    in_cell                         boolean      NOT NULL DEFAULT false,
+    on_wing                         boolean      NOT NULL DEFAULT false,
+    off_wing                        boolean      NOT NULL DEFAULT true,
+    start_date                      date         NOT NULL,
+    start_time                      time         NOT NULL,
+    end_time                        time,
+    appointment_series_schedule_id  bigint       DEFAULT NULL REFERENCES appointment_series_schedule (appointment_series_schedule_id),
+    unlock_notes                    text         DEFAULT NULL,
+    extra_information               text         DEFAULT NULL,
+    created_time                    timestamp    NOT NULL,
+    created_by                      varchar(100) NOT NULL,
+    updated_time                    timestamp    DEFAULT NULL,
+    updated_by                      varchar(100) DEFAULT NULL,
+    is_migrated                     boolean      NOT NULL DEFAULT false
+);
+CREATE INDEX idx_appointment_series_prison_code ON appointment_series (prison_code);
+CREATE INDEX idx_appointment_series_category_code ON appointment_series (category_code);
+CREATE INDEX idx_appointment_series_custom_name ON appointment_series (custom_name);
+CREATE INDEX idx_appointment_series_appointment_tier_id ON appointment_series (appointment_tier_id);
+CREATE INDEX idx_appointment_series_appointment_host_id ON appointment_series (appointment_host_id);
+CREATE INDEX idx_appointment_series_internal_location_id ON appointment_series (internal_location_id);
+CREATE INDEX idx_appointment_series_custom_location ON appointment_series (custom_location);
+CREATE INDEX idx_appointment_series_start_date ON appointment_series (start_date);
+CREATE INDEX idx_appointment_series_start_time ON appointment_series (start_time);
+CREATE INDEX idx_appointment_series_end_time ON appointment_series (end_time);
+CREATE INDEX idx_appointment_series_schedule_id ON appointment_series (appointment_series_schedule_id);
+CREATE INDEX idx_appointment_series_created_by ON appointment_series (created_by);
+
+ALTER TABLE appointment RENAME TO appointment_old;
+ALTER TABLE appointment_old RENAME CONSTRAINT appointment_pk TO appointment_old_pk;
+DROP INDEX IF EXISTS idx_appointment_prison_code;
+DROP INDEX IF EXISTS idx_appointment_category_code;
+DROP INDEX IF EXISTS idx_appointment_internal_location_id;
+DROP INDEX IF EXISTS idx_appointment_start_date;
+DROP INDEX IF EXISTS idx_appointment_start_time;
+DROP INDEX IF EXISTS idx_appointment_end_time;
+
+CREATE TABLE appointment
+(
+    appointment_id                  bigserial    NOT NULL CONSTRAINT appointment_pk PRIMARY KEY,
+    appointment_series_id           bigint       NOT NULL REFERENCES appointment_series (appointment_series_id),
+    sequence_number                 integer      NOT NULL,
+    prison_code                     varchar(6)   NOT NULL,
+    category_code                   varchar(12)  NOT NULL,
+    custom_name                     varchar(40)  DEFAULT NULL,
+    appointment_tier_id             bigint       NOT NULL REFERENCES appointment_tier (appointment_tier_id),
+    appointment_host_id             bigint       DEFAULT NULL REFERENCES appointment_host (appointment_host_id),
+    internal_location_id            bigint,
+    custom_location                 varchar(40)  DEFAULT NULL,
+    in_cell                         boolean      NOT NULL DEFAULT false,
+    on_wing                         boolean      NOT NULL DEFAULT false,
+    off_wing                        boolean      NOT NULL DEFAULT true,
+    start_date                      date         NOT NULL,
+    start_time                      time         NOT NULL,
+    end_time                        time,
+    unlock_notes                    text         DEFAULT NULL,
+    extra_information               text         DEFAULT NULL,
+    created_time                    timestamp    NOT NULL,
+    created_by                      varchar(100) NOT NULL,
+    updated_time                    timestamp    DEFAULT NULL,
+    updated_by                      varchar(100) DEFAULT NULL,
+    cancelled_time                  timestamp,
+    cancellation_reason_id          bigint       REFERENCES appointment_cancellation_reason (appointment_cancellation_reason_id),
+    cancelled_by                    varchar(100),
+    is_deleted                      boolean      NOT NULL DEFAULT false
+);
+CREATE INDEX idx_appointment_appointment_series_id ON appointment (appointment_series_id);
+CREATE INDEX idx_appointment_prison_code ON appointment (prison_code);
+CREATE INDEX idx_appointment_category_code ON appointment (category_code);
+CREATE INDEX idx_appointment_custom_name ON appointment (custom_name);
+CREATE INDEX idx_appointment_appointment_tier_id ON appointment (appointment_tier_id);
+CREATE INDEX idx_appointment_appointment_host_id ON appointment (appointment_host_id);
+CREATE INDEX idx_appointment_internal_location_id ON appointment (internal_location_id);
+CREATE INDEX idx_appointment_custom_location ON appointment (custom_location);
+CREATE INDEX idx_appointment_start_date ON appointment (start_date);
+CREATE INDEX idx_appointment_start_time ON appointment (start_time);
+CREATE INDEX idx_appointment_end_time ON appointment (end_time);
+CREATE INDEX idx_appointment_created_by ON appointment (created_by);
+CREATE INDEX idx_appointment_cancellation_reason_id ON appointment (cancellation_reason_id);
+
+CREATE TABLE appointment_attendee
+(
+    appointment_attendee_id     bigserial        NOT NULL CONSTRAINT appointment_attendee_pk PRIMARY KEY,
+    appointment_id              bigint           NOT NULL REFERENCES appointment (appointment_id),
+    prisoner_number             varchar(10)      NOT NULL,
+    booking_id                  bigint           NOT NULL,
+    added_time                  timestamp        DEFAULT NULL,
+    added_by                    varchar(100)     DEFAULT NULL,
+    attended                    boolean          DEFAULT NULL,
+    attendance_recorded_time    timestamp        DEFAULT NULL,
+    attendance_recorded_by      varchar(100)     DEFAULT NULL,
+    removed_time                timestamp        DEFAULT NULL,
+    removed_by                  varchar(100)     DEFAULT NULL
+);
+CREATE INDEX idx_appointment_attendee_appointment_id ON appointment_attendee (appointment_id);
+CREATE INDEX idx_appointment_attendee_prisoner_number ON appointment_attendee (prisoner_number);
+CREATE INDEX idx_appointment_attendee_booking_id ON appointment_attendee (booking_id);
+
+CREATE TABLE appointment_set
+(
+    appointment_set_id          bigserial        NOT NULL CONSTRAINT appointment_set_pk PRIMARY KEY,
+    prison_code                 varchar(6)       NOT NULL,
+    category_code               varchar(12)      NOT NULL,
+    custom_name                 varchar(40)      DEFAULT NULL,
+    appointment_tier_id         bigint           NOT NULL REFERENCES appointment_tier (appointment_tier_id),
+    appointment_host_id         bigint           DEFAULT NULL REFERENCES appointment_host (appointment_host_id),
+    internal_location_id        bigint,
+    custom_location             varchar(40)      DEFAULT NULL,
+    in_cell                     boolean          NOT NULL DEFAULT false,
+    on_wing                     boolean          NOT NULL DEFAULT false,
+    off_wing                    boolean          NOT NULL DEFAULT true,
+    start_date                  date             NOT NULL,
+    created_time                timestamp        NOT NULL,
+    created_by                  varchar(100)     NOT NULL
+);
+CREATE INDEX idx_appointment_set_prison_code ON appointment_set (prison_code);
+CREATE INDEX idx_appointment_set_category_code ON appointment_set (category_code);
+CREATE INDEX idx_appointment_set_custom_name ON appointment_set (custom_name);
+CREATE INDEX idx_appointment_set_appointment_tier_id ON appointment_set (appointment_tier_id);
+CREATE INDEX idx_appointment_set_appointment_host_id ON appointment_set (appointment_host_id);
+CREATE INDEX idx_appointment_set_internal_location_id ON appointment_set (internal_location_id);
+CREATE INDEX idx_appointment_set_custom_location ON appointment_set (custom_location);
+CREATE INDEX idx_appointment_set_start_date ON appointment_set (start_date);
+CREATE INDEX idx_appointment_set_created_by ON appointment_set (created_by);
+
+CREATE TABLE appointment_set_appointment_series
+(
+    appointment_set_appointment_series_id   bigserial NOT NULL CONSTRAINT appointment_set_appointment_series_pk PRIMARY KEY,
+    appointment_set_id                      bigint    NOT NULL REFERENCES appointment_set (appointment_set_id),
+    appointment_series_id                   bigint    NOT NULL REFERENCES appointment_series (appointment_series_id)
+);
+CREATE INDEX idx_appointment_set_id ON appointment_set_appointment_series (appointment_set_id);
+CREATE INDEX idx_appointment_set_appointment_series_id ON appointment_set_appointment_series (appointment_series_id);
+
+-- =============================================
+-- UPDATED VIEWS USING NEW TABLES AND COLUMNS
+-- =============================================
+
+CREATE OR REPLACE VIEW v_appointment_instance AS
+SELECT aa.appointment_attendee_id                                                    AS appointment_instance_id,
+       a.appointment_series_id,
+       aa.appointment_id,
+       aa.appointment_attendee_id,
+       asrs.appointment_type,
+       a.prison_code,
+       aa.prisoner_number,
+       aa.booking_id,
+       a.category_code,
+       a.custom_name,
+       a.appointment_tier_id,
+       a.appointment_host_id,
+       CASE
+           WHEN a.in_cell THEN null
+           ELSE a.internal_location_id END                                          AS internal_location_id,
+       a.custom_location,
+       a.in_cell,
+       a.on_wing,
+       a.off_wing,
+       a.start_date                                                                 AS appointment_date,
+       a.start_time,
+       a.end_time,
+       a.unlock_notes,
+       a.extra_information,
+       a.created_time,
+       a.created_by,
+       a.updated_time,
+       a.updated_by,
+       CASE
+           WHEN a.cancellation_reason_id IS NULL THEN false
+           ELSE NOT acr.is_delete END                                               AS is_cancelled
+FROM appointment_attendee aa
+     JOIN appointment a on aa.appointment_id = a.appointment_id
+     JOIN appointment_series asrs on asrs.appointment_series_id = a.appointment_series_id
+     LEFT JOIN appointment_cancellation_reason acr on a.cancellation_reason_id = acr.appointment_cancellation_reason_id
+WHERE aa.removed_time IS NULL AND NOT a.is_deleted;
+
+CREATE OR REPLACE VIEW v_appointment_search AS
+SELECT a.appointment_series_id,
+       a.appointment_id,
+       asrs.appointment_type,
+       a.prison_code,
+       a.category_code,
+       a.custom_name,
+       a.appointment_tier_id,
+       a.appointment_host_id,
+       CASE WHEN a.in_cell THEN null ELSE a.internal_location_id END                AS internal_location_id,
+       a.custom_location,
+       a.in_cell,
+       a.on_wing,
+       a.off_wing,
+       a.start_date,
+       a.start_time,
+       a.end_time,
+       asrs.appointment_series_schedule_id IS NOT NULL                              AS is_repeat,
+       a.sequence_number,
+       COALESCE(asch.number_of_appointments, 1)                                     AS max_sequence_number,
+       a.unlock_notes,
+       a.extra_information,
+       a.created_by,
+       a.updated_time IS NOT NULL                                                   AS is_edited,
+       CASE
+           WHEN a.cancellation_reason_id IS NULL THEN false
+           ELSE NOT acr.is_delete END                                               AS is_cancelled
+FROM appointment a
+         JOIN appointment_series asrs on asrs.appointment_series_id = a.appointment_series_id
+         LEFT JOIN appointment_series_schedule asch on asrs.appointment_series_schedule_id = asch.appointment_series_schedule_id
+         LEFT JOIN appointment_cancellation_reason acr on a.cancellation_reason_id = acr.appointment_cancellation_reason_id
+WHERE NOT a.is_deleted;
+
+-- =============================================
+-- MIGRATE EXISTING DATA
+-- =============================================
+
+INSERT INTO appointment_series_schedule
+SELECT
+    appointment_schedule_id,
+    repeat_period,
+    repeat_count
+FROM appointment_schedule;
+
+INSERT INTO appointment_series (
+    appointment_series_id,
+    appointment_type,
+    prison_code,
+    category_code,
+    custom_name,
+    appointment_tier_id,
+    internal_location_id,
+    in_cell,
+    start_date,
+    start_time,
+    end_time,
+    appointment_series_schedule_id,
+    extra_information,
+    created_time,
+    created_by,
+    updated_time,
+    updated_by,
+    is_migrated
+)
+SELECT
+    appointment_id,
+    appointment_type,
+    prison_code,
+    category_code,
+    appointment_description,
+    3,
+    internal_location_id,
+    in_cell,
+    start_date,
+    start_time,
+    end_time,
+    appointment_schedule_id,
+    comment,
+    created,
+    created_by,
+    updated,
+    updated_by,
+    is_migrated
+FROM appointment_old;
+
+INSERT INTO appointment (
+    appointment_id,
+    appointment_series_id,
+    sequence_number,
+    prison_code,
+    category_code,
+    custom_name,
+    appointment_tier_id,
+    internal_location_id,
+    in_cell,
+    start_date,
+    start_time,
+    end_time,
+    extra_information,
+    created_time,
+    created_by,
+    updated_time,
+    updated_by,
+    cancelled_time,
+    cancellation_reason_id,
+    cancelled_by,
+    is_deleted
+)
+SELECT
+    appointment_occurrence_id,
+    appointment_id,
+    sequence_number,
+    (SELECT prison_code FROM appointment_series WHERE appointment_series_id = appointment_id),
+    category_code,
+    appointment_description,
+    3,
+    internal_location_id,
+    in_cell,
+    start_date,
+    start_time,
+    end_time,
+    comment,
+    (SELECT created_time FROM appointment_series WHERE appointment_series_id = appointment_id),
+    (SELECT created_by FROM appointment_series WHERE appointment_series_id = appointment_id),
+    updated,
+    updated_by,
+    cancelled,
+    cancellation_reason_id,
+    cancelled_by,
+    deleted
+FROM appointment_occurrence;
+
+INSERT INTO appointment_attendee (
+    appointment_attendee_id,
+    appointment_id,
+    prisoner_number,
+    booking_id
+)
+SELECT
+    appointment_occurrence_allocation_id,
+    appointment_occurrence_id,
+    prisoner_number,
+    booking_id
+FROM appointment_occurrence_allocation;
+
+INSERT INTO appointment_set
+(
+    appointment_set_id,
+    prison_code,
+    category_code,
+    custom_name,
+    appointment_tier_id,
+    internal_location_id,
+    in_cell,
+    start_date,
+    created_time,
+    created_by
+)
+SELECT
+    bulk_appointment_id,
+    prison_code,
+    category_code,
+    appointment_description,
+    3,
+    internal_location_id,
+    in_cell,
+    start_date,
+    created,
+    created_by
+FROM bulk_appointment;
+
+INSERT INTO appointment_set_appointment_series
+(
+    appointment_set_appointment_series_id,
+    appointment_set_id,
+    appointment_series_id
+)
+SELECT
+    bulk_appointment_appointment_id,
+    bulk_appointment_id,
+    appointment_id
+FROM bulk_appointment_appointment;
+
+-- =============================================
+-- DELETE OLD TABLES AND VIEWS
+-- =============================================
+
+DROP VIEW v_appointment_occurrence_search;
+DROP TABLE IF EXISTS bulk_appointment_appointment;
+DROP TABLE IF EXISTS bulk_appointment;
+DROP TABLE IF EXISTS appointment_occurrence_allocation;
+DROP TABLE IF EXISTS appointment_occurrence;
+DROP TABLE IF EXISTS appointment_old;
+DROP TABLE IF EXISTS appointment_schedule;

--- a/src/main/resources/migrations/common/V2023.09.06__rename_appointment_tables.sql
+++ b/src/main/resources/migrations/common/V2023.09.06__rename_appointment_tables.sql
@@ -10,7 +10,8 @@ CREATE TABLE appointment_tier
 INSERT INTO appointment_tier
 VALUES   (1, 'Tier 1'),
          (2, 'Tier 2'),
-         (3, 'No tier, this activity is not considered ''purposeful'' for reporting');
+         (3, 'No tier, this activity is not considered ''purposeful'' for reporting'),
+         (4, 'Not specified');
 
 CREATE TABLE appointment_host
 (

--- a/src/main/resources/migrations/dev/V2023.09.06.1__appointment_sequences.sql
+++ b/src/main/resources/migrations/dev/V2023.09.06.1__appointment_sequences.sql
@@ -1,0 +1,7 @@
+SELECT setval('appointment_series_schedule_appointment_series_schedule_id_seq', (SELECT max(appointment_series_schedule_id) FROM appointment_series_schedule), true);
+SELECT setval('appointment_series_appointment_series_id_seq', (SELECT max(appointment_series_id) FROM appointment_series), true);
+ALTER SEQUENCE appointment_appointment_id_seq1 RENAME TO appointment_appointment_id_seq;
+SELECT setval('appointment_appointment_id_seq', (SELECT max(appointment_id) FROM appointment), true);
+SELECT setval('appointment_attendee_appointment_attendee_id_seq', (SELECT max(appointment_attendee_id) FROM appointment_attendee), true);
+SELECT setval('appointment_set_appointment_set_id_seq', (SELECT max(appointment_set_id) FROM appointment_set), true);
+SELECT setval('appointment_set_appointment_s_appointment_set_appointment_s_seq', (SELECT max(appointment_set_appointment_series_id) FROM appointment_set_appointment_series), true);

--- a/src/main/resources/migrations/prod/V2023.09.06.1__appointment_sequences.sql
+++ b/src/main/resources/migrations/prod/V2023.09.06.1__appointment_sequences.sql
@@ -1,0 +1,7 @@
+SELECT setval('appointment_series_schedule_appointment_series_schedule_id_seq', (SELECT max(appointment_series_schedule_id) FROM appointment_series_schedule), true);
+SELECT setval('appointment_series_appointment_series_id_seq', (SELECT max(appointment_series_id) FROM appointment_series), true);
+ALTER SEQUENCE appointment_appointment_id_seq1 RENAME TO appointment_appointment_id_seq;
+SELECT setval('appointment_appointment_id_seq', (SELECT max(appointment_id) FROM appointment), true);
+SELECT setval('appointment_attendee_appointment_attendee_id_seq', (SELECT max(appointment_attendee_id) FROM appointment_attendee), true);
+SELECT setval('appointment_set_appointment_set_id_seq', (SELECT max(appointment_set_id) FROM appointment_set), true);
+SELECT setval('appointment_set_appointment_s_appointment_set_appointment_s_seq', (SELECT max(appointment_set_appointment_series_id) FROM appointment_set_appointment_series), true);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentHostTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentHostTest.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentHostPrisonStaff
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentHost
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PRISON_STAFF_APPOINTMENT_HOST_ID
+
+class AppointmentHostTest {
+  @Test
+  fun `entity to model mapping`() {
+    val entity = appointmentHostPrisonStaff()
+    entity.toModel() isEqualTo AppointmentHost(
+      PRISON_STAFF_APPOINTMENT_HOST_ID,
+      "Prison staff",
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentOccurrenceTest.kt
@@ -155,7 +155,7 @@ class AppointmentOccurrenceTest {
     val referenceCodeMap = mapOf(entity.categoryCode to appointmentCategoryReferenceCode(entity.categoryCode))
     val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
     val userMap = mapOf(entity.updatedBy!! to userDetail(1, "UPDATE.USER", "UPDATE", "USER"))
-    assertThat(entity.toSummary("TPR", referenceCodeMap, locationMap, userMap)).isEqualTo(
+    assertThat(entity.toSummary(referenceCodeMap, locationMap, userMap)).isEqualTo(
       AppointmentOccurrenceSummary(
         entity.appointmentOccurrenceId,
         1,
@@ -182,7 +182,7 @@ class AppointmentOccurrenceTest {
     val referenceCodeMap = mapOf(entity.categoryCode to appointmentCategoryReferenceCode(entity.categoryCode))
     val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
     val userMap = mapOf(entity.updatedBy!! to userDetail(1, "UPDATE.USER", "UPDATE", "USER"))
-    assertThat(listOf(entity).toSummary("TPR", referenceCodeMap, locationMap, userMap)).isEqualTo(
+    assertThat(listOf(entity).toSummary(referenceCodeMap, locationMap, userMap)).isEqualTo(
       listOf(
         AppointmentOccurrenceSummary(
           entity.appointmentOccurrenceId,
@@ -212,7 +212,7 @@ class AppointmentOccurrenceTest {
     val referenceCodeMap = mapOf(entity.categoryCode to appointmentCategoryReferenceCode(entity.categoryCode))
     val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
     val userMap = mapOf(entity.updatedBy!! to userDetail(1, "UPDATE.USER", "UPDATE", "USER"))
-    with(entity.toSummary("TPR", referenceCodeMap, locationMap, userMap)) {
+    with(entity.toSummary(referenceCodeMap, locationMap, userMap)) {
       assertThat(internalLocation).isNull()
       assertThat(inCell).isTrue
     }
@@ -224,7 +224,7 @@ class AppointmentOccurrenceTest {
     val referenceCodeMap = mapOf(entity.categoryCode to appointmentCategoryReferenceCode(entity.categoryCode))
     val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
     val userMap = mapOf("UPDATE.USER" to userDetail(1, "UPDATE.USER", "UPDATE", "USER"))
-    with(entity.toSummary("TPR", referenceCodeMap, locationMap, userMap)) {
+    with(entity.toSummary(referenceCodeMap, locationMap, userMap)) {
       assertThat(updatedBy).isNull()
       assertThat(isEdited).isFalse
     }
@@ -250,7 +250,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    assertThat(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)).isEqualTo(
+    assertThat(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)).isEqualTo(
       appointmentOccurrenceDetails(
         entity.appointmentOccurrenceId,
         appointment.appointmentId,
@@ -282,7 +282,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    assertThat(listOf(entity).toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)).isEqualTo(
+    assertThat(listOf(entity).toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)).isEqualTo(
       listOf(
         appointmentOccurrenceDetails(
           entity.appointmentOccurrenceId,
@@ -315,7 +315,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    assertThat(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap).bulkAppointment).isEqualTo(BulkAppointmentSummary(1, 3))
+    assertThat(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap).bulkAppointment).isEqualTo(BulkAppointmentSummary(1, 3))
   }
 
   @Test
@@ -329,7 +329,7 @@ class AppointmentOccurrenceTest {
       entity.updatedBy!! to userDetail(2, "UPDATE.USER", "UPDATE", "USER"),
     )
     val prisonerMap = emptyMap<String, Prisoner>()
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap).prisoners) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap).prisoners) {
       assertThat(size).isEqualTo(1)
       with(first()) {
         assertThat(prisonerNumber).isEqualTo("A1234BC")
@@ -370,7 +370,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "4-5-6",
       ),
     )
-    with(entity.toDetails("TPR", prisonersMap, referenceCodeMap, locationMap, userMap).prisoners) {
+    with(entity.toDetails(prisonersMap, referenceCodeMap, locationMap, userMap).prisoners) {
       assertThat(size).isEqualTo(1)
       with(first()) {
         assertThat(prisonerNumber).isEqualTo("A1234BC")
@@ -403,7 +403,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(category.code).isEqualTo(appointment.categoryCode)
       assertThat(category.description).isEqualTo(appointment.categoryCode)
     }
@@ -429,7 +429,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(internalLocation).isNotNull
       assertThat(internalLocation!!.id).isEqualTo(entity.internalLocationId)
       assertThat(internalLocation!!.prisonCode).isEqualTo("TPR")
@@ -455,7 +455,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(createdBy.id).isEqualTo(-1)
       assertThat(createdBy.username).isEqualTo("CREATE.USER")
       assertThat(createdBy.firstName).isEqualTo("UNKNOWN")
@@ -494,7 +494,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(internalLocation).isNull()
       assertThat(inCell).isTrue
     }
@@ -520,7 +520,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(updatedBy).isNull()
       assertThat(isEdited).isFalse
     }
@@ -550,7 +550,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(isCancelled).isTrue
       assertThat(cancelled).isEqualTo(entity.cancelled)
       assertThat(cancelledBy).isNotNull
@@ -583,7 +583,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(isCancelled).isFalse
       assertThat(cancelled).isNull()
       assertThat(cancelledBy).isNull()
@@ -610,7 +610,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(repeat).isEqualTo(AppointmentRepeat(AppointmentRepeatPeriod.WEEKLY, 4))
     }
   }
@@ -639,7 +639,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(appointmentName).isEqualTo("appointment name (test category)")
     }
   }
@@ -668,7 +668,7 @@ class AppointmentOccurrenceTest {
         cellLocation = "1-2-3",
       ),
     )
-    with(entity.toDetails("TPR", prisonerMap, referenceCodeMap, locationMap, userMap)) {
+    with(entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)) {
       assertThat(appointmentName).isEqualTo("test category")
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTierTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTierTest.kt
@@ -1,0 +1,18 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentTier1
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentTier
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.TIER_1_APPOINTMENT_TIER_ID
+
+class AppointmentTierTest {
+  @Test
+  fun `entity to model mapping`() {
+    val entity = appointmentTier1()
+    entity.toModel() isEqualTo AppointmentTier(
+      TIER_1_APPOINTMENT_TIER_ID,
+      "Tier 1",
+    )
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
@@ -9,8 +9,13 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointm
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceSearch
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentRepeatPeriod
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentSchedule
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentTier
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.BulkAppointment
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NO_TIER_APPOINTMENT_TIER_ID
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NOT_SPECIFIED_APPOINTMENT_TIER_ID
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.TIER_1_APPOINTMENT_TIER_ID
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.TIER_2_APPOINTMENT_TIER_ID
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.LocalTime
@@ -38,6 +43,7 @@ internal fun appointmentEntity(
   prisonCode = "TPR",
   categoryCode = "TEST",
   appointmentDescription = appointmentDescription,
+  appointmentTier = appointmentTierNotSpecified(),
   internalLocationId = internalLocationId,
   inCell = inCell,
   startDate = startDate,
@@ -69,14 +75,18 @@ fun appointmentOccurrenceEntity(appointment: Appointment, appointmentOccurrenceI
     appointmentOccurrenceId = appointmentOccurrenceId,
     appointment = appointment,
     sequenceNumber = sequenceNumber,
+    prisonCode = appointment.prisonCode,
     categoryCode = appointment.categoryCode,
     appointmentDescription = appointment.appointmentDescription,
+    appointmentTier = appointment.appointmentTier,
     internalLocationId = appointment.internalLocationId,
     inCell = appointment.inCell,
     startDate = startDate,
     startTime = startTime,
     endTime = appointment.endTime,
     comment = "Appointment occurrence level comment",
+    created = appointment.created,
+    createdBy = appointment.createdBy,
     updated = updated,
     updatedBy = updatedBy,
   ).apply {
@@ -180,6 +190,7 @@ internal fun bulkAppointmentEntity(
     prisonCode = "TPR",
     categoryCode = "TEST",
     appointmentDescription = appointmentDescription,
+    appointmentTier = appointmentTierNotSpecified(),
     internalLocationId = if (inCell) null else 123,
     inCell = inCell,
     startDate = startDate,
@@ -201,6 +212,30 @@ internal fun bulkAppointmentEntity(
       count++
     }
   }
+
+internal fun appointmentTier1() =
+  AppointmentTier(
+    TIER_1_APPOINTMENT_TIER_ID,
+    "Tier 1",
+  )
+
+internal fun appointmentTier2() =
+  AppointmentTier(
+    TIER_2_APPOINTMENT_TIER_ID,
+    "Tier 2",
+  )
+
+internal fun appointmentNoTier() =
+  AppointmentTier(
+    NO_TIER_APPOINTMENT_TIER_ID,
+    "No tier, this activity is not considered 'purposeful' for reporting",
+  )
+
+internal fun appointmentTierNotSpecified() =
+  AppointmentTier(
+    NOT_SPECIFIED_APPOINTMENT_TIER_ID,
+    "Not specified",
+  )
 
 internal fun appointmentCancelledReason() =
   AppointmentCancellationReason(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers
 
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentCancellationReason
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentHost
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrence
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentOccurrenceAllocation
@@ -14,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointm
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.BulkAppointment
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NOT_SPECIFIED_APPOINTMENT_TIER_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NO_TIER_APPOINTMENT_TIER_ID
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PRISON_STAFF_APPOINTMENT_HOST_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.TIER_1_APPOINTMENT_TIER_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.TIER_2_APPOINTMENT_TIER_ID
 import java.time.LocalDate
@@ -235,6 +237,12 @@ internal fun appointmentTierNotSpecified() =
   AppointmentTier(
     NOT_SPECIFIED_APPOINTMENT_TIER_ID,
     "Not specified",
+  )
+
+internal fun appointmentHostPrisonStaff() =
+  AppointmentHost(
+    PRISON_STAFF_APPOINTMENT_HOST_ID,
+    "Prison staff",
   )
 
 internal fun appointmentCancelledReason() =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
@@ -12,8 +12,8 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointm
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentTier
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.BulkAppointment
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NO_TIER_APPOINTMENT_TIER_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NOT_SPECIFIED_APPOINTMENT_TIER_ID
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NO_TIER_APPOINTMENT_TIER_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.TIER_1_APPOINTMENT_TIER_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.TIER_2_APPOINTMENT_TIER_ID
 import java.time.LocalDate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentServiceTest.kt
@@ -34,6 +34,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentMigrateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentTierNotSpecified
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.bulkAppointmentRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userCaseLoads
@@ -43,8 +44,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointme
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.AppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.BulkAppointmentCreatedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentCancellationReasonRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentHostRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentTierRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.BulkAppointmentRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.NOT_SPECIFIED_APPOINTMENT_TIER_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_COUNT_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_INSTANCE_COUNT_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.APPOINTMENT_SERIES_ID_PROPERTY_KEY
@@ -85,6 +89,8 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointme
 @ExtendWith(FakeSecurityContext::class)
 class AppointmentServiceTest {
   private val appointmentRepository: AppointmentRepository = mock()
+  private val appointmentTierRepository: AppointmentTierRepository = mock()
+  private val appointmentHostRepository: AppointmentHostRepository = mock()
   private val appointmentCancellationReasonRepository: AppointmentCancellationReasonRepository = mock()
   private val bulkAppointmentRepository: BulkAppointmentRepository = mock()
   private val referenceCodeService: ReferenceCodeService = mock()
@@ -110,6 +116,8 @@ class AppointmentServiceTest {
 
   private val service = AppointmentService(
     appointmentRepository,
+    appointmentTierRepository,
+    appointmentHostRepository,
     appointmentCancellationReasonRepository,
     bulkAppointmentRepository,
     referenceCodeService,
@@ -126,6 +134,7 @@ class AppointmentServiceTest {
     MockitoAnnotations.openMocks(this)
     principal = SecurityContextHolder.getContext().authentication
     addCaseloadIdToRequestHeader("TPR")
+    whenever(appointmentTierRepository.findById(NOT_SPECIFIED_APPOINTMENT_TIER_ID)).thenReturn(Optional.of(appointmentTierNotSpecified()))
   }
 
   @AfterEach
@@ -161,6 +170,7 @@ class AppointmentServiceTest {
         prisonerBookings = emptyMap(),
         categoryCode = request.categoryCode!!,
         appointmentDescription = request.appointmentDescription,
+        appointmentTier = appointmentTierNotSpecified(),
         internalLocationId = request.internalLocationId,
         inCell = request.inCell,
         startDate = request.startDate,
@@ -190,6 +200,7 @@ class AppointmentServiceTest {
         prisonerBookings = emptyMap(),
         categoryCode = request.categoryCode!!,
         appointmentDescription = request.appointmentDescription,
+        appointmentTier = appointmentTierNotSpecified(),
         internalLocationId = request.internalLocationId,
         inCell = request.inCell,
         startDate = request.startDate,
@@ -222,6 +233,7 @@ class AppointmentServiceTest {
         prisonerBookings = emptyMap(),
         categoryCode = request.categoryCode!!,
         appointmentDescription = request.appointmentDescription,
+        appointmentTier = appointmentTierNotSpecified(),
         internalLocationId = request.internalLocationId,
         inCell = request.inCell,
         startDate = request.startDate,
@@ -256,6 +268,7 @@ class AppointmentServiceTest {
         prisonerBookings = emptyMap(),
         categoryCode = request.categoryCode!!,
         appointmentDescription = request.appointmentDescription,
+        appointmentTier = appointmentTierNotSpecified(),
         internalLocationId = request.internalLocationId,
         inCell = request.inCell,
         startDate = request.startDate,
@@ -281,6 +294,7 @@ class AppointmentServiceTest {
       prisonerNumbers = listOf(request.prisonerNumber!!),
       prisonerBookings = mapOf(request.prisonerNumber!! to request.bookingId.toString()),
       categoryCode = request.categoryCode!!,
+      appointmentTier = appointmentTierNotSpecified(),
       internalLocationId = request.internalLocationId,
       startDate = request.startDate,
       startTime = request.startTime,
@@ -290,7 +304,6 @@ class AppointmentServiceTest {
       isMigrated = true,
     )
 
-    verify(times(0)) { prisonApiUserClient.getUserCaseLoads() }
     verify(times(0)) { referenceCodeService.getScheduleReasonsMap(any()) }
     verify(times(0)) { locationService.getLocationsForAppointmentsMap(any()) }
   }
@@ -308,6 +321,7 @@ class AppointmentServiceTest {
       prisonerBookings = emptyMap(),
       categoryCode = request.categoryCode!!,
       appointmentDescription = request.appointmentDescription,
+      appointmentTier = appointmentTierNotSpecified(),
       internalLocationId = request.internalLocationId,
       inCell = request.inCell,
       startDate = request.startDate,
@@ -463,7 +477,7 @@ class AppointmentServiceTest {
         assertThat(value[APPOINTMENT_INSTANCE_COUNT_METRIC_KEY]).isEqualTo(1.0)
         assertThat(value[DESCRIPTION_LENGTH_METRIC_KEY]).isEqualTo(23.0)
         assertThat(value[EXTRA_INFORMATION_LENGTH_METRIC_KEY]).isEqualTo(25.0)
-        assertThat(value[EVENT_TIME_MS_METRIC_KEY]).isNotNull()
+        assertThat(value[EVENT_TIME_MS_METRIC_KEY]).isNotNull
       }
 
       verify(auditService).logEvent(any<AppointmentCreatedEvent>())
@@ -703,6 +717,7 @@ class AppointmentServiceTest {
         prisonCode = request.prisonCode,
         categoryCode = request.categoryCode,
         appointmentDescription = request.appointmentDescription,
+        appointmentTier = appointmentTierNotSpecified(),
         internalLocationId = request.internalLocationId,
         inCell = request.inCell,
         startDate = request.startDate,
@@ -737,7 +752,7 @@ class AppointmentServiceTest {
         assertThat(it.categoryCode).isEqualTo("TEST")
         assertThat(it.prisonCode).isEqualTo("TPR")
         assertThat(it.internalLocationId).isEqualTo(123)
-        assertThat(it.inCell).isFalse()
+        assertThat(it.inCell).isFalse
         assertThat(it.startDate).isEqualTo(LocalDate.now().plusDays(1))
         assertThat(it.startTime).isEqualTo(LocalTime.of(13, 0))
         assertThat(it.endTime).isEqualTo(LocalTime.of(14, 30))
@@ -763,7 +778,7 @@ class AppointmentServiceTest {
       assertThat(value[APPOINTMENT_INSTANCE_COUNT_METRIC_KEY]).isEqualTo(4.0)
       assertThat(value[DESCRIPTION_LENGTH_METRIC_KEY]).isEqualTo(23.0)
       assertThat(value[EXTRA_INFORMATION_COUNT_METRIC_KEY]).isEqualTo(4.0)
-      assertThat(value[EVENT_TIME_MS_METRIC_KEY]).isNotNull()
+      assertThat(value[EVENT_TIME_MS_METRIC_KEY]).isNotNull
     }
 
     verify(auditService).logEvent(any<BulkAppointmentCreatedEvent>())
@@ -835,7 +850,7 @@ class AppointmentServiceTest {
       assertThat(createdBy).isEqualTo(request.createdBy)
       assertThat(updated).isNull()
       assertThat(updatedBy).isNull()
-      assertThat(isMigrated).isTrue()
+      assertThat(isMigrated).isTrue
       with(occurrences()) {
         assertThat(size).isEqualTo(1)
         with(occurrences().first()) {
@@ -883,7 +898,7 @@ class AppointmentServiceTest {
       assertThat(createdBy).isEqualTo(request.createdBy)
       assertThat(updated).isNull()
       assertThat(updatedBy).isNull()
-      assertThat(isMigrated).isTrue()
+      assertThat(isMigrated).isTrue
       with(occurrences()) {
         assertThat(size).isEqualTo(1)
         with(occurrences().first()) {

--- a/src/test/resources/test_data/clean-all-data.sql
+++ b/src/test/resources/test_data/clean-all-data.sql
@@ -26,7 +26,6 @@ truncate table waiting_list restart identity;
 truncate table local_audit restart identity;
 
 --Appointments
-truncate table appointment_cancellation_reason restart identity;
 truncate table appointment_attendee restart identity;
 truncate table appointment restart identity;
 truncate table appointment_series_schedule restart identity;

--- a/src/test/resources/test_data/clean-all-data.sql
+++ b/src/test/resources/test_data/clean-all-data.sql
@@ -27,11 +27,11 @@ truncate table local_audit restart identity;
 
 --Appointments
 truncate table appointment_cancellation_reason restart identity;
-truncate table appointment_occurrence_allocation restart identity;
-truncate table appointment_occurrence restart identity;
-truncate table appointment_schedule restart identity;
+truncate table appointment_attendee restart identity;
 truncate table appointment restart identity;
-truncate table bulk_appointment_appointment restart identity;
-truncate table bulk_appointment restart identity;
+truncate table appointment_series_schedule restart identity;
+truncate table appointment_series restart identity;
+truncate table appointment_set_appointment_series restart identity;
+truncate table appointment_set restart identity;
 
 SET REFERENTIAL_INTEGRITY TRUE;

--- a/src/test/resources/test_data/seed-appointment-deleted-id-2.sql
+++ b/src/test/resources/test_data/seed-appointment-deleted-id-2.sql
@@ -1,8 +1,8 @@
-INSERT INTO appointment (appointment_id, appointment_type, category_code, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, comment, created, created_by)
-VALUES (2, 'INDIVIDUAL', 'AC1', 'TPR', 123, false, now()::date + 1, '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (2, 'INDIVIDUAL', 'TPR', 'AC1', 4, 123, false, now()::date + 1, '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment, cancelled, cancellation_reason_id, cancelled_by, deleted)
-VALUES (3, 2, 1, 'AC1', 123, false, now()::date + 1, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 1, 'TEST.USER', true);
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by, cancelled_time, cancellation_reason_id, cancelled_by, is_deleted)
+VALUES (3, 2, 1, 'TPR', 'AC1', 4, 123, false, now()::date + 1, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER', now()::timestamp, 1, 'TEST.USER', true);
 
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (4, 3, 'A1234BC', 456);

--- a/src/test/resources/test_data/seed-appointment-group-id-4.sql
+++ b/src/test/resources/test_data/seed-appointment-group-id-4.sql
@@ -1,11 +1,11 @@
-INSERT INTO appointment (appointment_id, appointment_type, category_code, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, comment, created, created_by)
-VALUES (3, 'GROUP', 'AC1', 'MDI', 123, false, '2022-10-01', '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (3, 'GROUP', 'MDI', 'AC1', 4, 123, false, '2022-10-01', '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (3, 3, 1, 'AC1', 123, false, '2022-10-01', '09:00', '10:30', 'Appointment occurrence level comment');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (3, 3, 1, 'MDI', 'AC1', 4, 123, false, '2022-10-01', '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (4, 3, 'A5193DY', 1200993);
 
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (5, 3, 'G4793VF', 1200994);

--- a/src/test/resources/test_data/seed-appointment-group-repeat-12-instances-id-7.sql
+++ b/src/test/resources/test_data/seed-appointment-group-repeat-12-instances-id-7.sql
@@ -1,40 +1,40 @@
-INSERT INTO appointment_schedule (appointment_schedule_id, repeat_period, repeat_count)
+INSERT INTO appointment_series_schedule (appointment_series_schedule_id, frequency, number_of_appointments)
 VALUES (2, 'WEEKLY', 4);
 
-INSERT INTO appointment (appointment_id, appointment_type, category_code, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, appointment_schedule_id, comment, created, created_by)
-VALUES (7, 'GROUP', 'AC1', 'TPR', 123, false, now()::date + 1, '09:00', '10:30', 2, 'Appointment level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, appointment_series_schedule_id, extra_information, created_time, created_by)
+VALUES (7, 'GROUP', 'TPR', 'AC1', 4, 123, false, now()::date + 1, '09:00', '10:30', 2, 'Appointment level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (20, 7, 1, 'AC1', 123, false, now()::date + 1, '09:00', '10:30', 'Appointment occurrence level comment');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (21, 7, 2, 'AC1', 123, false, now()::date + 8, '09:00', '10:30', 'Appointment occurrence level comment');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (22, 7, 3, 'AC1', 123, false, now()::date + 15, '09:00', '10:30', 'Appointment occurrence level comment');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (23, 7, 4, 'AC1', 123, false, now()::date + 22, '09:00', '10:30', 'Appointment occurrence level comment');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (20, 7, 1, 'TPR', 'AC1', 4, 123, false, now()::date + 1, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (21, 7, 2, 'TPR', 'AC1', 4, 123, false, now()::date + 8, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (22, 7, 3, 'TPR', 'AC1', 4, 123, false, now()::date + 15, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (23, 7, 4, 'TPR', 'AC1', 4, 123, false, now()::date + 22, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (30, 20, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (31, 20, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (32, 20, 'C3456DE', 458);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (33, 21, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (34, 21, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (35, 21, 'C3456DE', 458);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (36, 22, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (37, 22, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (38, 22, 'C3456DE', 458);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (39, 23, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (40, 23, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (41, 23, 'C3456DE', 458);
 

--- a/src/test/resources/test_data/seed-appointment-group-repeat-id-5.sql
+++ b/src/test/resources/test_data/seed-appointment-group-repeat-id-5.sql
@@ -1,32 +1,32 @@
-INSERT INTO appointment_schedule (appointment_schedule_id, repeat_period, repeat_count)
+INSERT INTO appointment_series_schedule (appointment_series_schedule_id, frequency, number_of_appointments)
 VALUES (1, 'WEEKLY', 4);
 
-INSERT INTO appointment (appointment_id, appointment_type, category_code, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, appointment_schedule_id, comment, created, created_by)
-VALUES (5, 'GROUP', 'AC1', 'TPR', 123, false, now()::date - 3, '09:00', '10:30', 1, 'Appointment level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, appointment_series_schedule_id, extra_information, created_time, created_by)
+VALUES (5, 'GROUP', 'TPR', 'AC1', 4, 123, false, now()::date - 3, '09:00', '10:30', 1, 'Appointment level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (10, 5, 1, 'AC1', 123, false, now()::date - 3, '09:00', '10:30', 'Appointment occurrence level comment');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (11, 5, 2, 'AC1', 123, false, now()::date + 4, '09:00', '10:30', 'Appointment occurrence level comment');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (12, 5, 3, 'AC1', 123, false, now()::date + 11, '09:00', '10:30', 'Appointment occurrence level comment');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (13, 5, 4, 'AC1', 123, false, now()::date + 18, '09:00', '10:30', 'Appointment occurrence level comment');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (10, 5, 1, 'TPR', 'AC1', 4, 123, false, now()::date - 3, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (11, 5, 2, 'TPR', 'AC1', 4, 123, false, now()::date + 4, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (12, 5, 3, 'TPR', 'AC1', 4, 123, false, now()::date + 11, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (13, 5, 4, 'TPR', 'AC1', 4, 123, false, now()::date + 18, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (20, 10, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (21, 10, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (22, 11, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (23, 11, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (24, 12, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (25, 12, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (26, 13, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (27, 13, 'B2345CD', 457);
 

--- a/src/test/resources/test_data/seed-appointment-search.sql
+++ b/src/test/resources/test_data/seed-appointment-search.sql
@@ -1,66 +1,66 @@
 --Individual appointments--
 --Prisoner A1234BC, Category AC1, Location 123, Today 08:30-10:00, Created by TEST.USER
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, internal_location_id, in_cell, start_date, start_time, end_time, created, created_by)
-VALUES (100, 'INDIVIDUAL', 'MDI', 'AC1', 123, false, now()::date, '08:30', '10:00', now()::timestamp, 'TEST.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (200, 100, 1, 'AC1', 123, false, now()::date, '08:30', '10:00');
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (100, 'INDIVIDUAL', 'MDI', 'AC1', 4, 123, false, now()::date, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (200, 100, 1, 'MDI', 'AC1', 4, 123, false, now()::date, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (300, 200, 'A1234BC', 456);
 
 --Prisoner B2345CD, Category AC2, Description Art Class, Location 456, Today 13:00-15:00, Created by DIFFERENT.USER
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, appointment_description, internal_location_id, in_cell, start_date, start_time, end_time, created, created_by)
-VALUES (101, 'INDIVIDUAL', 'MDI', 'AC2', 'Art Class', 456, false, now()::date, '13:00', '15:00', now()::timestamp, 'DIFFERENT.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (201, 101, 1, 'AC2', 456, false, now()::date, '13:00', '15:00');
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (101, 'INDIVIDUAL', 'MDI', 'AC2', 'Art Class', 4, 456, false, now()::date, '13:00', '15:00', now()::timestamp, 'DIFFERENT.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (201, 101, 1, 'MDI', 'AC2', 4, 456, false, now()::date, '13:00', '15:00', now()::timestamp, 'DIFFERENT.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (301, 201, 'B2345CD', 457);
 
 --Prisoner A1234BC, Category AC3, In cell, One week from now 12:30-14:00, Created by TEST.USER
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, internal_location_id, in_cell, start_date, start_time, end_time, created, created_by)
-VALUES (102, 'INDIVIDUAL', 'MDI', 'AC3', null, true, now()::date + 7, '12:30', '14:00', now()::timestamp, 'TEST.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (202, 102, 1, 'AC3', null, true, now()::date + 7, '12:30', '14:00');
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (102, 'INDIVIDUAL', 'MDI', 'AC3', 4, null, true, now()::date + 7, '12:30', '14:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (202, 102, 1, 'MDI', 'AC3', 4, null, true, now()::date + 7, '12:30', '14:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (302, 202, 'A1234BC', 456);
 
 --Prison OTH, Prisoner A1234BC, Category AC1, Location 789, Today 09:00-10:30, Created by OTHER.USER
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, internal_location_id, in_cell, start_date, start_time, end_time, created, created_by)
-VALUES (103, 'INDIVIDUAL', 'OTH', 'AC1', 789, false, now()::date, '09:00', '10:30', now()::timestamp, 'OTHER.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (203, 103, 1, 'AC1', 789, false, now()::date, '09:00', '10:30');
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (103, 'INDIVIDUAL', 'OTH', 'AC1', 4, 789, false, now()::date, '09:00', '10:30', now()::timestamp, 'OTHER.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (203, 103, 1, 'OTH', 'AC1', 4, 789, false, now()::date, '09:00', '10:30', now()::timestamp, 'OTHER.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (303, 203, 'D4567EF', 459);
 
 --Group appointments--
 --Prisoners A1234BC and B2345CD, Category AC1, Location 123, Started one week ago 09:00-10:30, Repeating weekly 4 times, One edited, One cancelled, One deleted, Created by TEST.USER
-INSERT INTO appointment_schedule (appointment_schedule_id, repeat_period, repeat_count)
+INSERT INTO appointment_series_schedule (appointment_series_schedule_id, frequency, number_of_appointments)
 VALUES (10, 'WEEKLY', 4);
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, internal_location_id, in_cell, start_date, start_time, end_time, appointment_schedule_id, created, created_by)
-VALUES (110, 'GROUP', 'MDI', 'AC1', 123, false, now()::date - 7, '09:00', '10:30', 10, now()::timestamp, 'TEST.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (210, 110, 1, 'AC1', 123, false, now()::date - 7, '09:00', '10:30');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, updated, updated_by)
-VALUES (211, 110, 2, 'AC1', 456, false, now()::date, '13:30', '15:00', now()::timestamp, 'DIFFERENT.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, cancelled, cancellation_reason_id, cancelled_by)
-VALUES (212, 110, 3, 'AC1', 123, false, now()::date + 7, '09:00', '10:30', now()::timestamp, 2, 'DIFFERENT.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, cancelled, cancellation_reason_id, cancelled_by, deleted)
-VALUES (213, 110, 4, 'AC1', 123, false, now()::date + 14, '09:00', '10:30', now()::timestamp, 1, 'DIFFERENT.USER', true);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, appointment_series_schedule_id, created_time, created_by)
+VALUES (110, 'GROUP', 'MDI', 'AC1', 4, 123, false, now()::date - 7, '09:00', '10:30', 10, now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (210, 110, 1, 'MDI', 'AC1', 4, 123, false, now()::date - 7, '09:00', '10:30', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, updated_time, updated_by)
+VALUES (211, 110, 2, 'MDI', 'AC1', 4, 456, false, now()::date, '13:30', '15:00', now()::timestamp, 'TEST.USER', now()::timestamp, 'DIFFERENT.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, cancelled_time, cancellation_reason_id, cancelled_by)
+VALUES (212, 110, 3, 'MDI', 'AC1', 4, 123, false, now()::date + 7, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 2, 'DIFFERENT.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, cancelled_time, cancellation_reason_id, cancelled_by, is_deleted)
+VALUES (213, 110, 4, 'MDI', 'AC1', 4, 123, false, now()::date + 14, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 1, 'DIFFERENT.USER', true);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (320, 210, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (321, 210, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (322, 211, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (323, 211, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (324, 212, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (325, 212, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (326, 213, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (327, 213, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (328, 211, 'C3456DE', 458);
 

--- a/src/test/resources/test_data/seed-appointment-single-id-1.sql
+++ b/src/test/resources/test_data/seed-appointment-single-id-1.sql
@@ -1,9 +1,9 @@
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, appointment_description, internal_location_id, in_cell, start_date, start_time, end_time, comment, created, created_by)
-VALUES (1, 'INDIVIDUAL', 'TPR', 'AC1', 'Appointment description', 123, false, now()::date + 1, '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (1, 'INDIVIDUAL', 'TPR', 'AC1', 'Appointment description', 4, 123, false, now()::date + 1, '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, appointment_description, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (2, 1, 1, 'AC1', 'Appointment description', 123, false, now()::date + 1, '09:00', '10:30', 'Appointment occurrence level comment');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (2, 1, 1, 'TPR', 'AC1', 'Appointment description', 4, 123, false, now()::date + 1, '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (3, 2, 'A1234BC', 456);
 

--- a/src/test/resources/test_data/seed-appointment-single-id-3.sql
+++ b/src/test/resources/test_data/seed-appointment-single-id-3.sql
@@ -1,8 +1,8 @@
-INSERT INTO appointment (appointment_id, appointment_type, category_code, appointment_description, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, comment, created, created_by)
-VALUES (3, 'INDIVIDUAL', 'AC1', 'Appointment description', 'MDI', 123, false, '2022-10-01', '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_series (appointment_series_id, appointment_type, category_code, custom_name, appointment_tier_id, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (3, 'INDIVIDUAL', 'AC1', 'Appointment description', 4, 'MDI', 123, false, '2022-10-01', '09:00', '10:30', 'Appointment level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, appointment_description, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (3, 3, 1, 'AC1', 'Appointment description', 123, false, '2022-10-01', '09:00', '10:30', 'Appointment occurrence level comment');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (3, 3, 1, 'MDI', 'AC1', 'Appointment description', 4, 123, false, '2022-10-01', '09:00', '10:30', 'Appointment occurrence level comment', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (4, 3, 'A11111A', 1200993);

--- a/src/test/resources/test_data/seed-appointments-changed-event.sql
+++ b/src/test/resources/test_data/seed-appointments-changed-event.sql
@@ -1,66 +1,66 @@
 --Individual appointments--
 --Prisoner A1234BC, Category AC1, Location 123, Today 08:30-10:00, Created by TEST.USER
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, internal_location_id, in_cell, start_date, start_time, end_time, created, created_by)
-VALUES (100, 'INDIVIDUAL', 'MDI', 'AC1', 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (200, 100, 1, 'AC1', 123, false, now()::date + 1, '08:30', '10:00');
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (100, 'INDIVIDUAL', 'MDI', 'AC1', 4, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (200, 100, 1, 'MDI', 'AC1', 4, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (300, 200, 'A1234BC', 456);
 
 --Prisoner B2345CD, Category AC2, Description Art Class, Location 456, Today 13:00-15:00, Created by DIFFERENT.USER
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, appointment_description, internal_location_id, in_cell, start_date, start_time, end_time, created, created_by)
-VALUES (101, 'INDIVIDUAL', 'MDI', 'AC2', 'Art Class', 456, false,now()::date + 1, '13:00', '15:00', now()::timestamp, 'DIFFERENT.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (201, 101, 1, 'AC2', 456, false, now()::date + 1, '13:00', '15:00');
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (101, 'INDIVIDUAL', 'MDI', 'AC2', 'Art Class', 4, 456, false,now()::date + 1, '13:00', '15:00', now()::timestamp, 'DIFFERENT.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (201, 101, 1, 'MDI', 'AC2', 4, 456, false, now()::date + 1, '13:00', '15:00', now()::timestamp, 'DIFFERENT.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (301, 201, 'B2345CD', 457);
 
 --Prisoner A1234BC, Category AC3, In cell, One week from now 12:30-14:00, Created by TEST.USER
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, internal_location_id, in_cell, start_date, start_time, end_time, created, created_by)
-VALUES (102, 'INDIVIDUAL', 'MDI', 'AC3', null, true, now()::date + 7, '12:30', '14:00', now()::timestamp, 'TEST.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (202, 102, 1, 'AC3', null, true, now()::date + 7, '12:30', '14:00');
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (102, 'INDIVIDUAL', 'MDI', 'AC3', 4, null, true, now()::date + 7, '12:30', '14:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (202, 102, 1, 'MDI', 'AC3', 4, null, true, now()::date + 7, '12:30', '14:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (302, 202, 'A1234BC', 456);
 
 --Prison OTH, Prisoner A1234BC, Category AC1, Location 789, Today 09:00-10:30, Created by OTHER.USER
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, internal_location_id, in_cell, start_date, start_time, end_time, created, created_by)
-VALUES (103, 'INDIVIDUAL', 'OTH', 'AC1', 789, false, now()::date + 1, '09:00', '10:30', now()::timestamp, 'OTHER.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (203, 103, 1, 'AC1', 789, false, now()::date + 1, '09:00', '10:30');
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (103, 'INDIVIDUAL', 'OTH', 'AC1', 4, 789, false, now()::date + 1, '09:00', '10:30', now()::timestamp, 'OTHER.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (203, 103, 1, 'OTH', 'AC1', 4, 789, false, now()::date + 1, '09:00', '10:30', now()::timestamp, 'OTHER.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (303, 203, 'D4567EF', 459);
 
 --Group appointments--
 --Prisoners A1234BC and B2345CD, Category AC1, Location 123, Started one week ago 09:00-10:30, Repeating weekly 4 times, One edited, One cancelled, One deleted, Created by TEST.USER
-INSERT INTO appointment_schedule (appointment_schedule_id, repeat_period, repeat_count)
+INSERT INTO appointment_series_schedule (appointment_series_schedule_id, frequency, number_of_appointments)
 VALUES (10, 'WEEKLY', 4);
-INSERT INTO appointment (appointment_id, appointment_type, prison_code, category_code, internal_location_id, in_cell, start_date, start_time, end_time, appointment_schedule_id, created, created_by)
-VALUES (110, 'GROUP', 'MDI', 'AC1', 123, false, now()::date - 7, '09:00', '10:30', 10, now()::timestamp, 'TEST.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time)
-VALUES (210, 110, 1, 'AC1', 123, false, now()::date - 7, '09:00', '10:30');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, updated, updated_by)
-VALUES (211, 110, 2, 'AC1', 456, false, now()::date + 1, '13:30', '15:00', now()::timestamp, 'DIFFERENT.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, cancelled, cancellation_reason_id, cancelled_by)
-VALUES (212, 110, 3, 'AC1', 123, false, now()::date + 7, '09:00', '10:30', now()::timestamp, 2, 'DIFFERENT.USER');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, internal_location_id, in_cell, start_date, start_time, end_time, cancelled, cancellation_reason_id, cancelled_by, deleted)
-VALUES (213, 110, 4, 'AC1', 123, false, now()::date + 14, '09:00', '10:30', now()::timestamp, 1, 'DIFFERENT.USER', true);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, appointment_series_schedule_id, created_time, created_by)
+VALUES (110, 'GROUP', 'MDI', 'AC1', 4, 123, false, now()::date - 7, '09:00', '10:30', 10, now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (210, 110, 1, 'MDI', 'AC1', 4, 123, false, now()::date - 7, '09:00', '10:30', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, updated_time, updated_by)
+VALUES (211, 110, 2, 'MDI', 'AC1', 4, 456, false, now()::date + 1, '13:30', '15:00', now()::timestamp, 'TEST.USER', now()::timestamp, 'DIFFERENT.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, cancelled_time, cancellation_reason_id, cancelled_by)
+VALUES (212, 110, 3, 'MDI', 'AC1', 4, 123, false, now()::date + 7, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 2, 'DIFFERENT.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, cancelled_time, cancellation_reason_id, cancelled_by, is_deleted)
+VALUES (213, 110, 4, 'MDI', 'AC1', 4, 123, false, now()::date + 14, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 1, 'DIFFERENT.USER', true);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (320, 210, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (321, 210, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (322, 211, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (323, 211, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (324, 212, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (325, 212, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (326, 213, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (327, 213, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (328, 211, 'C3456DE', 458);
 

--- a/src/test/resources/test_data/seed-bulk-appointment-id-6.sql
+++ b/src/test/resources/test_data/seed-bulk-appointment-id-6.sql
@@ -1,30 +1,30 @@
-INSERT INTO appointment (appointment_id, appointment_type, category_code, appointment_description, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, comment, created, created_by)
-VALUES (6, 'INDIVIDUAL', 'AC1', 'Appointment description', 'TPR', 123, false, now()::date + 1, '09:00', '09:15', 'Medical appointment for A1234BC', now()::timestamp, 'TEST.USER');
-INSERT INTO appointment (appointment_id, appointment_type, category_code, appointment_description, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, comment, created, created_by)
-VALUES (7, 'INDIVIDUAL', 'AC1', 'Appointment description', 'TPR', 123, false, now()::date + 1, '09:15', '09:30', 'Medical appointment for B2345CD', now()::timestamp, 'TEST.USER');
-INSERT INTO appointment (appointment_id, appointment_type, category_code, appointment_description, prison_code, internal_location_id, in_cell, start_date, start_time, end_time, comment, created, created_by)
-VALUES (8, 'INDIVIDUAL', 'AC1', 'Appointment description', 'TPR', 123, false, now()::date + 1, '09:30', '09:45', 'Medical appointment for C3456DE', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (6, 'INDIVIDUAL', 'TPR', 'AC1', 'Appointment description', 4, 123, false, now()::date + 1, '09:00', '09:15', 'Medical appointment for A1234BC', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (7, 'INDIVIDUAL', 'TPR', 'AC1', 'Appointment description', 4, 123, false, now()::date + 1, '09:15', '09:30', 'Medical appointment for B2345CD', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (8, 'INDIVIDUAL', 'TPR', 'AC1', 'Appointment description', 4, 123, false, now()::date + 1, '09:30', '09:45', 'Medical appointment for C3456DE', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, appointment_description, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (6, 6, 1, 'AC1', 'Appointment description', 123, false, now()::date + 1, '09:00', '09:15', 'Medical appointment for A1234BC');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, appointment_description, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (7, 7, 1, 'AC1', 'Appointment description', 123, false, now()::date + 1, '09:15', '09:30', 'Medical appointment for B2345CD');
-INSERT INTO appointment_occurrence (appointment_occurrence_id, appointment_id, sequence_number, category_code, appointment_description, internal_location_id, in_cell, start_date, start_time, end_time, comment)
-VALUES (8, 8, 1, 'AC1', 'Appointment description', 123, false, now()::date + 1, '09:30', '09:45', 'Medical appointment for C3456DE');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (6, 6, 1, 'TPR', 'AC1', 'Appointment description', 4, 123, false, now()::date + 1, '09:00', '09:15', 'Medical appointment for A1234BC', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (7, 7, 1, 'TPR', 'AC1', 'Appointment description', 4, 123, false, now()::date + 1, '09:15', '09:30', 'Medical appointment for B2345CD', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, extra_information, created_time, created_by)
+VALUES (8, 8, 1, 'TPR', 'AC1', 'Appointment description', 4, 123, false, now()::date + 1, '09:30', '09:45', 'Medical appointment for C3456DE', now()::timestamp, 'TEST.USER');
 
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (6, 6, 'A1234BC', 456);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (7, 7, 'B2345CD', 457);
-INSERT INTO appointment_occurrence_allocation (appointment_occurrence_allocation_id, appointment_occurrence_id, prisoner_number, booking_id)
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (8, 8, 'C3456DE', 458);
 
-INSERT INTO bulk_appointment (bulk_appointment_id, prison_code, category_code, appointment_description, internal_location_id, in_cell, start_date, created, created_by)
-VALUES (6, 'TPR', 'AC1', 'Appointment description', 123, false, now()::date + 1, now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_set (appointment_set_id, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, created_time, created_by)
+VALUES (6, 'TPR', 'AC1', 'Appointment description', 4, 123, false, now()::date + 1, now()::timestamp, 'TEST.USER');
 
-INSERT INTO bulk_appointment_appointment (bulk_appointment_appointment_id, bulk_appointment_id, appointment_id)
+INSERT INTO appointment_set_appointment_series (appointment_set_appointment_series_id, appointment_set_id, appointment_series_id)
 VALUES (6, 6, 6);
-INSERT INTO bulk_appointment_appointment (bulk_appointment_appointment_id, bulk_appointment_id, appointment_id)
+INSERT INTO appointment_set_appointment_series (appointment_set_appointment_series_id, appointment_set_id, appointment_series_id)
 VALUES (7, 6, 7);
-INSERT INTO bulk_appointment_appointment (bulk_appointment_appointment_id, bulk_appointment_id, appointment_id)
+INSERT INTO appointment_set_appointment_series (appointment_set_appointment_series_id, appointment_set_id, appointment_series_id)
 VALUES (8, 6, 8);

--- a/src/test/resources/test_data/seed-reference-data.sql
+++ b/src/test/resources/test_data/seed-reference-data.sql
@@ -78,10 +78,3 @@ INSERT INTO prison_regime
 (prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES ('MDI', '09:00:00', '12:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00'),
        ('RSI', '09:00:00', '12:00:00', '13:45:00', '16:45:00', '18:00:00', '20:00:00');
-
---
--- Appointment cancellation reasons
---
-INSERT INTO appointment_cancellation_reason (appointment_cancellation_reason_id, description, is_delete)
-VALUES   (1, 'Created in error', true),
-         (2, 'Cancelled', false);


### PR DESCRIPTION
This is the first of several PRs which will rename the API appointment entities and endpoints in line with the UI:

- appointment → appointment_series
- appointment_occurrence → appointment
- appointment_occurrence_allocation → appointment_allocation
- bulk_appointment → appointment_set
- bulk_appointment_appointment → appointment_set_appointment_series

This PR fully renames the database tables and columns matching the updated database diagram below. N.B. this PR also adds in several new columns intended to support MVP+ functionality. This has been done so that DPR and potentially the Analytical Platform can start the work to report on this new functionality and data.

![image](https://github.com/ministryofjustice/hmpps-activities-management-api/assets/9396346/a5336e06-29f0-4642-8c6a-071d7018e5ce)
