### PR TITLE
SAA-552: Movement list endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -273,6 +273,16 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .bodyToMono(typeReference<Location>())
 
+  suspend fun getLocationAsync(locationId: Long, includeInactive: Boolean = false): Location =
+    prisonApiWebClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/locations/{locationId}?includeInactive={includeInactive}")
+          .build(locationId, includeInactive)
+      }
+      .retrieve()
+      .awaitBody()
+
   internal fun <T> UriBuilder.maybeQueryParam(name: String, type: T?) =
     this.queryParamIfPresent(name, Optional.ofNullable(type))
 
@@ -363,5 +373,16 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
     return nonAssociationDetails?.nonAssociations?.filter {
       !excludeExpired || it.expiryDate == null || LocalDateTime.parse(it.expiryDate).isAfter(LocalDateTime.now())
     }
+  }
+
+  suspend fun getEventLocationsAsync(prisonCode: String): List<Location> {
+    return prisonApiWebClient.get()
+      .uri { uriBuilder: UriBuilder ->
+        uriBuilder
+          .path("/api/agencies/{prisonCode}/eventLocations")
+          .build(prisonCode)
+      }
+      .retrieve()
+      .awaitBody()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -277,8 +277,9 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
     prisonApiWebClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
-          .path("/api/locations/{locationId}?includeInactive={includeInactive}")
-          .build(locationId, includeInactive)
+          .path("/api/locations/{locationId}")
+          .queryParam("includeInactive", includeInactive)
+          .build(locationId)
       }
       .retrieve()
       .awaitBody()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/InternalLocationEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/InternalLocationEvents.kt
@@ -1,0 +1,48 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+  description =
+  """
+  The details of an internal location that has events scheduled to take place there. Supports movement lists.
+  Contains additional information about the events taking place at the location.
+  The system of record for internal locations is NOMIS and they are managed in that application.
+  """,
+)
+data class InternalLocationEvents(
+  @Schema(
+    description =
+    """
+    The id of the internal location. Mapped from AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID in NOMIS.
+    """,
+    example = "27723",
+  )
+  val id: Long,
+
+  @Schema(
+    description =
+    """
+    The prison code/agency id of the internal location. Mapped from AGENCY_LOCATIONS.AGY_LOC_ID in NOMIS.
+    """,
+    example = "SKI",
+  )
+  val prisonCode: String,
+
+  @Schema(
+    description = "The code of the internal location. Mapped from AGENCY_INTERNAL_LOCATIONS.DESCRIPTION",
+    example = "EDUC-ED1-ED1",
+  )
+  val code: String,
+
+  @Schema(
+    description = "The description of the internal location. Mapped from AGENCY_INTERNAL_LOCATIONS.USER_DESC",
+    example = "Education 1",
+  )
+  val description: String,
+
+  @Schema(
+    description = "Collection of scheduled events due to take place at the internal location",
+  )
+  var events: Set<ScheduledEvent>,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/InternalLocationEventsSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/InternalLocationEventsSummary.kt
@@ -1,0 +1,44 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+import io.swagger.v3.oas.annotations.media.Schema
+
+@Schema(
+  description =
+  """
+  The summary of an internal location that has events scheduled to take place there. Supports movement lists.
+  Will contain additional summary information about the events taking place at the location as well as the total
+  number of prisoners due to arrive at the location.
+  The system of record for internal locations is NOMIS and they are managed in that application.
+  """,
+)
+data class InternalLocationEventsSummary(
+  @Schema(
+    description =
+    """
+    The id of the internal location. Mapped from AGENCY_INTERNAL_LOCATIONS.INTERNAL_LOCATION_ID in NOMIS.
+    """,
+    example = "27723",
+  )
+  val id: Long,
+
+  @Schema(
+    description =
+    """
+    The prison code/agency id of the internal location. Mapped from AGENCY_LOCATIONS.AGY_LOC_ID in NOMIS.
+    """,
+    example = "SKI",
+  )
+  val prisonCode: String,
+
+  @Schema(
+    description = "The code of the internal location. Mapped from AGENCY_INTERNAL_LOCATIONS.DESCRIPTION",
+    example = "EDUC-ED1-ED1",
+  )
+  val code: String,
+
+  @Schema(
+    description = "The description of the internal location. Mapped from AGENCY_INTERNAL_LOCATIONS.USER_DESC",
+    example = "Education 1",
+  )
+  val description: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AppointmentInstanceRepository.kt
@@ -44,4 +44,20 @@ interface AppointmentInstanceRepository : ReadOnlyRepository<AppointmentInstance
     prisonCode: String,
     prisonerNumber: String,
   ): List<AppointmentInstance>
+
+  @Query(
+    value =
+    "FROM AppointmentInstance ai " +
+      "WHERE ai.prisonCode = :prisonCode" +
+      "  AND ai.internalLocationId IN :internalLocationIds" +
+      "  AND ai.appointmentDate = :date" +
+      "  AND ai.startTime BETWEEN :earliestStartTime AND :latestStartTime",
+  )
+  fun findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+    prisonCode: String,
+    internalLocationIds: Set<Long>,
+    date: LocalDate,
+    earliestStartTime: LocalTime,
+    latestStartTime: LocalTime,
+  ): List<AppointmentInstance>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/PrisonerScheduledActivityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/PrisonerScheduledActivityRepository.kt
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerScheduledActivity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.UniquePropertyId
 import java.time.LocalDate
+import java.time.LocalTime
 
 /**
  * This repository is READ-ONLY and uses the view V_PRISONER_SCHEDULED_ACTIVITIES.
@@ -43,5 +44,39 @@ interface PrisonerScheduledActivityRepository : JpaRepository<PrisonerScheduledA
     prisonCode: String,
     prisonerNumbers: Set<String>,
     date: LocalDate,
+  ): List<PrisonerScheduledActivity>
+
+  @Query(
+    """
+    SELECT sa FROM PrisonerScheduledActivity sa 
+    WHERE sa.prisonCode = :prisonCode
+    AND sa.sessionDate = :date
+    AND sa.startTime BETWEEN :earliestStartTime AND :latestStartTime
+    AND sa.cancelled = false
+    """,
+  )
+  fun findByPrisonCodeAndDateAndTime(
+    prisonCode: String,
+    date: LocalDate,
+    earliestStartTime: LocalTime,
+    latestStartTime: LocalTime,
+  ): List<PrisonerScheduledActivity>
+
+  @Query(
+    """
+    SELECT sa FROM PrisonerScheduledActivity sa 
+    WHERE sa.prisonCode = :prisonCode
+    AND sa.sessionDate = :date
+    AND sa.internalLocationId in :internalLocationIds
+    AND sa.startTime BETWEEN :earliestStartTime AND :latestStartTime
+    AND sa.cancelled = false
+    """,
+  )
+  fun findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+    prisonCode: String,
+    internalLocationIds: Set<Int>,
+    date: LocalDate,
+    earliestStartTime: LocalTime,
+    latestStartTime: LocalTime,
   ): List<PrisonerScheduledActivity>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationController.kt
@@ -1,11 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
 import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.responses.ApiResponses
+import org.springframework.format.annotation.DateTimeFormat
 import org.springframework.http.MediaType
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
@@ -16,16 +18,21 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.LocationGroup
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEventsSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.whereabouts.LocationPrefixDto
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.InternalLocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.LocationGroupServiceSelector
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.LocationService
+import java.time.LocalDate
 
 @RestController
 @RequestMapping("/locations")
 class LocationController(
   private val locationService: LocationService,
   private val locationGroupServiceSelector: LocationGroupServiceSelector,
+  private val internalLocationService: InternalLocationService,
 ) {
   @GetMapping(
     value = ["/prison/{prisonCode}"],
@@ -167,4 +174,79 @@ class LocationController(
     @PathVariable("prisonCode") prisonCode: String,
     @RequestParam(value = "groupName", required = true) groupName: String,
   ): LocationPrefixDto? = locationService.getLocationPrefixFromGroup(prisonCode, groupName)
+
+  @GetMapping(
+    value = ["/prison/{prisonCode}/events-summaries"],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @ResponseBody
+  @Operation(
+    summary = """
+      Get a list of internal locations that have events scheduled to take place on the specified date and optional time slot.
+      """,
+    description = """
+      Returns internal locations that have events scheduled to take place on the specified date and optional time slot.
+      Will contain summary information about the events taking place at the location as well as the total number of
+      prisoners due to arrive at the location. This endpoint supports the creation of movement lists allowing
+      users to select from a sublist of only the internal locations that have events scheduled there.
+    """,
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Successful call - zero or more internal locations with scheduled events found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = InternalLocationEventsSummary::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Requested resource not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN')")
+  suspend fun getInternalLocationEventsSummary(
+    @PathVariable("prisonCode")
+    @Parameter(description = "The 3-digit prison code.")
+    prisonCode: String,
+
+    @RequestParam(value = "date", required = true)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    @Parameter(description = "Date of scheduled events (required). Format YYYY-MM-DD. Up to 60 days in the future")
+    date: LocalDate,
+
+    @RequestParam(value = "timeSlot", required = false)
+    @Parameter(description = "Time slot for the scheduled events (optional). If supplied, one of AM, PM or ED.")
+    timeSlot: TimeSlot?,
+  ): Set<InternalLocationEventsSummary> {
+    require(date.isBefore(LocalDate.now().plusDays(61))) {
+      "Supply a date up to 60 days in the future"
+    }
+    return internalLocationService.getInternalLocationEventsSummaries(
+      prisonCode,
+      date,
+      timeSlot,
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationController.kt
@@ -226,7 +226,7 @@ class LocationController(
     ],
   )
   @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN')")
-  suspend fun getInternalLocationEventsSummary(
+  fun getInternalLocationEventsSummary(
     @PathVariable("prisonCode")
     @Parameter(description = "The 3-digit prison code.")
     prisonCode: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
@@ -272,10 +272,15 @@ class ScheduledEventController(
     @RequestBody(required = true)
     @Parameter(description = "Set of internal location ids (required). Example [123, 456].", required = true)
     internalLocationIds: Set<Long>,
-  ) = internalLocationService.getInternalLocationEvents(
-    prisonCode,
-    internalLocationIds,
-    date,
-    timeSlot,
-  )
+  ): Set<InternalLocationEvents> {
+    require(date.isBefore(LocalDate.now().plusDays(61))) {
+      "Supply a date up to 60 days in the future"
+    }
+    return internalLocationService.getInternalLocationEvents(
+      prisonCode,
+      internalLocationIds,
+      date,
+      timeSlot,
+    )
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonerScheduledEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.LocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ReferenceCodeDomain
@@ -201,4 +203,77 @@ class ScheduledEventController(
       locationService.getLocationsForAppointmentsMap(prisonCode),
     )
   }
+
+  @PostMapping(
+    value = ["/prison/{prisonCode}/locations"],
+    consumes = [MediaType.APPLICATION_JSON_VALUE],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @ResponseBody
+  @Operation(
+    summary = "Get a list of scheduled events for a prison and list of internal location ids numbers for a date and optional time slot",
+    description = """
+      Returns scheduled events for the prison, internal location ids, single date and an optional time slot.
+      This endpoint only returns activities and appointments and these come from the local database.
+      This endpoint supports the creation of movement lists.
+    """,
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Successful call - zero or more scheduled events found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = InternalLocationEvents::class)),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Requested resource not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN')")
+  fun getScheduledEventsForMultipleLocations(
+    @PathVariable("prisonCode")
+    @Parameter(description = "The 3-character prison code.")
+    prisonCode: String,
+
+    @RequestParam(value = "date", required = true)
+    @Parameter(description = "The exact date to return events for (required) in format YYYY-MM-DD")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    date: LocalDate,
+
+    @RequestParam(value = "timeSlot", required = false)
+    @Parameter(description = "Time slot of the events (optional). If supplied, one of AM, PM or ED.")
+    timeSlot: TimeSlot?,
+
+    @RequestBody(required = true)
+    @Parameter(description = "Set of internal location ids (required). Example [123, 456].", required = true)
+    internalLocationIds: Set<Long>,
+  ) = scheduledEventService.getInternalLocationEvents(
+    prisonCode,
+    internalLocationIds,
+    date,
+    timeSlot,
+  )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonerScheduledEvents
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.InternalLocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.LocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ReferenceCodeDomain
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ReferenceCodeService
@@ -36,6 +37,7 @@ class ScheduledEventController(
   private val scheduledEventService: ScheduledEventService,
   private val referenceCodeService: ReferenceCodeService,
   private val locationService: LocationService,
+  private val internalLocationService: InternalLocationService,
 ) {
 
   @GetMapping(
@@ -270,7 +272,7 @@ class ScheduledEventController(
     @RequestBody(required = true)
     @Parameter(description = "Set of internal location ids (required). Example [123, 456].", required = true)
     internalLocationIds: Set<Long>,
-  ) = scheduledEventService.getInternalLocationEvents(
+  ) = internalLocationService.getInternalLocationEvents(
     prisonCode,
     internalLocationIds,
     date,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
@@ -1,18 +1,23 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
+import kotlinx.coroutines.runBlocking
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalTimeRange
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentSearch
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleInstance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerScheduledActivity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEventsSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentAttendeeSearchRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSearchRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSearchSpecification
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonerScheduledActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.checkCaseloadAccess
 import java.time.LocalDate
+import java.time.LocalTime
 
 @Service
 class InternalLocationService(
@@ -20,57 +25,64 @@ class InternalLocationService(
   private val appointmentAttendeeSearchRepository: AppointmentAttendeeSearchRepository,
   private val appointmentSearchSpecification: AppointmentSearchSpecification,
   private val prisonApiClient: PrisonApiClient,
+  private val prisonerScheduledActivityRepository: PrisonerScheduledActivityRepository,
   private val prisonRegimeService: PrisonRegimeService,
-  private val scheduledInstanceService: ScheduledInstanceService,
 ) {
-  suspend fun getInternalLocationEventsSummaries(prisonCode: String, date: LocalDate, timeSlot: TimeSlot?): Set<InternalLocationEventsSummary> {
-    checkCaseloadAccess(prisonCode)
-
-    val locationActivitiesMap = getLocationActivitiesMap(prisonCode, date, timeSlot)
-    val locationAppointmentsMap = getLocationAppointmentsMap(prisonCode, date, timeSlot)
-
-    val internalLocationIds = locationActivitiesMap.keys.union(locationAppointmentsMap.keys).toSet()
-
-    val internalLocationsMap = getInternalLocationsMapById(prisonCode, internalLocationIds)
-
-    return internalLocationsMap.map {
-      InternalLocationEventsSummary(it.key, prisonCode, it.value.description, it.value.userDescription ?: it.value.description)
-    }.toSet()
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  suspend fun getInternalLocationsMapById(prisonCode: String, internalLocationIds: Set<Long>): Map<Long, Location> {
+  fun getInternalLocationEventsSummaries(prisonCode: String, date: LocalDate, timeSlot: TimeSlot?) =
+    runBlocking {
+      checkCaseloadAccess(prisonCode)
+
+      val timeRange =
+        timeSlot?.let { prisonRegimeService.getTimeRangeForPrisonAndTimeSlot(prisonCode, it) } ?: LocalTimeRange(
+          LocalTime.of(0, 0),
+          LocalTime.of(23, 59),
+        )
+
+      val locationActivitiesMap = getLocationActivitiesMap(prisonCode, date, timeRange)
+      val locationAppointmentsMap = getLocationAppointmentsMap(prisonCode, date, timeRange)
+
+      val internalLocationIds = locationActivitiesMap.keys.union(locationAppointmentsMap.keys).toSet()
+
+      val internalLocationsMap = getInternalLocationsMapByIds(prisonCode, internalLocationIds)
+
+      internalLocationsMap.map {
+        InternalLocationEventsSummary(it.key, it.value.agencyId, it.value.description, it.value.userDescription ?: it.value.description)
+      }.toSet()
+    }
+
+  suspend fun getInternalLocationsMapByIds(prisonCode: String, internalLocationIds: Set<Long>): Map<Long, Location> {
     val internalLocationsMap = prisonApiClient.getEventLocationsAsync(prisonCode)
       .filter { internalLocationIds.contains(it.locationId) }
       .associateBy { it.locationId }
       .toMutableMap()
 
-    // Get any missing location ids via prisonApiClient. They will be inactive
+    // Try to get any missing location ids via prisonApiClient. If found, they will be inactive
     internalLocationIds.filterNot { internalLocationsMap.containsKey(it) }.forEach {
-      val location = prisonApiClient.getLocationAsync(it, true)
-      internalLocationsMap[location.locationId] = location
+      log.info("Retrieving inactive internal location with id $it")
+      runCatching {
+        val location = prisonApiClient.getLocationAsync(it, true)
+        internalLocationsMap[location.locationId] = location
+      }.onFailure { t ->
+        log.warn("Failed to retrieve inactive internal location with id $it", t)
+      }
     }
 
     return internalLocationsMap
   }
 
-  private fun getLocationActivitiesMap(prisonCode: String, date: LocalDate, timeSlot: TimeSlot?): Map<Long, ActivityScheduleInstance> =
-    scheduledInstanceService.getActivityScheduleInstancesByDateRange(prisonCode, LocalDateRange(date, date), timeSlot)
-      .filterNot { it.activitySchedule.internalLocation?.id == null }
-      .associateBy { it.activitySchedule.internalLocation!!.id.toLong() }
+  private fun getLocationActivitiesMap(prisonCode: String, date: LocalDate, timeRange: LocalTimeRange): Map<Long, PrisonerScheduledActivity> =
+    prisonerScheduledActivityRepository.findByPrisonCodeAndDateAndTime(prisonCode, date, timeRange.start, timeRange.end)
+      .filterNot { it.internalLocationId == null }
+      .associateBy { it.internalLocationId!!.toLong() }
 
-  private fun getLocationAppointmentsMap(prisonCode: String, date: LocalDate, timeSlot: TimeSlot?): Map<Long, AppointmentSearch> {
-    var appointmentsSpec = appointmentSearchSpecification.prisonCodeEquals(prisonCode)
+  private fun getLocationAppointmentsMap(prisonCode: String, date: LocalDate, timeRange: LocalTimeRange): Map<Long, AppointmentSearch> {
+    val appointmentsSpec = appointmentSearchSpecification.prisonCodeEquals(prisonCode)
       .and(appointmentSearchSpecification.startDateEquals(date))
-
-    timeSlot?.apply {
-      val timeRange = timeSlot.let { prisonRegimeService.getTimeRangeForPrisonAndTimeSlot(prisonCode, it) }
-      appointmentsSpec = appointmentsSpec.and(
-        appointmentSearchSpecification.startTimeBetween(
-          timeRange.start,
-          timeRange.end.minusMinutes(1),
-        ),
-      )
-    }
+      .and(appointmentSearchSpecification.startTimeBetween(timeRange.start, timeRange.end))
 
     val appointments = appointmentSearchRepository.findAll(appointmentsSpec)
     val attendeeMap = appointmentAttendeeSearchRepository.findByAppointmentIds(appointments.map { it.appointmentId })

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
@@ -10,26 +12,52 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalTim
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentSearch
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerScheduledActivity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEventsSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentAttendeeSearchRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentInstanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSearchRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSearchSpecification
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonerScheduledActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.checkCaseloadAccess
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transformAppointmentInstanceToScheduledEvents
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transformPrisonerScheduledActivityToScheduledEvents
 import java.time.LocalDate
 import java.time.LocalTime
 
 @Service
 class InternalLocationService(
-  private val appointmentSearchRepository: AppointmentSearchRepository,
   private val appointmentAttendeeSearchRepository: AppointmentAttendeeSearchRepository,
+  private val appointmentInstanceRepository: AppointmentInstanceRepository,
+  private val appointmentSearchRepository: AppointmentSearchRepository,
   private val appointmentSearchSpecification: AppointmentSearchSpecification,
   private val prisonApiClient: PrisonApiClient,
   private val prisonerScheduledActivityRepository: PrisonerScheduledActivityRepository,
   private val prisonRegimeService: PrisonRegimeService,
+  private val referenceCodeService: ReferenceCodeService,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  suspend fun getInternalLocationsMapByIds(prisonCode: String, internalLocationIds: Set<Long>): Map<Long, Location> {
+    val internalLocationsMap = prisonApiClient.getEventLocationsAsync(prisonCode)
+      .filter { internalLocationIds.contains(it.locationId) }
+      .associateBy { it.locationId }
+      .toMutableMap()
+
+    // Try to get any missing location ids via prisonApiClient. If found, they will be inactive
+    internalLocationIds.filterNot { internalLocationsMap.containsKey(it) }.forEach {
+      log.info("Retrieving inactive internal location with id $it")
+      runCatching {
+        val location = prisonApiClient.getLocationAsync(it, true)
+        internalLocationsMap[location.locationId] = location
+      }.onFailure { t ->
+        log.warn("Failed to retrieve inactive internal location with id $it", t)
+      }
+    }
+
+    return internalLocationsMap
   }
 
   fun getInternalLocationEventsSummaries(prisonCode: String, date: LocalDate, timeSlot: TimeSlot?) =
@@ -54,26 +82,6 @@ class InternalLocationService(
       }.toSet()
     }
 
-  suspend fun getInternalLocationsMapByIds(prisonCode: String, internalLocationIds: Set<Long>): Map<Long, Location> {
-    val internalLocationsMap = prisonApiClient.getEventLocationsAsync(prisonCode)
-      .filter { internalLocationIds.contains(it.locationId) }
-      .associateBy { it.locationId }
-      .toMutableMap()
-
-    // Try to get any missing location ids via prisonApiClient. If found, they will be inactive
-    internalLocationIds.filterNot { internalLocationsMap.containsKey(it) }.forEach {
-      log.info("Retrieving inactive internal location with id $it")
-      runCatching {
-        val location = prisonApiClient.getLocationAsync(it, true)
-        internalLocationsMap[location.locationId] = location
-      }.onFailure { t ->
-        log.warn("Failed to retrieve inactive internal location with id $it", t)
-      }
-    }
-
-    return internalLocationsMap
-  }
-
   private fun getLocationActivitiesMap(prisonCode: String, date: LocalDate, timeRange: LocalTimeRange): Map<Long, PrisonerScheduledActivity> =
     prisonerScheduledActivityRepository.findByPrisonCodeAndDateAndTime(prisonCode, date, timeRange.start, timeRange.end)
       .filterNot { it.internalLocationId == null }
@@ -91,4 +99,64 @@ class InternalLocationService(
 
     return appointments.filterNot { it.internalLocationId == null }.associateBy { it.internalLocationId!! }
   }
+
+  fun getInternalLocationEvents(prisonCode: String, internalLocationIds: Set<Long>, date: LocalDate, timeSlot: TimeSlot?) =
+    runBlocking {
+      checkCaseloadAccess(prisonCode)
+
+      val referenceCodesForAppointmentsMap =
+        referenceCodeService.getReferenceCodesMap(ReferenceCodeDomain.APPOINTMENT_CATEGORY)
+      val internalLocationsMap = getInternalLocationsMapByIds(prisonCode, internalLocationIds)
+      val eventPriorities = withContext(Dispatchers.IO) {
+        prisonRegimeService.getEventPrioritiesForPrison(prisonCode)
+      }
+
+      val timeRange =
+        timeSlot?.let { prisonRegimeService.getTimeRangeForPrisonAndTimeSlot(prisonCode, it) } ?: LocalTimeRange(
+          LocalTime.of(0, 0),
+          LocalTime.of(23, 59),
+        )
+
+      val activities = withContext(Dispatchers.IO) {
+        prisonerScheduledActivityRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+          prisonCode,
+          internalLocationIds.map { it.toInt() }.toSet(),
+          date,
+          timeRange.start,
+          timeRange.end,
+        )
+      }
+
+      val appointments = appointmentInstanceRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+        prisonCode,
+        internalLocationIds,
+        date,
+        timeRange.start,
+        timeRange.end,
+      )
+
+      val scheduledEventsMap = transformPrisonerScheduledActivityToScheduledEvents(
+        prisonCode,
+        eventPriorities,
+        activities,
+      ).union(
+        transformAppointmentInstanceToScheduledEvents(
+          prisonCode,
+          eventPriorities,
+          referenceCodesForAppointmentsMap,
+          internalLocationsMap,
+          appointments,
+        ),
+      ).filterNot { it.internalLocationId == null }.groupBy { it.internalLocationId!! }
+
+      internalLocationsMap.map {
+        InternalLocationEvents(
+          it.key,
+          it.value.agencyId,
+          it.value.description,
+          it.value.userDescription ?: it.value.description,
+          scheduledEventsMap[it.key]?.toSet() ?: emptySet(),
+        )
+      }.toSet()
+    }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
@@ -1,0 +1,82 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentSearch
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleInstance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEventsSummary
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentAttendeeSearchRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSearchRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSearchSpecification
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.checkCaseloadAccess
+import java.time.LocalDate
+
+@Service
+class InternalLocationService(
+  private val appointmentSearchRepository: AppointmentSearchRepository,
+  private val appointmentAttendeeSearchRepository: AppointmentAttendeeSearchRepository,
+  private val appointmentSearchSpecification: AppointmentSearchSpecification,
+  private val prisonApiClient: PrisonApiClient,
+  private val prisonRegimeService: PrisonRegimeService,
+  private val scheduledInstanceService: ScheduledInstanceService,
+) {
+  suspend fun getInternalLocationEventsSummaries(prisonCode: String, date: LocalDate, timeSlot: TimeSlot?): Set<InternalLocationEventsSummary> {
+    checkCaseloadAccess(prisonCode)
+
+    val locationActivitiesMap = getLocationActivitiesMap(prisonCode, date, timeSlot)
+    val locationAppointmentsMap = getLocationAppointmentsMap(prisonCode, date, timeSlot)
+
+    val internalLocationIds = locationActivitiesMap.keys.union(locationAppointmentsMap.keys).toSet()
+
+    val internalLocationsMap = getInternalLocationsMapById(prisonCode, internalLocationIds)
+
+    return internalLocationsMap.map {
+      InternalLocationEventsSummary(it.key, prisonCode, it.value.description, it.value.userDescription ?: it.value.description)
+    }.toSet()
+  }
+
+  suspend fun getInternalLocationsMapById(prisonCode: String, internalLocationIds: Set<Long>): Map<Long, Location> {
+    val internalLocationsMap = prisonApiClient.getEventLocationsAsync(prisonCode)
+      .filter { internalLocationIds.contains(it.locationId) }
+      .associateBy { it.locationId }
+      .toMutableMap()
+
+    // Get any missing location ids via prisonApiClient. They will be inactive
+    internalLocationIds.filterNot { internalLocationsMap.containsKey(it) }.forEach {
+      val location = prisonApiClient.getLocationAsync(it, true)
+      internalLocationsMap[location.locationId] = location
+    }
+
+    return internalLocationsMap
+  }
+
+  private fun getLocationActivitiesMap(prisonCode: String, date: LocalDate, timeSlot: TimeSlot?): Map<Long, ActivityScheduleInstance> =
+    scheduledInstanceService.getActivityScheduleInstancesByDateRange(prisonCode, LocalDateRange(date, date), timeSlot)
+      .filterNot { it.activitySchedule.internalLocation?.id == null }
+      .associateBy { it.activitySchedule.internalLocation!!.id.toLong() }
+
+  private fun getLocationAppointmentsMap(prisonCode: String, date: LocalDate, timeSlot: TimeSlot?): Map<Long, AppointmentSearch> {
+    var appointmentsSpec = appointmentSearchSpecification.prisonCodeEquals(prisonCode)
+      .and(appointmentSearchSpecification.startDateEquals(date))
+
+    timeSlot?.apply {
+      val timeRange = timeSlot.let { prisonRegimeService.getTimeRangeForPrisonAndTimeSlot(prisonCode, it) }
+      appointmentsSpec = appointmentsSpec.and(
+        appointmentSearchSpecification.startTimeBetween(
+          timeRange.start,
+          timeRange.end.minusMinutes(1),
+        ),
+      )
+    }
+
+    val appointments = appointmentSearchRepository.findAll(appointmentsSpec)
+    val attendeeMap = appointmentAttendeeSearchRepository.findByAppointmentIds(appointments.map { it.appointmentId })
+      .groupBy { it.appointmentSearch.appointmentId }
+    appointments.forEach { it.attendees = attendeeMap[it.appointmentId] ?: emptyList() }
+
+    return appointments.filterNot { it.internalLocationId == null }.associateBy { it.internalLocationId!! }
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
@@ -15,19 +15,16 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalTimeRange
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.rangeTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerScheduledActivity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.RolloutPrison
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonerScheduledEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentInstanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonerScheduledActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.checkCaseloadAccess
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.multiplePrisonerActivitiesToScheduledEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.multiplePrisonerAppointmentsToScheduledEvents
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.multiplePrisonerCourtEventsToScheduledEvents
@@ -54,8 +51,6 @@ class ScheduledEventService(
   private val prisonerScheduledActivityRepository: PrisonerScheduledActivityRepository,
   private val appointmentInstanceRepository: AppointmentInstanceRepository,
   private val prisonRegimeService: PrisonRegimeService,
-  private val internalLocationService: InternalLocationService,
-  private val referenceCodeService: ReferenceCodeService,
 ) {
   /**
    *  Get scheduled events for a single prisoner, between two dates and with an optional time slot.
@@ -461,64 +456,4 @@ class ScheduledEventService(
       latestStartTime,
     )
   }
-
-  fun getInternalLocationEvents(prisonCode: String, internalLocationIds: Set<Long>, date: LocalDate, timeSlot: TimeSlot?) =
-    runBlocking {
-      checkCaseloadAccess(prisonCode)
-
-      val referenceCodesForAppointmentsMap =
-        referenceCodeService.getReferenceCodesMap(ReferenceCodeDomain.APPOINTMENT_CATEGORY)
-      val internalLocationsMap = internalLocationService.getInternalLocationsMapByIds(prisonCode, internalLocationIds)
-      val eventPriorities = withContext(Dispatchers.IO) {
-        prisonRegimeService.getEventPrioritiesForPrison(prisonCode)
-      }
-
-      val timeRange =
-        timeSlot?.let { prisonRegimeService.getTimeRangeForPrisonAndTimeSlot(prisonCode, it) } ?: LocalTimeRange(
-          LocalTime.of(0, 0),
-          LocalTime.of(23, 59),
-        )
-
-      val activities = withContext(Dispatchers.IO) {
-        prisonerScheduledActivityRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
-          prisonCode,
-          internalLocationIds.map { it.toInt() }.toSet(),
-          date,
-          timeRange.start,
-          timeRange.end,
-        )
-      }
-
-      val appointments = appointmentInstanceRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
-        prisonCode,
-        internalLocationIds,
-        date,
-        timeRange.start,
-        timeRange.end,
-      )
-
-      val scheduledEventsMap = transformPrisonerScheduledActivityToScheduledEvents(
-        prisonCode,
-        eventPriorities,
-        activities,
-      ).union(
-        transformAppointmentInstanceToScheduledEvents(
-          prisonCode,
-          eventPriorities,
-          referenceCodesForAppointmentsMap,
-          internalLocationsMap,
-          appointments,
-        ),
-      ).filterNot { it.internalLocationId == null }.groupBy { it.internalLocationId!! }
-
-      internalLocationsMap.map {
-        InternalLocationEvents(
-          it.key,
-          it.value.agencyId,
-          it.value.description,
-          it.value.userDescription ?: it.value.description,
-          scheduledEventsMap[it.key]?.toSet() ?: emptySet(),
-        )
-      }.toSet()
-    }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
@@ -555,7 +555,7 @@ class PrisonApiClientTest {
   @Test
   fun `getEventLocationsAsync - success`() {
     val prisonCode = "MDI"
-    val eventLocations = setOf(internalLocation(), appointmentLocation(2, prisonCode))
+    val eventLocations = listOf(internalLocation(), appointmentLocation(2, prisonCode))
     prisonApiMockServer.stubGetEventLocations(prisonCode, eventLocations)
     runBlocking {
       prisonApiClient.getEventLocationsAsync(prisonCode) isEqualTo eventLocations

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
@@ -19,6 +19,9 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDat
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.rangeTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCategoryReferenceCode
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.internalLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.wiremock.PrisonApiMockServer
 import java.time.LocalDate
@@ -370,6 +373,24 @@ class PrisonApiClientTest {
   }
 
   @Test
+  fun `getLocationAsync do not include inactive - success`() {
+    val internalLocation = internalLocation()
+    prisonApiMockServer.stubGetLocation(internalLocation.locationId, internalLocation, false)
+    runBlocking {
+      prisonApiClient.getLocationAsync(internalLocation.locationId) isEqualTo internalLocation
+    }
+  }
+
+  @Test
+  fun `getLocationAsync include inactive - success`() {
+    val internalLocation = internalLocation()
+    prisonApiMockServer.stubGetLocation(internalLocation.locationId, internalLocation, true)
+    runBlocking {
+      prisonApiClient.getLocationAsync(internalLocation.locationId, true) isEqualTo internalLocation
+    }
+  }
+
+  @Test
   fun `getStudyArea - success`() {
     prisonApiMockServer.stubGetReferenceCode("STUDY_AREA", "ENGLA", "prisonapi/study-area-code-ENGLA.json")
 
@@ -529,5 +550,15 @@ class PrisonApiClientTest {
     val function = PrisonApiClient::class.declaredFunctions.first { it.name == "getOffenderNonAssociations" }
 
     assertThat(function.returnType).isEqualTo(typeOf<List<OffenderNonAssociationDetail>?>())
+  }
+
+  @Test
+  fun `getEventLocationsAsync - success`() {
+    val prisonCode = "MDI"
+    val eventLocations = setOf(internalLocation(), appointmentLocation(2, prisonCode))
+    prisonApiMockServer.stubGetEventLocations(prisonCode, eventLocations)
+    runBlocking {
+      prisonApiClient.getEventLocationsAsync(prisonCode) isEqualTo eventLocations
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
@@ -155,9 +155,6 @@ class AppointmentTest {
   @Test
   fun `entity to summary mapping`() {
     val entity = appointmentSeriesEntity().appointments().first()
-    val referenceCodeMap = mapOf(entity.categoryCode to appointmentCategoryReferenceCode(entity.categoryCode))
-    val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
-    val userMap = mapOf(entity.updatedBy!! to userDetail(1, "UPDATE.USER", "UPDATE", "USER"))
     assertThat(entity.toSummary()).isEqualTo(
       AppointmentSummary(
         entity.appointmentId,
@@ -174,9 +171,6 @@ class AppointmentTest {
   @Test
   fun `entity list to summary list mapping`() {
     val entity = appointmentSeriesEntity().appointments().first()
-    val referenceCodeMap = mapOf(entity.categoryCode to appointmentCategoryReferenceCode(entity.categoryCode))
-    val locationMap = mapOf(entity.internalLocationId!! to appointmentLocation(entity.internalLocationId!!, "TPR"))
-    val userMap = mapOf(entity.updatedBy!! to userDetail(1, "UPDATE.USER", "UPDATE", "USER"))
     assertThat(listOf(entity).toSummary()).isEqualTo(
       listOf(
         AppointmentSummary(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Attendan
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EligibilityRule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonRegime
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerScheduledActivity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.RolloutPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingList
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingListStatus
@@ -409,3 +410,47 @@ fun waitingList(
     this.allocation = allocation
   }
 }
+
+internal fun activityFromDbInstance(
+  scheduledInstanceId: Long = 1,
+  allocationId: Long = 1,
+  prisonCode: String = "MDI",
+  sessionDate: LocalDate = LocalDate.of(2022, 12, 14),
+  startTime: LocalTime? = LocalTime.of(10, 0),
+  endTime: LocalTime? = LocalTime.of(11, 30),
+  prisonerNumber: String = "G4793VF",
+  bookingId: Int = 900001,
+  inCell: Boolean = false,
+  onWing: Boolean = false,
+  offWing: Boolean = false,
+  internalLocationId: Int? = 1,
+  internalLocationCode: String? = "MDI-EDU_ROOM1",
+  internalLocationDescription: String? = "Education room 1",
+  scheduleDescription: String? = "HB1 AM",
+  activityId: Int = 1,
+  activityCategory: String = "Education",
+  activitySummary: String? = "English level 1",
+  cancelled: Boolean = false,
+  suspended: Boolean = false,
+) = PrisonerScheduledActivity(
+  scheduledInstanceId = scheduledInstanceId,
+  allocationId = allocationId,
+  prisonCode = prisonCode,
+  sessionDate = sessionDate,
+  startTime = startTime,
+  endTime = endTime,
+  prisonerNumber = prisonerNumber,
+  bookingId = bookingId,
+  inCell = inCell,
+  onWing = onWing,
+  offWing = offWing,
+  internalLocationId = internalLocationId,
+  internalLocationCode = internalLocationCode,
+  internalLocationDescription = internalLocationDescription,
+  scheduleDescription = scheduleDescription,
+  activityId = activityId,
+  activityCategory = activityCategory,
+  activitySummary = activitySummary,
+  cancelled = cancelled,
+  suspended = suspended,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
@@ -107,6 +107,7 @@ private fun appointmentAttendeeEntity(appointment: Appointment, appointmentAtten
   )
 
 internal fun appointmentInstanceEntity(
+  appointmentInstanceId: Long = 3,
   prisonerNumber: String = "A1234BC",
   bookingId: Long = 456,
   internalLocationId: Long = 123,
@@ -118,10 +119,10 @@ internal fun appointmentInstanceEntity(
   categoryCode: String = "TEST",
 ) =
   AppointmentInstance(
-    appointmentInstanceId = 3,
+    appointmentInstanceId = appointmentInstanceId,
     appointmentSeriesId = 1,
     appointmentId = 2,
-    appointmentAttendeeId = 3,
+    appointmentAttendeeId = appointmentInstanceId,
     appointmentType = AppointmentType.INDIVIDUAL,
     prisonCode = "TPR",
     prisonerNumber = prisonerNumber,
@@ -146,18 +147,21 @@ internal fun appointmentInstanceEntity(
   )
 
 internal fun appointmentSearchEntity(
+  prisonCode: String = "TPR",
   prisonerNumber: String = "A1234BC",
   bookingId: Long = 456,
   internalLocationId: Long = 123,
   inCell: Boolean = false,
   startDate: LocalDate = LocalDate.now(),
+  startTime: LocalTime = LocalTime.of(9, 0),
+  endTime: LocalTime = LocalTime.of(10, 30),
   createdBy: String = "CREATE.USER",
 ) =
   AppointmentSearch(
     appointmentSeriesId = 1,
     appointmentId = 2,
     appointmentType = AppointmentType.INDIVIDUAL,
-    prisonCode = "TPR",
+    prisonCode = prisonCode,
     categoryCode = "TEST",
     customName = null,
     internalLocationId = if (inCell) null else internalLocationId,
@@ -166,8 +170,8 @@ internal fun appointmentSearchEntity(
     onWing = false,
     offWing = true,
     startDate = startDate.plusDays(1),
-    startTime = LocalTime.of(9, 0),
-    endTime = LocalTime.of(10, 30),
+    startTime = startTime,
+    endTime = endTime,
     isRepeat = false,
     sequenceNumber = 1,
     maxSequenceNumber = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/LocationFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/LocationFactory.kt
@@ -1,6 +1,10 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers
 
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEvents
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEventsSummary
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerScheduledEventsFixture.activityInstance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerScheduledEventsFixture.appointmentInstance
 
 fun locations(
   agencyId: String = "PBI",
@@ -16,4 +20,29 @@ fun locations(
     locationType = locationType,
     userDescription = userDescription,
   ),
+)
+
+fun internalLocationEventsSummary(
+  id: Long = 1L,
+  prisonCode: String = "MDI",
+  code: String = "EDUC-ED1-ED1",
+  description: String = "Education 1",
+) = InternalLocationEventsSummary(
+  id,
+  prisonCode,
+  code,
+  description,
+)
+
+fun internalLocationEvents(
+  id: Long = 1L,
+  prisonCode: String = "MDI",
+  code: String = "EDUC-ED1-ED1",
+  description: String = "Education 1",
+) = InternalLocationEvents(
+  id,
+  prisonCode,
+  code,
+  description,
+  setOf(activityInstance(), appointmentInstance()),
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
@@ -35,6 +35,24 @@ fun userCaseLoads(prisonCode: String) =
     ),
   )
 
+fun internalLocation(
+  locationId: Long = 1L,
+  locationType: String = "AREA",
+  description: String = "EDUC-ED1-ED1",
+  prisonCode: String = "MDI",
+  locationUsage: String = "PROG",
+  userDescription: String = "Education 1",
+) =
+  Location(
+    locationId = locationId,
+    locationType = locationType,
+    description = description,
+    agencyId = prisonCode,
+    locationUsage = locationUsage,
+    locationPrefix = "$prisonCode-$description",
+    userDescription = userDescription,
+  )
+
 fun appointmentLocation(locationId: Long, prisonCode: String, description: String = "Test Appointment Location", userDescription: String = "Test Appointment Location User Description") =
   Location(
     locationId = locationId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
@@ -41,7 +41,7 @@ fun internalLocation(
   description: String = "EDUC-ED1-ED1",
   prisonCode: String = "MDI",
   locationUsage: String = "PROG",
-  userDescription: String = "Education 1",
+  userDescription: String? = "Education 1",
 ) =
   Location(
     locationId = locationId,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.rangeTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.internalLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEvents
@@ -587,7 +588,6 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
           with(events) {
             size isEqualTo 1
             with(this.single { it.scheduledInstanceId == 1L }) {
-              assertThat(this).isNotNull()
               eventType isEqualTo "ACTIVITY"
             }
           }
@@ -599,7 +599,6 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
           with(events) {
             size isEqualTo 1
             with(this.single { it.scheduledInstanceId == 6L }) {
-              assertThat(this).isNotNull()
               eventType isEqualTo "ACTIVITY"
             }
           }
@@ -611,7 +610,6 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
           with(events) {
             size isEqualTo 1
             with(this.single { it.appointmentAttendeeId == 5L }) {
-              assertThat(this).isNotNull()
               appointmentAttendeeId isEqualTo 5L
               eventType isEqualTo "APPOINTMENT"
             }
@@ -639,9 +637,7 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
           prisonCode isEqualTo prisonCode
           code isEqualTo activityLocation1.description
           description isEqualTo activityLocation1.userDescription
-          with(events) {
-            size isEqualTo 0
-          }
+          events hasSize 0
         }
         with(this.single { it.id == activityLocation2.locationId }) {
           prisonCode isEqualTo prisonCode
@@ -650,7 +646,6 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
           with(events) {
             size isEqualTo 1
             with(this.single { it.scheduledInstanceId == 6L }) {
-              assertThat(this).isNotNull()
               eventType isEqualTo "ACTIVITY"
             }
           }
@@ -659,9 +654,7 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
           prisonCode isEqualTo prisonCode
           code isEqualTo appointmentLocation1.description
           description isEqualTo appointmentLocation1.userDescription
-          with(events) {
-            size isEqualTo 0
-          }
+          events hasSize 0
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -464,7 +464,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
     )
   }
 
-  fun stubGetEventLocations(prisonCode: String, locations: Set<Location>) {
+  fun stubGetEventLocations(prisonCode: String, locations: List<Location>) {
     stubFor(
       WireMock.get(WireMock.urlEqualTo("/api/agencies/$prisonCode/eventLocations"))
         .willReturn(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -273,13 +273,25 @@ class PrisonApiMockServer : WireMockServer(8999) {
     )
   }
 
-  fun stubGetLocation(locationId: Long, jsonResponseFile: String) {
+  fun stubGetLocation(locationId: Long, jsonResponseFile: String, includeInactive: Boolean? = null) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/locations/$locationId"))
+      WireMock.get(WireMock.urlEqualTo("/api/locations/$locationId" + (includeInactive?.let { "?includeInactive=$includeInactive" } ?: "")))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withBodyFile(jsonResponseFile)
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubGetLocation(locationId: Long, location: Location, includeInactive: Boolean? = null) {
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/api/locations/$locationId" + (includeInactive?.let { "?includeInactive=$includeInactive" } ?: "")))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsString(location))
             .withStatus(200),
         ),
     )
@@ -292,18 +304,6 @@ class PrisonApiMockServer : WireMockServer(8999) {
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withBodyFile(jsonResponseFile)
-            .withStatus(200),
-        ),
-    )
-  }
-
-  fun stubGetLocation(locationId: Long, location: Location) {
-    stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/locations/$locationId"))
-        .willReturn(
-          WireMock.aResponse()
-            .withHeader("Content-Type", "application/json")
-            .withBody(mapper.writeValueAsString(location))
             .withStatus(200),
         ),
     )
@@ -459,6 +459,18 @@ class PrisonApiMockServer : WireMockServer(8999) {
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
             .withBody("[]")
+            .withStatus(200),
+        ),
+    )
+  }
+
+  fun stubGetEventLocations(prisonCode: String, locations: Set<Location>) {
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/api/agencies/$prisonCode/eventLocations"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsString(locations))
             .withStatus(200),
         ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationControllerTest.kt
@@ -12,6 +12,7 @@ import org.springframework.test.web.servlet.get
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.LocationGroup
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.whereabouts.LocationPrefixDto
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.InternalLocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.LocationGroupServiceSelector
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.LocationService
 
@@ -25,10 +26,13 @@ class LocationControllerTest : ControllerTestBase<LocationController>() {
   @MockBean
   private lateinit var locationGroupServiceSelector: LocationGroupServiceSelector
 
+  @MockBean
+  private lateinit var internalLocationService: InternalLocationService
+
   private val groupName = "Houseblock 1"
   private val prisonCode = "MDI"
 
-  override fun controller() = LocationController(locationService, locationGroupServiceSelector)
+  override fun controller() = LocationController(locationService, locationGroupServiceSelector, internalLocationService)
 
   @Test
   fun `Cell locations for group - 200 response when locations found`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDat
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCategoryReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.InternalLocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.LocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerScheduledEventsFixture
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ReferenceCodeDomain
@@ -37,7 +38,10 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
   @MockBean
   private lateinit var locationService: LocationService
 
-  override fun controller() = ScheduledEventController(scheduledEventService, referenceCodeService, locationService)
+  @MockBean
+  private lateinit var internalLocationService: InternalLocationService
+
+  override fun controller() = ScheduledEventController(scheduledEventService, referenceCodeService, locationService, internalLocationService)
 
   @BeforeEach
   fun setupMocks() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationServiceTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
 import kotlinx.coroutines.runBlocking
-import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -390,12 +389,10 @@ class InternalLocationServiceTest {
           description isEqualTo education1Location.userDescription
           with(events) {
             size isEqualTo 2
-            with(this.first { it.scheduledInstanceId == education1Activity.scheduledInstanceId }) {
-              assertThat(this).isNotNull()
+            with(this.single { it.scheduledInstanceId == education1Activity.scheduledInstanceId }) {
               eventType isEqualTo "ACTIVITY"
             }
-            with(this.first { it.appointmentAttendeeId == education1AppointmentInstance.appointmentAttendeeId }) {
-              assertThat(this).isNotNull()
+            with(this.single { it.appointmentAttendeeId == education1AppointmentInstance.appointmentAttendeeId }) {
               appointmentAttendeeId isEqualTo education1AppointmentInstance.appointmentInstanceId
               eventType isEqualTo "APPOINTMENT"
             }
@@ -443,12 +440,10 @@ class InternalLocationServiceTest {
           description isEqualTo education2Location.userDescription
           with(events) {
             size isEqualTo 2
-            with(this.first { it.scheduledInstanceId == education2Activity.scheduledInstanceId }) {
-              assertThat(this).isNotNull()
+            with(this.single { it.scheduledInstanceId == education2Activity.scheduledInstanceId }) {
               eventType isEqualTo "ACTIVITY"
             }
-            with(this.first { it.appointmentAttendeeId == education2AppointmentInstance.appointmentAttendeeId }) {
-              assertThat(this).isNotNull()
+            with(this.single { it.appointmentAttendeeId == education2AppointmentInstance.appointmentAttendeeId }) {
               appointmentAttendeeId isEqualTo education2AppointmentInstance.appointmentInstanceId
               eventType isEqualTo "APPOINTMENT"
             }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationServiceTest.kt
@@ -24,6 +24,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventTyp
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityFromDbInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentInstanceEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentSearchEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.internalLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEventsSummary
@@ -489,7 +490,7 @@ class InternalLocationServiceTest {
           prisonCode isEqualTo prisonCode
           code isEqualTo education1Location.description
           description isEqualTo education1Location.userDescription
-          events.size isEqualTo 0
+          events hasSize 0
         }
       }
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationServiceTest.kt
@@ -1,0 +1,520 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import kotlinx.coroutines.runBlocking
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.stub
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalTimeRange
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityFromDbInstance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentInstanceEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentSearchEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.internalLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEventsSummary
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentAttendeeSearchRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentInstanceRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSearchRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSearchSpecification
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonerScheduledActivityRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.CaseloadAccessException
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.addCaseloadIdToRequestHeader
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.clearCaseloadIdFromRequestHeader
+import java.time.LocalDate
+import java.time.LocalTime
+
+class InternalLocationServiceTest {
+  private val appointmentAttendeeSearchRepository: AppointmentAttendeeSearchRepository = mock()
+  private val appointmentInstanceRepository: AppointmentInstanceRepository = mock()
+  private val appointmentSearchRepository: AppointmentSearchRepository = mock()
+  private val appointmentSearchSpecification: AppointmentSearchSpecification = spy()
+  private val prisonApiClient: PrisonApiClient = mock()
+  private val prisonerScheduledActivityRepository: PrisonerScheduledActivityRepository = mock()
+  private val prisonRegimeService: PrisonRegimeService = mock()
+  private val referenceCodeService: ReferenceCodeService = mock()
+
+  val service = InternalLocationService(
+    appointmentAttendeeSearchRepository,
+    appointmentInstanceRepository,
+    appointmentSearchRepository,
+    appointmentSearchSpecification,
+    prisonApiClient,
+    prisonerScheduledActivityRepository,
+    prisonRegimeService,
+    referenceCodeService,
+  )
+
+  private val prisonCode: String = "MDI"
+  private val date = LocalDate.now()
+
+  private val timeSlotAm = Pair(LocalTime.of(8, 30), LocalTime.of(11, 45))
+  private val timeSlotPm = Pair(LocalTime.of(13, 45), LocalTime.of(16, 45))
+  private val timeSlotEd = Pair(LocalTime.of(17, 30), LocalTime.of(19, 15))
+
+  private val education1Location = internalLocation(
+    locationId = 2L,
+    description = "EDUC-ED1-ED1",
+    userDescription = "Education 1",
+  )
+  private val education2Location = internalLocation(
+    locationId = 3L,
+    description = "EDUC-ED2-ED2",
+    userDescription = "Education 2",
+  )
+  private val inactiveEducation1Location = internalLocation(
+    locationId = 1L,
+    description = "EDUC-ED1",
+    userDescription = "Education 1",
+  )
+  private val noUserDescriptionLocation = internalLocation(
+    locationId = 4L,
+    description = "NO-USR-DESC",
+    userDescription = null,
+  )
+
+  private val education1Appointment = appointmentSearchEntity(
+    prisonCode = prisonCode,
+    internalLocationId = education1Location.locationId,
+    startTime = LocalTime.of(9, 0),
+    endTime = LocalTime.of(10, 30),
+  )
+  private val noUserDescriptionLocationAppointment = appointmentSearchEntity(
+    prisonCode = prisonCode,
+    internalLocationId = noUserDescriptionLocation.locationId,
+    startTime = LocalTime.of(14, 0),
+    endTime = LocalTime.of(15, 30),
+  )
+  private val noLocationAppointment = appointmentSearchEntity(
+    prisonCode = prisonCode,
+    inCell = true,
+    startTime = LocalTime.of(18, 0),
+    endTime = LocalTime.of(18, 30),
+  )
+
+  private val education1Activity = activityFromDbInstance(
+    scheduledInstanceId = 1,
+    internalLocationId = education1Location.locationId.toInt(),
+    startTime = LocalTime.of(8, 30),
+    endTime = LocalTime.of(11, 45),
+  )
+  private val education2Activity = activityFromDbInstance(
+    scheduledInstanceId = 2,
+    internalLocationId = education2Location.locationId.toInt(),
+    startTime = LocalTime.of(8, 30),
+    endTime = LocalTime.of(11, 45),
+  )
+  private val inactiveEducation1Activity = activityFromDbInstance(
+    scheduledInstanceId = 3,
+    internalLocationId = inactiveEducation1Location.locationId.toInt(),
+    startTime = LocalTime.of(13, 45),
+    endTime = LocalTime.of(16, 45),
+  )
+  private val noLocationActivity = activityFromDbInstance(
+    scheduledInstanceId = 4,
+    internalLocationId = null,
+    startTime = LocalTime.of(17, 30),
+    endTime = LocalTime.of(19, 15),
+  )
+
+  private val education1AppointmentInstance = appointmentInstanceEntity(
+    appointmentInstanceId = 5,
+    internalLocationId = education1Location.locationId,
+  )
+  private val education2AppointmentInstance = appointmentInstanceEntity(
+    appointmentInstanceId = 6,
+    internalLocationId = education2Location.locationId,
+  )
+  private val noLocationAppointmentInstance = appointmentInstanceEntity(
+    appointmentInstanceId = 7,
+    inCell = true,
+  )
+
+  @BeforeEach
+  fun setUp() {
+    prisonApiClient.stub {
+      on {
+        runBlocking {
+          getEventLocationsAsync(prisonCode)
+        }
+      } doReturn listOf(education1Location, education2Location, noUserDescriptionLocation)
+
+      on {
+        runBlocking {
+          getLocationAsync(inactiveEducation1Location.locationId, true)
+        }
+      } doReturn inactiveEducation1Location
+
+      on {
+        runBlocking {
+          getLocationAsync(-1, true)
+        }
+      } doThrow WebClientResponseException(404, "", null, null, null)
+    }
+
+    prisonRegimeService.stub {
+      on {
+        getTimeRangeForPrisonAndTimeSlot(prisonCode, TimeSlot.AM)
+      } doReturn LocalTimeRange(timeSlotAm.first, timeSlotAm.second)
+      on {
+        getTimeRangeForPrisonAndTimeSlot(prisonCode, TimeSlot.PM)
+      } doReturn LocalTimeRange(timeSlotPm.first, timeSlotPm.second)
+      on {
+        getTimeRangeForPrisonAndTimeSlot(prisonCode, TimeSlot.ED)
+      } doReturn LocalTimeRange(timeSlotEd.first, timeSlotEd.second)
+    }
+  }
+
+  @AfterEach
+  fun tearDown() {
+    clearCaseloadIdFromRequestHeader()
+  }
+
+  @Nested
+  @DisplayName("getInternalLocationsMapByIds")
+  inner class GetInternalLocationsMapByIds {
+    @Test
+    fun `filters locations matching supplied ids`() = runBlocking {
+      service.getInternalLocationsMapByIds(
+        prisonCode,
+        setOf(education2Location.locationId),
+      ) isEqualTo mapOf(
+        education2Location.locationId to education2Location,
+      )
+    }
+
+    @Test
+    fun `retrieves inactive locations matching supplied ids`() = runBlocking {
+      service.getInternalLocationsMapByIds(
+        prisonCode,
+        setOf(
+          inactiveEducation1Location.locationId,
+        ),
+      ) isEqualTo mapOf(
+        inactiveEducation1Location.locationId to inactiveEducation1Location,
+      )
+    }
+
+    @Test
+    fun `retrieves inactive locations and combines with those matching supplied ids`() = runBlocking {
+      service.getInternalLocationsMapByIds(
+        prisonCode,
+        setOf(
+          inactiveEducation1Location.locationId,
+          education2Location.locationId,
+        ),
+      ) isEqualTo mapOf(
+        inactiveEducation1Location.locationId to inactiveEducation1Location,
+        education2Location.locationId to education2Location,
+      )
+    }
+
+    @Test
+    fun `tries to retrieve inactive locations matching supplied ids and catches errors`() = runBlocking {
+      service.getInternalLocationsMapByIds(
+        prisonCode,
+        setOf(
+          -1,
+          education2Location.locationId,
+        ),
+      ) isEqualTo mapOf(
+        education2Location.locationId to education2Location,
+      )
+    }
+  }
+
+  @Nested
+  @DisplayName("getInternalLocationEventsSummaries")
+  inner class GetInternalLocationEventsSummaries {
+    @BeforeEach
+    fun setUp() {
+      addCaseloadIdToRequestHeader(prisonCode)
+    }
+
+    @Test
+    fun `uses events from all day when no time slot is supplied`() = runBlocking {
+      whenever(
+        prisonerScheduledActivityRepository.findByPrisonCodeAndDateAndTime(
+          prisonCode,
+          date,
+          LocalTime.of(0, 0),
+          LocalTime.of(23, 59),
+        ),
+      ).thenReturn(listOf(education2Activity))
+      whenever(appointmentSearchRepository.findAll(any())).thenReturn(listOf(education1Appointment))
+
+      service.getInternalLocationEventsSummaries(
+        prisonCode,
+        date,
+        null,
+      ) isEqualTo setOf(
+        InternalLocationEventsSummary(
+          education1Location.locationId,
+          prisonCode,
+          education1Location.description,
+          education1Location.userDescription!!,
+        ),
+        InternalLocationEventsSummary(
+          education2Location.locationId,
+          prisonCode,
+          education2Location.description,
+          education2Location.userDescription!!,
+        ),
+      )
+
+      verify(appointmentSearchSpecification).prisonCodeEquals(prisonCode)
+      verify(appointmentSearchSpecification).startDateEquals(date)
+      verify(appointmentSearchSpecification).startTimeBetween(LocalTime.of(0, 0), LocalTime.of(23, 59))
+      verifyNoMoreInteractions(appointmentSearchSpecification)
+    }
+
+    @Test
+    fun `uses events from time slot when time slot is supplied`() = runBlocking {
+      whenever(
+        prisonerScheduledActivityRepository.findByPrisonCodeAndDateAndTime(
+          prisonCode,
+          date,
+          timeSlotPm.first,
+          timeSlotPm.second,
+        ),
+      ).thenReturn(listOf(inactiveEducation1Activity))
+      whenever(appointmentSearchRepository.findAll(any())).thenReturn(listOf(noUserDescriptionLocationAppointment))
+
+      service.getInternalLocationEventsSummaries(
+        prisonCode,
+        date,
+        TimeSlot.PM,
+      ) isEqualTo setOf(
+        InternalLocationEventsSummary(
+          noUserDescriptionLocation.locationId,
+          prisonCode,
+          noUserDescriptionLocation.description,
+          noUserDescriptionLocation.description,
+        ),
+        InternalLocationEventsSummary(
+          inactiveEducation1Location.locationId,
+          prisonCode,
+          inactiveEducation1Location.description,
+          inactiveEducation1Location.userDescription!!,
+        ),
+      )
+
+      verify(appointmentSearchSpecification).prisonCodeEquals(prisonCode)
+      verify(appointmentSearchSpecification).startDateEquals(date)
+      verify(appointmentSearchSpecification).startTimeBetween(timeSlotPm.first, timeSlotPm.second)
+      verifyNoMoreInteractions(appointmentSearchSpecification)
+    }
+
+    @Test
+    fun `exclude events with no internal location ids`() = runBlocking {
+      whenever(
+        prisonerScheduledActivityRepository.findByPrisonCodeAndDateAndTime(
+          prisonCode,
+          date,
+          timeSlotPm.first,
+          timeSlotPm.second,
+        ),
+      ).thenReturn(listOf(noLocationActivity))
+      whenever(appointmentSearchRepository.findAll(any())).thenReturn(listOf(noLocationAppointment))
+
+      service.getInternalLocationEventsSummaries(
+        prisonCode,
+        date,
+        TimeSlot.AM,
+      ) isEqualTo emptySet()
+    }
+  }
+
+  @Nested
+  @DisplayName("getInternalLocationEvents")
+  inner class GetInternalLocationEvents {
+    @BeforeEach
+    fun setUp() {
+      addCaseloadIdToRequestHeader(prisonCode)
+
+      whenever(prisonRegimeService.getEventPrioritiesForPrison(prisonCode))
+        .thenReturn(EventPriorities(EventType.entries.associateWith { listOf(Priority(it.defaultPriority)) }))
+    }
+
+    @Test
+    fun `uses events from all day when no time slot is supplied`() = runBlocking {
+      val internalLocationIds = setOf(education1Location.locationId)
+
+      whenever(
+        prisonerScheduledActivityRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+          prisonCode,
+          internalLocationIds.map { it.toInt() }.toSet(),
+          date,
+          LocalTime.of(0, 0),
+          LocalTime.of(23, 59),
+        ),
+      ).thenReturn(listOf(education1Activity))
+      whenever(
+        appointmentInstanceRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+          prisonCode,
+          internalLocationIds,
+          date,
+          LocalTime.of(0, 0),
+          LocalTime.of(23, 59),
+        ),
+      ).thenReturn(listOf(education1AppointmentInstance))
+
+      val result = service.getInternalLocationEvents(
+        prisonCode,
+        setOf(education1Location.locationId),
+        date,
+        null,
+      )
+
+      with(result) {
+        size isEqualTo 1
+        with(this.first()) {
+          id isEqualTo education1Location.locationId
+          prisonCode isEqualTo prisonCode
+          code isEqualTo education1Location.description
+          description isEqualTo education1Location.userDescription
+          with(events) {
+            size isEqualTo 2
+            with(this.first { it.scheduledInstanceId == education1Activity.scheduledInstanceId }) {
+              assertThat(this).isNotNull()
+              eventType isEqualTo "ACTIVITY"
+            }
+            with(this.first { it.appointmentAttendeeId == education1AppointmentInstance.appointmentAttendeeId }) {
+              assertThat(this).isNotNull()
+              appointmentAttendeeId isEqualTo education1AppointmentInstance.appointmentInstanceId
+              eventType isEqualTo "APPOINTMENT"
+            }
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `uses events from time slot when time slot is supplied`() = runBlocking {
+      val internalLocationIds = setOf(education2Location.locationId)
+
+      whenever(
+        prisonerScheduledActivityRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+          prisonCode,
+          internalLocationIds.map { it.toInt() }.toSet(),
+          date,
+          timeSlotPm.first,
+          timeSlotPm.second,
+        ),
+      ).thenReturn(listOf(education2Activity))
+      whenever(
+        appointmentInstanceRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+          prisonCode,
+          internalLocationIds,
+          date,
+          timeSlotPm.first,
+          timeSlotPm.second,
+        ),
+      ).thenReturn(listOf(education2AppointmentInstance))
+
+      val result = service.getInternalLocationEvents(
+        prisonCode,
+        setOf(education2Location.locationId),
+        date,
+        TimeSlot.PM,
+      )
+
+      with(result) {
+        size isEqualTo 1
+        with(this.first()) {
+          id isEqualTo education2Location.locationId
+          prisonCode isEqualTo prisonCode
+          code isEqualTo education2Location.description
+          description isEqualTo education2Location.userDescription
+          with(events) {
+            size isEqualTo 2
+            with(this.first { it.scheduledInstanceId == education2Activity.scheduledInstanceId }) {
+              assertThat(this).isNotNull()
+              eventType isEqualTo "ACTIVITY"
+            }
+            with(this.first { it.appointmentAttendeeId == education2AppointmentInstance.appointmentAttendeeId }) {
+              assertThat(this).isNotNull()
+              appointmentAttendeeId isEqualTo education2AppointmentInstance.appointmentInstanceId
+              eventType isEqualTo "APPOINTMENT"
+            }
+          }
+        }
+      }
+    }
+
+    @Test
+    fun `exclude events with no internal location ids`() = runBlocking {
+      val internalLocationIds = setOf(education2Location.locationId)
+
+      whenever(
+        prisonerScheduledActivityRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+          prisonCode,
+          internalLocationIds.map { it.toInt() }.toSet(),
+          date,
+          timeSlotEd.first,
+          timeSlotEd.second,
+        ),
+      ).thenReturn(listOf(noLocationActivity))
+      whenever(
+        appointmentInstanceRepository.findByPrisonCodeAndInternalLocationIdsAndDateAndTime(
+          prisonCode,
+          internalLocationIds,
+          date,
+          timeSlotEd.first,
+          timeSlotEd.second,
+        ),
+      ).thenReturn(listOf(noLocationAppointmentInstance))
+
+      val result = service.getInternalLocationEvents(
+        prisonCode,
+        setOf(education1Location.locationId),
+        date,
+        TimeSlot.ED,
+      )
+
+      with(result) {
+        size isEqualTo 1
+        with(this.first()) {
+          id isEqualTo education1Location.locationId
+          prisonCode isEqualTo prisonCode
+          code isEqualTo education1Location.description
+          description isEqualTo education1Location.userDescription
+          events.size isEqualTo 0
+        }
+      }
+    }
+  }
+
+  @Nested
+  @DisplayName("caseload checks")
+  inner class CaseloadChecks {
+    @Test
+    fun `getInternalLocationEventsSummaries throws caseload access exception if caseload id header does not match`() {
+      addCaseloadIdToRequestHeader("WRONG")
+      assertThatThrownBy { service.getInternalLocationEventsSummaries(prisonCode, LocalDate.now(), null) }
+        .isInstanceOf(CaseloadAccessException::class.java)
+    }
+
+    @Test
+    fun `getInternalLocationEvents throws caseload access exception if caseload id header does not match`() {
+      addCaseloadIdToRequestHeader("WRONG")
+      assertThatThrownBy { service.getInternalLocationEvents(prisonCode, setOf(1L), LocalDate.now(), null) }
+        .isInstanceOf(CaseloadAccessException::class.java)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
@@ -256,6 +256,8 @@ class ScheduledInstanceServiceTest {
       whenever(attendanceSummaryRepository.findByPrisonAndDate("MDI", LocalDate.now()))
         .thenReturn(listOf(attendanceSummary))
 
+      addCaseloadIdToRequestHeader("MDI")
+
       val result = service.attendanceSummary("MDI", LocalDate.now())
 
       assertThat(result).isEqualTo(listOf(attendanceSummary.toModel()))


### PR DESCRIPTION
Adds two new endpoints to support movement lists:

- /locations/prison/{prisonCode}/events-summaries - Get a list of internal locations that have events scheduled to take place on the specified date and optional time slot
- /scheduled-events/prison/{prisonCode}/locations - Get a list of scheduled events for a prison and list of internal location ids numbers for a date and optional time slot
      