### PR TITLE
SAA-1208 adding a new transaction handler around attendance changes to guarantee attendances are updated before events are emitting attendance amended events.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceEntityListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceEntityListener.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
 import jakarta.persistence.PostPersist
-import jakarta.persistence.PostUpdate
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,15 +24,6 @@ class AttendanceEntityListener {
       OutboundEvent.PRISONER_ATTENDANCE_CREATED,
       attendance.attendanceId,
       "Failed to send prisoner attendance created event for attendance ID ${attendance.attendanceId}",
-    )
-  }
-
-  @PostUpdate
-  fun onUpdate(attendance: Attendance) {
-    send(
-      OutboundEvent.PRISONER_ATTENDANCE_AMENDED,
-      attendance.attendanceId,
-      "Failed to send prisoner attendance amended event for attendance ID ${attendance.attendanceId}",
     )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
@@ -12,6 +12,8 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Atte
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ScheduledInstanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transform
 import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AllAttendance as ModelAllAttendance
@@ -23,6 +25,8 @@ class AttendancesService(
   private val attendanceRepository: AttendanceRepository,
   private val attendanceReasonRepository: AttendanceReasonRepository,
   private val caseNotesApiClient: CaseNotesApiClient,
+  private val transactionHandler: TransactionHandler,
+  private val outboundEventsService: OutboundEventsService,
 ) {
 
   companion object {
@@ -35,25 +39,33 @@ class AttendancesService(
   fun mark(principalName: String, attendances: List<AttendanceUpdateRequest>) {
     log.info("Attendance marking in progress")
 
-    val attendanceUpdatesById = attendances.onEach(AttendanceUpdateRequestValidator::validate).associateBy { it.id }
-    val attendanceReasonsByCode = attendanceReasonRepository.findAll().associateBy { it.code }
+    val markedAttendanceIds = transactionHandler.new {
+      val attendanceUpdatesById = attendances.onEach(AttendanceUpdateRequestValidator::validate).associateBy { it.id }
+      val attendanceReasonsByCode = attendanceReasonRepository.findAll().associateBy { it.code }
 
-    attendanceRepository.findAllById(attendanceUpdatesById.keys).onEach { attendance ->
-      val updateRequest = attendanceUpdatesById[attendance.attendanceId]!!
+      attendanceRepository.findAllById(attendanceUpdatesById.keys).onEach { attendance ->
+        val updateRequest = attendanceUpdatesById[attendance.attendanceId]!!
 
-      attendance.mark(
-        principalName = principalName,
-        reason = attendanceReasonsByCode[updateRequest.maybeAttendanceReason()],
-        newStatus = updateRequest.status,
-        newComment = updateRequest.comment,
-        newIssuePayment = updateRequest.issuePayment,
-        newIncentiveLevelWarningIssued = updateRequest.incentiveLevelWarningIssued,
-        newCaseNoteId = updateRequest.mayBeCaseNote(attendance.prisonerNumber)?.caseNoteId,
-        newOtherAbsenceReason = updateRequest.otherAbsenceReason,
-      )
+        attendance.mark(
+          principalName = principalName,
+          reason = attendanceReasonsByCode[updateRequest.maybeAttendanceReason()],
+          newStatus = updateRequest.status,
+          newComment = updateRequest.comment,
+          newIssuePayment = updateRequest.issuePayment,
+          newIncentiveLevelWarningIssued = updateRequest.incentiveLevelWarningIssued,
+          newCaseNoteId = updateRequest.mayBeCaseNote(attendance.prisonerNumber)?.caseNoteId,
+          newOtherAbsenceReason = updateRequest.otherAbsenceReason,
+        )
 
-      attendanceRepository.saveAndFlush(attendance)
-    }.also { log.info("Attendance marking done for ${it.size} attendance record(s)") }
+        attendanceRepository.saveAndFlush(attendance)
+      }.map { it.attendanceId }
+    }.getOrThrow()
+
+    markedAttendanceIds.forEach { id ->
+      outboundEventsService.send(OutboundEvent.PRISONER_ATTENDANCE_AMENDED, id)
+    }.also { log.info("Sending attendance amended events.") }
+
+    log.info("Attendance marking done for ${markedAttendanceIds.size} attendance record(s)")
   }
 
   private fun AttendanceUpdateRequest.mayBeCaseNote(prisonerNumber: String): CaseNote? =

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
@@ -59,7 +59,7 @@ class AttendancesService(
 
         attendanceRepository.saveAndFlush(attendance)
       }.map { it.attendanceId }
-    }.getOrThrow()
+    }
 
     markedAttendanceIds.forEach { id ->
       outboundEventsService.send(OutboundEvent.PRISONER_ATTENDANCE_AMENDED, id)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
@@ -70,7 +70,7 @@ class ScheduledInstanceService(
       val uncancelledAttendances = scheduledInstance.uncancelSessionAndAttendances()
 
       repository.saveAndFlush(scheduledInstance) to uncancelledAttendances
-    }.getOrThrow()
+    }
 
     // Emit sync events - manually
     if (!uncancelledInstance.cancelled) {
@@ -100,8 +100,8 @@ class ScheduledInstanceService(
         cancellationReason = attendanceReasonRepository.findByCode(AttendanceReasonEnum.CANCELLED),
       )
 
-      repository.saveAndFlush(scheduledInstance)to cancelledAttendances
-    }.getOrThrow()
+      repository.saveAndFlush(scheduledInstance) to cancelledAttendances
+    }
 
     // Emit sync events - manually
     if (cancelledInstance.cancelled) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/TransactionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/TransactionHandler.kt
@@ -11,5 +11,5 @@ import org.springframework.transaction.annotation.Transactional
 @Component
 class TransactionHandler {
   @Transactional(propagation = Propagation.REQUIRES_NEW)
-  fun <T> new(block: () -> T): Result<T> = runCatching { block() }
+  fun <T> new(block: () -> T): T = block()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/TransactionHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/TransactionHandler.kt
@@ -1,0 +1,15 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Propagation
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * To be used in services or components where a new transaction is required to ensure any DB changes are committed prior
+ * to taking any further action e.g. emitting new/update/delete events.
+ */
+@Component
+class TransactionHandler {
+  @Transactional(propagation = Propagation.REQUIRES_NEW)
+  fun <T> new(block: () -> T): Result<T> = runCatching { block() }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
@@ -66,11 +66,11 @@ class ActivitiesChangedEventHandler(
           allocationRepository.findByPrisonCodeAndPrisonerNumber(event.prisonCode(), event.prisonerNumber())
             .suspendPrisonersAllocations(now, event)
             .suspendPrisonersFutureAttendances(now, event)
-        }.onSuccess { updatedAttendances ->
+        }.let { updatedAttendances ->
           updatedAttendances.forEach {
             outboundEventsService.send(OutboundEvent.PRISONER_ATTENDANCE_AMENDED, it.attendanceId)
           }.also { log.info("Sending attendance amended events.") }
-        }.onFailure { throw it }
+        }
       }
 
       Outcome.success()

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
@@ -7,6 +7,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.isPermanentlyReleased
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.isTemporarilyReleased
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Attendance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceReasonEnum
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
@@ -15,8 +16,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Allo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceReasonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.Action
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.ActivitiesChangedEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
 import java.time.LocalDateTime
 
 @Component
@@ -28,6 +32,8 @@ class ActivitiesChangedEventHandler(
   private val attendanceReasonRepository: AttendanceReasonRepository,
   private val prisonerSearchApiClient: PrisonerSearchApiApplicationClient,
   private val allocationHandler: PrisonerAllocationHandler,
+  private val transactionHandler: TransactionHandler,
+  private val outboundEventsService: OutboundEventsService,
 ) : EventHandler<ActivitiesChangedEvent> {
 
   companion object {
@@ -56,9 +62,15 @@ class ActivitiesChangedEventHandler(
   private fun suspendPrisonerAllocationsAndAttendances(event: ActivitiesChangedEvent) =
     runCatching {
       LocalDateTime.now().let { now ->
-        allocationRepository.findByPrisonCodeAndPrisonerNumber(event.prisonCode(), event.prisonerNumber())
-          .suspendPrisonersAllocations(now, event)
-          .suspendPrisonersFutureAttendances(now, event)
+        transactionHandler.new {
+          allocationRepository.findByPrisonCodeAndPrisonerNumber(event.prisonCode(), event.prisonerNumber())
+            .suspendPrisonersAllocations(now, event)
+            .suspendPrisonersFutureAttendances(now, event)
+        }.onSuccess { updatedAttendances ->
+          updatedAttendances.forEach {
+            outboundEventsService.send(OutboundEvent.PRISONER_ATTENDANCE_AMENDED, it.attendanceId)
+          }.also { log.info("Sending attendance amended events.") }
+        }.onFailure { throw it }
       }
 
       Outcome.success()
@@ -76,10 +88,10 @@ class ActivitiesChangedEventHandler(
   private fun List<Allocation>.suspendPrisonersFutureAttendances(
     dateTime: LocalDateTime,
     event: ActivitiesChangedEvent,
-  ) {
+  ): List<Attendance> {
     val reason = attendanceReasonRepository.findByCode(AttendanceReasonEnum.SUSPENDED)
 
-    forEach { allocation ->
+    return flatMap { allocation ->
       attendanceRepository.findAttendancesOnOrAfterDateForPrisoner(
         event.prisonCode(),
         dateTime.toLocalDate(),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandler.kt
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiApplicationClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.extensions.isActiveInPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Attendance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceReasonEnum
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
@@ -13,7 +14,10 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Allo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceReasonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OffenderReceivedEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -25,6 +29,8 @@ class OffenderReceivedEventHandler(
   private val prisonApiClient: PrisonApiApplicationClient,
   private val attendanceRepository: AttendanceRepository,
   private val attendanceReasonRepository: AttendanceReasonRepository,
+  private val transactionHandler: TransactionHandler,
+  private val outboundEventsService: OutboundEventsService,
 ) : EventHandler<OffenderReceivedEvent> {
 
   companion object {
@@ -39,9 +45,15 @@ class OffenderReceivedEventHandler(
         if (prisoner.isActiveInPrison(event.prisonCode())) {
           allocationRepository.findByPrisonCodeAndPrisonerNumber(event.prisonCode(), event.prisonerNumber()).let { allocations ->
             if (allocations.isNotEmpty()) {
-              allocations
-                .resetSuspendedAllocations(event)
-                .resetFutureSuspendedAttendances(event)
+              transactionHandler.new {
+                allocations
+                  .resetSuspendedAllocations(event)
+                  .resetFutureSuspendedAttendances(event)
+              }.onSuccess { updatedAttendances ->
+                updatedAttendances.forEach {
+                  outboundEventsService.send(OutboundEvent.PRISONER_ATTENDANCE_AMENDED, it.attendanceId)
+                }.also { log.info("Sending attendance amended events.") }
+              }
             } else {
               log.info("No allocations for prisoner ${event.prisonerNumber()} in prison ${event.prisonCode()}")
             }
@@ -69,11 +81,11 @@ class OffenderReceivedEventHandler(
         log.info("Reset ${this.size} suspended allocations for prisoner ${event.prisonerNumber()} at prison ${event.prisonCode()}.")
       }
 
-  private fun List<Allocation>.resetFutureSuspendedAttendances(event: OffenderReceivedEvent) {
+  private fun List<Allocation>.resetFutureSuspendedAttendances(event: OffenderReceivedEvent): List<Attendance> {
     val now = LocalDateTime.now()
     val cancelledReason = attendanceReasonRepository.findByCode(AttendanceReasonEnum.CANCELLED)
 
-    forEach { allocation ->
+    return flatMap { allocation ->
       attendanceRepository.findAttendancesOnOrAfterDateForPrisoner(
         prisonCode = event.prisonCode(),
         sessionDate = LocalDate.now(),
@@ -92,8 +104,7 @@ class OffenderReceivedEventHandler(
           } else {
             attendance.unsuspend().also { log.info("Unsuspended attendance ${attendance.attendanceId}") }
           }
-        }
-        .also { log.info("Reset ${it.size} suspended attendances for prisoner ${allocation.prisonerNumber} allocation ID ${allocation.allocationId} at prison ${event.prisonCode()}.") }
+        }.also { log.info("Reset ${it.size} suspended attendances for prisoner ${allocation.prisonerNumber} allocation ID ${allocation.allocationId} at prison ${event.prisonCode()}.") }
     }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandler.kt
@@ -49,7 +49,7 @@ class OffenderReceivedEventHandler(
                 allocations
                   .resetSuspendedAllocations(event)
                   .resetFutureSuspendedAttendances(event)
-              }.onSuccess { updatedAttendances ->
+              }.let { updatedAttendances ->
                 updatedAttendances.forEach {
                   outboundEventsService.send(OutboundEvent.PRISONER_ATTENDANCE_AMENDED, it.attendanceId)
                 }.also { log.info("Sending attendance amended events.") }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceEntityListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceEntityListenerTest.kt
@@ -25,11 +25,4 @@ class AttendanceEntityListenerTest(@Autowired private val listener: AttendanceEn
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ATTENDANCE_CREATED, attendance.attendanceId)
     verifyNoMoreInteractions(outboundEventsService)
   }
-
-  @Test
-  fun `prisoner attendance amended event raised on update`() {
-    listener.onUpdate(attendance)
-    verify(outboundEventsService).send(OutboundEvent.PRISONER_ATTENDANCE_AMENDED, attendance.attendanceId)
-    verifyNoMoreInteractions(outboundEventsService)
-  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AttendanceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AttendanceIntegrationTest.kt
@@ -21,7 +21,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.A
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_ACTIVITY_ADMIN
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_PRISON
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAttendancesService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsPublisher
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundHMPPSDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.PrisonerAttendanceInformation
@@ -45,9 +44,6 @@ class AttendanceIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var attendanceRepository: AttendanceRepository
-
-  @Autowired
-  private lateinit var attendancesService: ManageAttendancesService
 
   private val eventCaptor = argumentCaptor<OutboundHMPPSDomainEvent>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
@@ -48,6 +48,7 @@ class ScheduledInstanceServiceTest {
     attendanceReasonRepository,
     attendanceSummaryRepository,
     outboundEventsService,
+    TransactionHandler(),
   )
 
   @Nested
@@ -131,6 +132,7 @@ class ScheduledInstanceServiceTest {
       assertThat(instance.cancelled).isFalse
       verify(repository).saveAndFlush(instance)
       verify(outboundEventsService).send(OutboundEvent.ACTIVITY_SCHEDULED_INSTANCE_AMENDED, instance.scheduledInstanceId)
+      verify(outboundEventsService).send(OutboundEvent.PRISONER_ATTENDANCE_AMENDED, instance.attendances.first().attendanceId)
     }
 
     @Test
@@ -203,6 +205,7 @@ class ScheduledInstanceServiceTest {
 
       verify(outboundEventsService)
         .send(OutboundEvent.ACTIVITY_SCHEDULED_INSTANCE_AMENDED, instance.scheduledInstanceId)
+      verify(outboundEventsService).send(OutboundEvent.PRISONER_ATTENDANCE_AMENDED, instance.attendances.first().attendanceId)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -31,7 +33,10 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Allo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceReasonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.Action
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.activitiesChangedEvent
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -52,6 +57,7 @@ class ActivitiesChangedEventHandlerTest {
   private val attendanceReasonRepository: AttendanceReasonRepository = mock()
   private val prisonerSearchApiClient: PrisonerSearchApiApplicationClient = mock()
   private val prisonerAllocationHandler: PrisonerAllocationHandler = mock()
+  private val outboundEventsService: OutboundEventsService = mock()
 
   private val handler = ActivitiesChangedEventHandler(
     rolloutPrisonRepository,
@@ -60,6 +66,8 @@ class ActivitiesChangedEventHandlerTest {
     attendanceReasonRepository,
     prisonerSearchApiClient,
     prisonerAllocationHandler,
+    TransactionHandler(),
+    outboundEventsService,
   )
 
   @Test
@@ -161,6 +169,7 @@ class ActivitiesChangedEventHandlerTest {
     verify(historicAttendance, never()).completeWithoutPayment(suspendedAttendanceReason)
     verify(todaysFutureAttendance).completeWithoutPayment(suspendedAttendanceReason)
     verify(tomorrowsFutureAttendance).completeWithoutPayment(suspendedAttendanceReason)
+    verify(outboundEventsService, times(2)).send(eq(OutboundEvent.PRISONER_ATTENDANCE_AMENDED), any())
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderReceivedEventHandlerTest.kt
@@ -3,10 +3,13 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.reset
 import org.mockito.kotlin.stub
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -27,6 +30,9 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Allo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceReasonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.offenderReceivedFromTemporaryAbsence
 import java.time.LocalDate
 import java.time.LocalDateTime
@@ -42,9 +48,10 @@ class OffenderReceivedEventHandlerTest {
     on { agencyId } doReturn moorlandPrisonCode
   }
   private val attendanceReasonRepository: AttendanceReasonRepository = mock()
+  private val outboundEventsService: OutboundEventsService = mock()
 
   private val handler =
-    OffenderReceivedEventHandler(rolloutPrisonRepository, allocationRepository, prisonApiClient, attendanceRepository, attendanceReasonRepository)
+    OffenderReceivedEventHandler(rolloutPrisonRepository, allocationRepository, prisonApiClient, attendanceRepository, attendanceReasonRepository, TransactionHandler(), outboundEventsService)
 
   @BeforeEach
   fun beforeTests() {
@@ -174,6 +181,7 @@ class OffenderReceivedEventHandlerTest {
     assertThat(historicAttendance.hasReason(AttendanceReasonEnum.SUSPENDED)).isTrue
     assertThat(todaysFutureAttendance.hasReason(AttendanceReasonEnum.SUSPENDED)).isFalse
     assertThat(tomorrowsFutureAttendance.hasReason(AttendanceReasonEnum.SUSPENDED)).isFalse
+    verify(outboundEventsService, times(2)).send(eq(OutboundEvent.PRISONER_ATTENDANCE_AMENDED), any())
   }
 
   @Test


### PR DESCRIPTION
A problem has shown itself whereby (bulk) attendance amendment events are being processed by the sync service before the changes had fully committed in our service DB.  This resulted in the activities service and NOMIS being out of sync with each.

The crux of the changes here involve wrapping the attendance changes in a completely independent new transaction which has to complete after which we publish the events in the service/component and not use the attendance entity listener.

Hopefully this is a short term solution with regards to raising attendance amended events until we have time to revisit and address  a more complete solution towards the raising of events in general.  Ideally we should be looking to move away from entity listeners e.g. use of `TransactionalEventListener` which can determine when a transaction has committed so could replace the use of entity listeners perhaps.