### PR TITLE
SAA-1194: Added status update timestamp

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/WaitingList.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/WaitingList.kt
@@ -56,6 +56,8 @@ data class WaitingList(
         declinedReason = null
       }
 
+      if (field != value) statusUpdatedTime = LocalDateTime.now()
+
       field = value
     }
 
@@ -75,6 +77,8 @@ data class WaitingList(
   var updatedTime: LocalDateTime? = null
 
   var updatedBy: String? = null
+
+  var statusUpdatedTime: LocalDateTime? = null
 
   @OneToOne
   @JoinColumn(name = "allocation_id", nullable = true)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/WaitingListApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/WaitingListApplication.kt
@@ -58,6 +58,13 @@ data class WaitingListApplication(
   val status: WaitingListStatus,
 
   @Schema(
+    description = "The date and time the waiting list status was last updated",
+    example = "2023-06-04T16:30:00",
+  )
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  val statusUpdatedTime: LocalDateTime? = null,
+
+  @Schema(
     description = "The past or present date on which the waiting list was requested",
     example = "2023-06-23",
   )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -507,4 +507,5 @@ fun EntityWaitingList.toModel() = ModelWaitingListApplication(
   creationTime = creationTime,
   updatedTime = updatedTime,
   updatedBy = updatedBy,
+  statusUpdatedTime = statusUpdatedTime,
 )

--- a/src/main/resources/migrations/common/V2023.09.15__add_waiting_list_status_updated_column.sql
+++ b/src/main/resources/migrations/common/V2023.09.15__add_waiting_list_status_updated_column.sql
@@ -1,0 +1,1 @@
+ALTER TABLE waiting_list ADD COLUMN status_updated_time timestamp;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
@@ -677,6 +677,7 @@ class WaitingListServiceTest {
     waitingList.status isEqualTo WaitingListStatus.PENDING
     waitingList.updatedTime isEqualTo null
     waitingList.updatedBy isEqualTo null
+    waitingList.statusUpdatedTime isEqualTo null
 
     service.updateWaitingList(
       waitingList.waitingListId,
@@ -693,6 +694,7 @@ class WaitingListServiceTest {
     waitingList.status isEqualTo WaitingListStatus.APPROVED
     waitingList.updatedTime!! isCloseTo TimeSource.now()
     waitingList.updatedBy isEqualTo "Frank"
+    waitingList.statusUpdatedTime isCloseTo TimeSource.now()
   }
 
   @Test
@@ -704,6 +706,7 @@ class WaitingListServiceTest {
     waitingList.status isEqualTo WaitingListStatus.PENDING
     waitingList.updatedTime isEqualTo null
     waitingList.updatedBy isEqualTo null
+    waitingList.statusUpdatedTime isEqualTo null
 
     service.updateWaitingList(
       waitingList.waitingListId,
@@ -720,6 +723,7 @@ class WaitingListServiceTest {
     waitingList.status isEqualTo WaitingListStatus.DECLINED
     waitingList.updatedTime!! isCloseTo TimeSource.now()
     waitingList.updatedBy isEqualTo "Frank"
+    waitingList.statusUpdatedTime isCloseTo TimeSource.now()
   }
 
   @Test
@@ -731,6 +735,7 @@ class WaitingListServiceTest {
     waitingList.status isEqualTo WaitingListStatus.PENDING
     waitingList.updatedTime isEqualTo null
     waitingList.updatedBy isEqualTo null
+    waitingList.statusUpdatedTime isEqualTo null
 
     service.updateWaitingList(
       waitingList.waitingListId,
@@ -741,6 +746,7 @@ class WaitingListServiceTest {
     waitingList.status isEqualTo WaitingListStatus.PENDING
     waitingList.updatedTime isEqualTo null
     waitingList.updatedBy isEqualTo null
+    waitingList.statusUpdatedTime isEqualTo null
   }
 
   @Test
@@ -763,6 +769,7 @@ class WaitingListServiceTest {
     waitingList.status isEqualTo WaitingListStatus.ALLOCATED
     waitingList.updatedTime isEqualTo null
     waitingList.updatedBy isEqualTo null
+    waitingList.statusUpdatedTime isEqualTo null
   }
 
   @Test
@@ -784,6 +791,37 @@ class WaitingListServiceTest {
     waitingList.status isEqualTo WaitingListStatus.REMOVED
     waitingList.updatedTime isEqualTo null
     waitingList.updatedBy isEqualTo null
+    waitingList.statusUpdatedTime isEqualTo null
+  }
+
+  @Test
+  fun`only status changes update "statusUpdatedTime"`() {
+    val waitingList = waitingList(
+      prisonCode = pentonvillePrisonCode,
+      initialStatus = WaitingListStatus.PENDING,
+    ).also {
+      whenever(waitingListRepository.findById(it.waitingListId)) doReturn Optional.of(it)
+    }
+
+    service.updateWaitingList(
+      waitingList.waitingListId,
+      WaitingListApplicationUpdateRequest(
+        applicationDate = LocalDate.now().minusDays(1),
+        comments = "test",
+        requestedBy = "test",
+      ),
+      "Frank",
+    )
+
+    waitingList.statusUpdatedTime isEqualTo null
+
+    service.updateWaitingList(
+      waitingList.waitingListId,
+      WaitingListApplicationUpdateRequest(status = WaitingListStatus.APPROVED),
+      "Frank",
+    )
+
+    waitingList.statusUpdatedTime isCloseTo TimeSource.now()
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -575,6 +575,7 @@ class TransformFunctionsTest {
       prisonerNumber isEqualTo "123456"
       bookingId isEqualTo 100L
       status isEqualTo WaitingListStatus.DECLINED
+      statusUpdatedTime isEqualTo null
       requestedDate isEqualTo TimeSource.today()
       requestedBy isEqualTo "Fred"
       comments isEqualTo "Some random test comments"


### PR DESCRIPTION
## Overview

Adds new field to `waiting_list` to record status updates independently of other changes.

### Screenshot

"Last changed" text should only update when the status itself has been updated:

<img width="1195" alt="Screenshot at Sep 18 12-35-00" src="https://github.com/ministryofjustice/hmpps-activities-management-api/assets/125488090/afa74461-744b-45c5-a49c-b32f80f21556">
