### PR TITLE
SAA-1221 suspension and end of pending allocations need to be considered when starting and ending allocations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -31,7 +31,11 @@ inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>(
 @Service
 class PrisonApiClient(private val prisonApiWebClient: WebClient) {
 
-  fun getPrisonerDetails(prisonerNumber: String, fullInfo: Boolean = true, extraInfo: Boolean? = null): Mono<InmateDetail> {
+  fun getPrisonerDetails(
+    prisonerNumber: String,
+    fullInfo: Boolean = true,
+    extraInfo: Boolean? = null,
+  ): Mono<InmateDetail> {
     return prisonApiWebClient.get()
       .uri { uriBuilder: UriBuilder ->
         uriBuilder
@@ -389,14 +393,14 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .awaitBody()
   }
 
-  fun getLatestMovementForPrisoners(prisonerNumbers: Set<String>) =
+  fun getMovementsForPrisonersFromPrison(prisonCode: String, prisonerNumbers: Set<String>) =
     prisonerNumbers.ifNotEmpty {
       prisonApiWebClient
         .post()
-        .uri("/api/movements/offenders?latestOnly=true")
+        .uri("/api/movements/offenders")
         .bodyValue(prisonerNumbers)
         .retrieve()
         .bodyToMono(typeReference<List<Movement>>())
         .block()
-    } ?: emptyList()
+    }?.filter { it.fromAgency == prisonCode } ?: emptyList()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.InmateDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.LocationGroup
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Movement
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderAdjudicationHearing
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.Education
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.OffenderNonAssociationDetail
@@ -19,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.LocalDateRange
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.ifNotEmpty
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.Optional
@@ -386,4 +388,15 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
       .retrieve()
       .awaitBody()
   }
+
+  fun getLatestMovementForPrisoners(prisonerNumbers: Set<String>) =
+    prisonerNumbers.ifNotEmpty {
+      prisonApiWebClient
+        .post()
+        .uri("/api/movements/offenders?latestOnly=true")
+        .bodyValue(prisonerNumbers)
+        .retrieve()
+        .bodyToMono(typeReference<List<Movement>>())
+        .block()
+    } ?: emptyList()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/extensions/MovementExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/extensions/MovementExt.kt
@@ -1,0 +1,7 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.extensions
+
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Movement
+import java.time.LocalDateTime
+import java.time.LocalTime
+
+fun Movement.movementDateTime(): LocalDateTime = LocalDateTime.of(movementDate, LocalTime.parse(movementTime))

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExt.kt
@@ -21,6 +21,8 @@ fun Prisoner.isTemporarilyReleased() =
 fun Prisoner.isPermanentlyReleased() =
   isInactiveOut() && confirmedReleaseDate?.onOrBefore(LocalDate.now()) == true && lastMovementType() == MovementType.RELEASE
 
+fun Prisoner.isAtDifferentLocationTo(prisonCode: String) = prisonCode != prisonId
+
 enum class MovementType(val nomisShortCode: String) {
   RELEASE("REL"),
   TEMPORARY_ABSENCE("TAP"),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExt.kt
@@ -4,7 +4,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.onOrBefore
 import java.time.LocalDate
 
-fun Prisoner.isOut() = inOutStatus == Prisoner.InOutStatus.OUT
+fun Prisoner.isOutOfPrison() = inOutStatus == Prisoner.InOutStatus.OUT
 
 fun Prisoner.lastMovementType(): MovementType? =
   MovementType.entries.firstOrNull { it.nomisShortCode == lastMovementTypeCode }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/CollectionExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/CollectionExt.kt
@@ -1,0 +1,4 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common
+
+fun <T, R> Collection<T>.ifNotEmpty(block: (Collection<T>) -> R): R? =
+  this.takeIf { it.isNotEmpty() }?.let { block(this) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -206,9 +206,12 @@ data class Allocation(
       prisonerStatus = PrisonerStatus.ACTIVE
     }
 
+  /**
+   * Only active and pending allocations can be auto-suspended.
+   */
   fun autoSuspend(dateTime: LocalDateTime, reason: String) =
     this.apply {
-      failWithMessageIfAllocationsIsNot("You can only suspend active allocations", PrisonerStatus.ACTIVE)
+      failWithMessageIfAllocationsIsNot("You can only auto-suspend active and pending allocations", PrisonerStatus.ACTIVE, PrisonerStatus.PENDING)
 
       prisonerStatus = PrisonerStatus.AUTO_SUSPENDED
       suspendedTime = dateTime

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
@@ -25,13 +25,13 @@ class ManageAllocationsJob(
     if (withDeallocate) {
       jobRunner.runJob(
         JobDefinition(jobType = JobType.DEALLOCATE_ENDING) {
-          service.allocations(AllocationOperation.DEALLOCATE_ENDING)
+          service.allocations(AllocationOperation.ENDING_TODAY)
         },
       )
 
       jobRunner.runJob(
         JobDefinition(jobType = JobType.DEALLOCATE_EXPIRING) {
-          service.allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+          service.allocations(AllocationOperation.EXPIRING_TODAY)
         },
       )
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AllocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AllocationRepository.kt
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.BookingCount
+import java.time.LocalDate
 
 @Repository
 interface AllocationRepository : JpaRepository<Allocation, Long> {
@@ -67,7 +68,10 @@ interface AllocationRepository : JpaRepository<Allocation, Long> {
       order by a.bookingId
       """,
   )
-  fun findBookingAllocationCountsByPrisonAndPrisonerStatus(prisonCode: String, prisonerStatus: PrisonerStatus): List<BookingCount>
+  fun findBookingAllocationCountsByPrisonAndPrisonerStatus(
+    prisonCode: String,
+    prisonerStatus: PrisonerStatus,
+  ): List<BookingCount>
 
   @Query(
     "select case when count(a) > 0 then true else false end " +
@@ -81,4 +85,17 @@ interface AllocationRepository : JpaRepository<Allocation, Long> {
     prisonerNumber: String,
     prisonerStatus: Collection<PrisonerStatus>,
   ): Boolean
+
+  @Query(
+    value =
+    "FROM Allocation a " +
+      "WHERE a.prisonerStatus = :prisonerStatus " +
+      "  AND a.startDate <=  :startDate " +
+      "  AND a.activitySchedule.activity.prisonCode = :prisonCode",
+  )
+  fun findByPrisonCodePrisonerStatusStartingOnOrBeforeDate(
+    prisonCode: String,
+    prisonerStatus: PrisonerStatus,
+    startDate: LocalDate,
+  ): List<Allocation>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
@@ -110,7 +110,7 @@ class ActivitiesChangedEventHandler(
     filterNot { it.prisonerStatus == PrisonerStatus.PENDING && it.startDate.isAfter(LocalDate.now()) }
 
   private fun List<Allocation>.suspendPrisonersAllocations(suspendedAt: LocalDateTime, event: ActivitiesChangedEvent) =
-    onEach { it.autoSuspend(suspendedAt, "Temporary absence") }
+    onEach { it.autoSuspend(suspendedAt, "Temporarily released or transferred") }
       .also { log.info("Suspended ${it.size} allocations for prisoner ${event.prisonerNumber()} at prison ${event.prisonCode()}.") }
 
   private fun List<Allocation>.suspendPrisonersFutureAttendances(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.containsExactly
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.internalLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.movement
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.wiremock.PrisonApiMockServer
@@ -577,18 +578,18 @@ class PrisonApiClientTest {
   @Test
   fun `getLatestMovementForPrisoners - success when movement found`() {
     val movement = movement(prisonerNumber = "AB1235C")
-    prisonApiMockServer.stubLatestPrisonerMovements(listOf("AB1235C"), listOf(movement))
-    prisonApiClient.getLatestMovementForPrisoners(setOf("AB1235C")) containsExactly listOf(movement)
+    prisonApiMockServer.stubPrisonerMovements(listOf("AB1235C"), listOf(movement))
+    prisonApiClient.getMovementsForPrisonersFromPrison(moorlandPrisonCode, setOf("AB1235C")) containsExactly listOf(movement)
   }
 
   @Test
   fun `getLatestMovementForPrisoners - empty when no movement found`() {
-    prisonApiMockServer.stubLatestPrisonerMovements(listOf("AB1235C"), emptyList())
-    prisonApiClient.getLatestMovementForPrisoners(setOf("AB1235C")) containsExactly emptyList()
+    prisonApiMockServer.stubPrisonerMovements(listOf("AB1235C"), emptyList())
+    prisonApiClient.getMovementsForPrisonersFromPrison(moorlandPrisonCode, setOf("AB1235C")) containsExactly emptyList()
   }
 
   @Test
   fun `getLatestMovementForPrisoners - empty when no prisoners supplied`() {
-    prisonApiClient.getLatestMovementForPrisoners(emptySet()) containsExactly emptyList()
+    prisonApiClient.getMovementsForPrisonersFromPrison(moorlandPrisonCode, emptySet()) containsExactly emptyList()
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExtTest.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSou
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import java.time.LocalDate
 
 class PrisonerExtTest {
@@ -73,5 +74,23 @@ class PrisonerExtTest {
 
     activeInPrisoner.status isEqualTo "ACTIVE IN"
     activeInPrisoner.isActiveIn() isBool true
+  }
+
+  @Test
+  fun `is at different location`() {
+    val activeInPrisoner = Prisoner(
+      prisonerNumber = "1",
+      firstName = "Freddie",
+      lastName = "Bloggs",
+      dateOfBirth = LocalDate.EPOCH,
+      gender = "Female",
+      status = "ACTIVE IN",
+      prisonId = moorlandPrisonCode,
+      confirmedReleaseDate = null,
+    )
+
+    activeInPrisoner.isAtDifferentLocationTo(pentonvillePrisonCode) isBool true
+    activeInPrisoner.copy(prisonId = null).isAtDifferentLocationTo(pentonvillePrisonCode) isBool true
+    activeInPrisoner.isAtDifferentLocationTo(moorlandPrisonCode) isBool false
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/Assertions.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/Assertions.kt
@@ -25,6 +25,10 @@ internal infix fun <T> Collection<T>.hasSize(size: Int) {
   assertThat(this).hasSize(size)
 }
 
+internal inline infix fun <reified T> Collection<T>.containsExactly(value: Collection<T>) {
+  assertThat(this).containsExactly(*value.toTypedArray())
+}
+
 internal infix fun String.startsWith(prefix: String) {
   assertThat(this).startsWith(prefix)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
@@ -2,13 +2,16 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers
 
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.CaseLoad
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Movement
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.OffenderAdjudicationHearing
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.PrisonerSchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.UserDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toIsoDateTime
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toIsoTime
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 
 fun userDetail(
   id: Long = 1,
@@ -53,7 +56,12 @@ fun internalLocation(
     userDescription = userDescription,
   )
 
-fun appointmentLocation(locationId: Long, prisonCode: String, description: String = "Test Appointment Location", userDescription: String = "Test Appointment Location User Description") =
+fun appointmentLocation(
+  locationId: Long,
+  prisonCode: String,
+  description: String = "Test Appointment Location",
+  userDescription: String = "Test Appointment Location User Description",
+) =
   Location(
     locationId = locationId,
     locationType = "APP",
@@ -124,4 +132,27 @@ fun adjudicationHearing(
     internalLocationId = internalLocationId,
     internalLocationDescription = internalLocationDescription,
     eventStatus = eventStatus,
+  )
+
+fun movement(
+  prisonerNumber: String = "A1179MT",
+  movementDate: LocalDate = LocalDate.now(),
+  movementTime: LocalTime = LocalTime.now(),
+  movementType: Movement.MovementType = Movement.MovementType.TRN
+) =
+  Movement(
+    offenderNo = prisonerNumber,
+    createDateTime = TimeSource.now().toIsoDateTime(),
+    fromAgency = "MDI",
+    fromAgencyDescription = "Moorland",
+    toAgency = "OUT",
+    toAgencyDescription = "Outside",
+    fromCity = "",
+    toCity = "",
+    movementType = movementType,
+    movementTypeDescription = movementType.value,
+    directionCode = "OUT",
+    movementDate = movementDate,
+    movementTime = movementTime.toIsoTime(),
+    movementReason = "Abscond",
   )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
@@ -136,6 +136,7 @@ fun adjudicationHearing(
 
 fun movement(
   prisonerNumber: String = "A1179MT",
+  fromPrisonCode: String = moorlandPrisonCode,
   movementDate: LocalDate = LocalDate.now(),
   movementTime: LocalTime = LocalTime.now(),
   movementType: Movement.MovementType = Movement.MovementType.TRN,
@@ -143,7 +144,7 @@ fun movement(
   Movement(
     offenderNo = prisonerNumber,
     createDateTime = TimeSource.now().toIsoDateTime(),
-    fromAgency = "MDI",
+    fromAgency = fromPrisonCode,
     fromAgencyDescription = "Moorland",
     toAgency = "OUT",
     toAgencyDescription = "Outside",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/PrisonApiFactory.kt
@@ -138,7 +138,7 @@ fun movement(
   prisonerNumber: String = "A1179MT",
   movementDate: LocalDate = LocalDate.now(),
   movementTime: LocalTime = LocalTime.now(),
-  movementType: Movement.MovementType = Movement.MovementType.TRN
+  movementType: Movement.MovementType = Movement.MovementType.TRN,
 ) =
   Movement(
     offenderNo = prisonerNumber,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/TimeSource.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/TimeSource.kt
@@ -11,4 +11,6 @@ object TimeSource {
   fun yesterday(): LocalDate = today().minusDays(1)
 
   fun tomorrow(): LocalDate = today().plusDays(1)
+
+  fun daysInPast(days: Long): LocalDate = today().minusDays(days)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -480,7 +480,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
 
     allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "A11111A").onEach {
       assertThat(it.status(PrisonerStatus.AUTO_SUSPENDED))
-      assertThat(it.suspendedReason).isEqualTo("Temporary absence")
+      assertThat(it.suspendedReason).isEqualTo("Temporarily released or transferred")
       assertThat(it.suspendedTime).isCloseTo(LocalDateTime.now(), within(10, ChronoUnit.SECONDS))
       assertThat(it.suspendedBy).isEqualTo("Activities Management Service")
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -147,12 +147,12 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:test_data/seed-allocations-pending.sql")
   @Test
   fun `pending allocations on or before today are activated when prisoners are in prison`() {
-    listOf("PAST", "TODAY", "FUTURE").forEach { prisonerNumber ->
+    listOf("PAST", "TODAY", "FUTURE").map { prisonerNumber ->
       PrisonerSearchPrisonerFixture.instance(
         prisonerNumber = prisonerNumber,
         inOutStatus = Prisoner.InOutStatus.IN,
-      ).also { prisonerSearchApiMockServer.stubSearchByPrisonerNumber(it) }
-    }
+      )
+    }.also { prisoners -> prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(listOf("PAST", "TODAY"), prisoners) }
 
     with(allocationRepository.findAll()) {
       size isEqualTo 3
@@ -177,12 +177,12 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:test_data/seed-allocations-pending.sql")
   @Test
   fun `pending allocations on or before today are suspended when prisoners are out of prison`() {
-    listOf("PAST", "TODAY", "FUTURE").forEach { prisonerNumber ->
+    listOf("PAST", "TODAY").map { prisonerNumber ->
       PrisonerSearchPrisonerFixture.instance(
         prisonerNumber = prisonerNumber,
         inOutStatus = Prisoner.InOutStatus.OUT,
-      ).also { prisonerSearchApiMockServer.stubSearchByPrisonerNumber(it) }
-    }
+      )
+    }.also { prisoners -> prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(listOf("PAST", "TODAY"), prisoners) }
 
     with(allocationRepository.findAll()) {
       size isEqualTo 3

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.springframework.beans.factory.annotation.Autowired

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -31,6 +31,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.movement
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.WaitingListRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSearchPrisonerFixture
@@ -120,9 +121,9 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
     }
 
     prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(listOf("A11111A"), listOf(prisoner))
-    prisonApiMockServer.stubLatestPrisonerMovements(
+    prisonApiMockServer.stubPrisonerMovements(
       listOf("A11111A"),
-      listOf(movement("A11111A", movementDate = TimeSource.daysInPast(10))),
+      listOf(movement("A11111A", fromPrisonCode = pentonvillePrisonCode, movementDate = TimeSource.daysInPast(10))),
     )
 
     with(allocationRepository.findAll()) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -15,7 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason.ENDED
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason.EXPIRED
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason.TEMPORARILY_RELEASED
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus.ACTIVE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus.AUTO_SUSPENDED
@@ -139,7 +139,7 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
 
     val expiredAllocations = allocationRepository.findAll().also { it hasSize 2 }
 
-    expiredAllocations.forEach { allocation -> allocation isDeallocatedWithReason EXPIRED }
+    expiredAllocations.forEach { allocation -> allocation isDeallocatedWithReason TEMPORARILY_RELEASED }
 
     waitingListRepository.findAll().prisoner("A11111A") isDeclinedWithReason "Released"
   }
@@ -217,7 +217,8 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
 
   private fun List<Allocation>.prisoner(number: String) = single { it.prisonerNumber == number }
 
-  private fun List<Allocation>.prisonerAllocation(prisonerStatus: PrisonerStatus) = single { it.prisonerStatus == prisonerStatus }
+  private fun List<Allocation>.prisonerAllocation(prisonerStatus: PrisonerStatus) =
+    single { it.prisonerStatus == prisonerStatus }
 
   private fun List<WaitingList>.prisoner(number: String) = single { it.prisonerNumber == number }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.springframework.beans.factory.annotation.Autowired
@@ -25,9 +26,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingL
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingListStatus.DECLINED
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingListStatus.REMOVED
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.movement
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.WaitingListRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSearchPrisonerFixture
@@ -117,18 +120,27 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
     }
 
     prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(listOf("A11111A"), listOf(prisoner))
+    prisonApiMockServer.stubLatestPrisonerMovements(
+      listOf("A11111A"),
+      listOf(movement("A11111A", movementDate = TimeSource.daysInPast(10))),
+    )
 
     with(allocationRepository.findAll()) {
-      size isEqualTo 1
-      prisoner("A11111A") isStatus AUTO_SUSPENDED
+      this hasSize 2
+      prisonerAllocation(AUTO_SUSPENDED).prisonerNumber isEqualTo "A11111A"
+      prisonerAllocation(PENDING).prisonerNumber isEqualTo "A11111A"
     }
 
     webTestClient.manageAllocations(withDeallocate = true)
 
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, 1L)
+    verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, 2L)
     verifyNoMoreInteractions(outboundEventsService)
 
-    allocationRepository.findAll().prisoner("A11111A") isDeallocatedWithReason EXPIRED
+    val expiredAllocations = allocationRepository.findAll().also { it hasSize 2 }
+
+    expiredAllocations.forEach { allocation -> allocation isDeallocatedWithReason EXPIRED }
+
     waitingListRepository.findAll().prisoner("A11111A") isDeclinedWithReason "Released"
   }
 
@@ -204,6 +216,8 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
   }
 
   private fun List<Allocation>.prisoner(number: String) = single { it.prisonerNumber == number }
+
+  private fun List<Allocation>.prisonerAllocation(prisonerStatus: PrisonerStatus) = single { it.prisonerStatus == prisonerStatus }
 
   private fun List<WaitingList>.prisoner(number: String) = single { it.prisonerNumber == number }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -499,9 +499,9 @@ class PrisonApiMockServer : WireMockServer(8999) {
     )
   }
 
-  fun stubLatestPrisonerMovements(prisonerNumbers: List<String>, movements: List<Movement>) {
+  fun stubPrisonerMovements(prisonerNumbers: List<String>, movements: List<Movement>) {
     stubFor(
-      WireMock.post(WireMock.urlEqualTo("/api/movements/offenders?latestOnly=true"))
+      WireMock.post(WireMock.urlEqualTo("/api/movements/offenders"))
         .withRequestBody(equalToJson(mapper.writeValueAsString(prisonerNumbers)))
         .willReturn(
           WireMock.aResponse()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -285,12 +285,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetLocation(locationId: Long, jsonResponseFile: String, includeInactive: Boolean? = null) {
     stubFor(
-      WireMock.get(
-        WireMock.urlEqualTo(
-          "/api/locations/$locationId" + (includeInactive?.let { "?includeInactive=$includeInactive" }
-            ?: ""),
-        ),
-      )
+      WireMock.get(WireMock.urlEqualTo("/api/locations/$locationId" + (includeInactive?.let { "?includeInactive=$includeInactive" } ?: "")))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -302,12 +297,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubGetLocation(locationId: Long, location: Location, includeInactive: Boolean? = null) {
     stubFor(
-      WireMock.get(
-        WireMock.urlEqualTo(
-          "/api/locations/$locationId" + (includeInactive?.let { "?includeInactive=$includeInactive" }
-            ?: ""),
-        ),
-      )
+      WireMock.get(WireMock.urlEqualTo("/api/locations/$locationId" + (includeInactive?.let { "?includeInactive=$includeInactive" } ?: "")))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -74,4 +74,16 @@ class PrisonerSearchApiMockServer : WireMockServer(8111) {
         ),
     )
   }
+
+  fun stubSearchByPrisonerNumber(prisoner: Prisoner) {
+    stubFor(
+      WireMock.get(WireMock.urlEqualTo("/prisoner/${prisoner.prisonerNumber}"))
+        .willReturn(
+          WireMock.aResponse()
+            .withHeader("Content-Type", "application/json")
+            .withBody(mapper.writeValueAsString(prisoner))
+            .withStatus(200),
+        ),
+    )
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -33,8 +33,8 @@ class ManageAllocationsJobTest {
   fun `deallocate allocation operation triggered`() {
     job.execute(withDeallocate = true)
 
-    verify(deallocationService).allocations(AllocationOperation.DEALLOCATE_ENDING)
-    verify(deallocationService).allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    verify(deallocationService).allocations(AllocationOperation.ENDING_TODAY)
+    verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
     verify(safeJobRunner, times(2)).runJob(jobDefinitionCaptor.capture())
 
     assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.DEALLOCATE_ENDING)
@@ -46,8 +46,8 @@ class ManageAllocationsJobTest {
     job.execute(withActivate = true, withDeallocate = true)
 
     verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
-    verify(deallocationService).allocations(AllocationOperation.DEALLOCATE_ENDING)
-    verify(deallocationService).allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    verify(deallocationService).allocations(AllocationOperation.ENDING_TODAY)
+    verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
     verify(safeJobRunner, times(3)).runJob(jobDefinitionCaptor.capture())
 
     assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.ALLOCATE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
@@ -8,19 +8,17 @@ import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
-import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiApplicationClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.MovementType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
@@ -71,7 +69,7 @@ class ManageAllocationsServiceTest {
     whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
     whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
 
-    service.allocations(AllocationOperation.DEALLOCATE_ENDING)
+    service.allocations(AllocationOperation.ENDING_TODAY)
 
     allocation.verifyIsEnded()
 
@@ -86,7 +84,7 @@ class ManageAllocationsServiceTest {
     whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
     whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
 
-    service.allocations(AllocationOperation.DEALLOCATE_ENDING)
+    service.allocations(AllocationOperation.ENDING_TODAY)
 
     verify(waitingListService).declinePendingOrApprovedApplications(
       activity.activityId,
@@ -106,7 +104,7 @@ class ManageAllocationsServiceTest {
     whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
     whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
 
-    service.allocations(AllocationOperation.DEALLOCATE_ENDING)
+    service.allocations(AllocationOperation.ENDING_TODAY)
 
     allocation.verifyIsEnded(DeallocationReason.OTHER, "by test")
 
@@ -123,7 +121,7 @@ class ManageAllocationsServiceTest {
     whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
     whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
 
-    service.allocations(AllocationOperation.DEALLOCATE_ENDING)
+    service.allocations(AllocationOperation.ENDING_TODAY)
 
     allocation.verifyIsEnded()
 
@@ -141,7 +139,7 @@ class ManageAllocationsServiceTest {
     whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
     whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
 
-    service.allocations(AllocationOperation.DEALLOCATE_ENDING)
+    service.allocations(AllocationOperation.ENDING_TODAY)
 
     allocation.verifyIsActive()
 
@@ -160,7 +158,7 @@ class ManageAllocationsServiceTest {
     whenever(activityRepo.getAllForPrisonAndDate(pentonville.code, today)).thenReturn(listOf(pentonvilleActivity))
     whenever(activityRepo.getAllForPrisonAndDate(moorland.code, today)).thenReturn(listOf(moorlandActivity))
 
-    service.allocations(AllocationOperation.DEALLOCATE_ENDING)
+    service.allocations(AllocationOperation.ENDING_TODAY)
 
     listOf(pentonvilleActivity, moorlandActivity).onEach { activity ->
       with(activity) {
@@ -181,7 +179,7 @@ class ManageAllocationsServiceTest {
     whenever(activityRepo.getAllForPrisonAndDate(pentonville.code, today)).thenReturn(listOf(pentonvilleActivity))
     whenever(activityRepo.getAllForPrisonAndDate(moorland.code, today)).thenReturn(listOf(moorlandActivity))
 
-    service.allocations(AllocationOperation.DEALLOCATE_ENDING)
+    service.allocations(AllocationOperation.ENDING_TODAY)
 
     verify(waitingListService).declinePendingOrApprovedApplications(
       pentonvilleActivity.activityId,
@@ -214,7 +212,7 @@ class ManageAllocationsServiceTest {
     )
     whenever(searchApiClient.findByPrisonerNumbers(listOf(prisoner.prisonerNumber))).doReturn(Mono.just(listOf(prisoner)))
 
-    service.allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    service.allocations(AllocationOperation.EXPIRING_TODAY)
 
     allocation.verifyIsExpired()
 
@@ -240,7 +238,7 @@ class ManageAllocationsServiceTest {
     )
     whenever(searchApiClient.findByPrisonerNumbers(listOf(prisoner.prisonerNumber))).doReturn(Mono.just(listOf(prisoner)))
 
-    service.allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    service.allocations(AllocationOperation.EXPIRING_TODAY)
 
     allocation.verifyIsExpired()
 
@@ -267,7 +265,7 @@ class ManageAllocationsServiceTest {
     )
     whenever(searchApiClient.findByPrisonerNumbers(listOf(prisoner.prisonerNumber))).doReturn(Mono.just(listOf(prisoner)))
 
-    service.allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    service.allocations(AllocationOperation.EXPIRING_TODAY)
 
     allocation.verifyIsExpired()
 
@@ -294,7 +292,7 @@ class ManageAllocationsServiceTest {
     )
     whenever(searchApiClient.findByPrisonerNumbers(listOf(prisoner.prisonerNumber))).doReturn(Mono.just(listOf(prisoner)))
 
-    service.allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    service.allocations(AllocationOperation.EXPIRING_TODAY)
 
     verify(waitingListService).declinePendingOrApprovedApplications(
       prison.code,
@@ -331,7 +329,7 @@ class ManageAllocationsServiceTest {
     )
     whenever(searchApiClient.findByPrisonerNumbers(listOf(prisoner.prisonerNumber))).doReturn(Mono.just(listOf(prisoner)))
 
-    service.allocations(AllocationOperation.DEALLOCATE_EXPIRING)
+    service.allocations(AllocationOperation.EXPIRING_TODAY)
 
     allocation.verifyIsExpired()
 
@@ -344,50 +342,125 @@ class ManageAllocationsServiceTest {
       whenever(rolloutPrisonRepo.findAll()) doReturn listOf(it)
     }
 
-    val pendingAllocationYesterday: Allocation = mock {
-      on { prisonerStatus } doReturn PrisonerStatus.PENDING
-      on { startDate } doReturn TimeSource.yesterday()
+    val pendingAllocationYesterday: Allocation = allocation().copy(
+      allocationId = 1,
+      prisonerNumber = "1",
+      startDate = TimeSource.yesterday(),
+      prisonerStatus = PrisonerStatus.PENDING,
+    ).also {
+      whenever(searchApiClient.findByPrisonerNumber(it.prisonerNumber)) doReturn prisoner(it, Prisoner.InOutStatus.IN)
     }
 
-    val pendingAllocationToday: Allocation = mock {
-      on { prisonerStatus } doReturn PrisonerStatus.PENDING
-      on { startDate } doReturn TimeSource.today()
+    val pendingAllocationToday: Allocation = allocation().copy(
+      allocationId = 2,
+      prisonerNumber = "2",
+      startDate = TimeSource.today(),
+      prisonerStatus = PrisonerStatus.PENDING,
+    ).also {
+      whenever(searchApiClient.findByPrisonerNumber(it.prisonerNumber)) doReturn prisoner(it, Prisoner.InOutStatus.IN)
     }
 
-    val pendingAllocationTomorrow: Allocation = mock {
-      on { prisonerStatus } doReturn PrisonerStatus.PENDING
-      on { startDate } doReturn TimeSource.tomorrow()
-    }
+    whenever(
+      allocationRepository.findByPrisonCodePrisonerStatusStartingOnOrBeforeDate(
+        prison.code,
+        PrisonerStatus.PENDING,
+        TimeSource.today(),
+      ),
+    ) doReturn listOf(pendingAllocationYesterday, pendingAllocationToday)
 
-    val activeAllocation: Allocation = mock {
-      on { prisonerStatus } doReturn PrisonerStatus.ACTIVE
-      on { startDate } doReturn TimeSource.yesterday()
-    }
-
-    val allocations = listOf(pendingAllocationYesterday, pendingAllocationToday, pendingAllocationTomorrow, activeAllocation)
-
-    val schedule: ActivitySchedule = mock {
-      on { allocations() } doReturn allocations
-    }
-
-    mock<Activity> {
-      on { schedules() } doReturn listOf(schedule)
-    }.also {
-      whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())) doReturn listOf(it)
-    }
+    pendingAllocationYesterday.prisonerStatus isEqualTo PrisonerStatus.PENDING
+    pendingAllocationToday.prisonerStatus isEqualTo PrisonerStatus.PENDING
 
     service.allocations(AllocationOperation.STARTING_TODAY)
 
-    verify(pendingAllocationYesterday).activate()
-    verify(pendingAllocationToday).activate()
-    verify(pendingAllocationTomorrow, never()).activate()
-    verify(activeAllocation, never()).activate()
+    pendingAllocationYesterday.prisonerStatus isEqualTo PrisonerStatus.ACTIVE
+    pendingAllocationToday.prisonerStatus isEqualTo PrisonerStatus.ACTIVE
 
-    verify(allocationRepository).saveAllAndFlush(listOf(pendingAllocationYesterday, pendingAllocationToday))
-    verifyNoMoreInteractions(allocationRepository)
-
-    allocations.forEach { verify(it).startDate }
+    verify(allocationRepository).saveAndFlush(pendingAllocationYesterday)
+    verify(allocationRepository).saveAndFlush(pendingAllocationToday)
   }
+
+  @Test
+  fun `pending allocations on or before today are auto-suspended when prisoner is out of prison`() {
+    val prison = rolloutPrison().also {
+      whenever(rolloutPrisonRepo.findAll()) doReturn listOf(it)
+    }
+
+    val pendingAllocationYesterday: Allocation = allocation().copy(
+      allocationId = 1,
+      prisonerNumber = "1",
+      startDate = TimeSource.yesterday(),
+      prisonerStatus = PrisonerStatus.PENDING,
+    ).also {
+      whenever(searchApiClient.findByPrisonerNumber(it.prisonerNumber)) doReturn prisoner(it, Prisoner.InOutStatus.OUT)
+    }
+
+    val pendingAllocationToday: Allocation = allocation().copy(
+      allocationId = 2,
+      prisonerNumber = "2",
+      startDate = TimeSource.today(),
+      prisonerStatus = PrisonerStatus.PENDING,
+    ).also {
+      whenever(searchApiClient.findByPrisonerNumber(it.prisonerNumber)) doReturn prisoner(it, Prisoner.InOutStatus.OUT)
+    }
+
+    whenever(
+      allocationRepository.findByPrisonCodePrisonerStatusStartingOnOrBeforeDate(
+        prison.code,
+        PrisonerStatus.PENDING,
+        TimeSource.today(),
+      ),
+    ) doReturn listOf(pendingAllocationYesterday, pendingAllocationToday)
+
+    pendingAllocationYesterday.prisonerStatus isEqualTo PrisonerStatus.PENDING
+    pendingAllocationToday.prisonerStatus isEqualTo PrisonerStatus.PENDING
+
+    service.allocations(AllocationOperation.STARTING_TODAY)
+
+    listOf(pendingAllocationYesterday, pendingAllocationToday).forEach { allocation ->
+      allocation.prisonerStatus isEqualTo PrisonerStatus.AUTO_SUSPENDED
+      allocation.suspendedReason isEqualTo "Temporarily released or transferred"
+      allocation.suspendedTime isCloseTo TimeSource.now()
+    }
+
+    verify(allocationRepository).saveAndFlush(pendingAllocationYesterday)
+    verify(allocationRepository).saveAndFlush(pendingAllocationToday)
+  }
+
+  @Test
+  fun `pending allocation not processed when prisoner not found`() {
+    val prison = rolloutPrison().also {
+      whenever(rolloutPrisonRepo.findAll()) doReturn listOf(it)
+    }
+
+    val pendingAllocation: Allocation = allocation().copy(
+      allocationId = 1,
+      prisonerNumber = "1",
+      startDate = TimeSource.yesterday(),
+      prisonerStatus = PrisonerStatus.PENDING,
+    ).also {
+      whenever(searchApiClient.findByPrisonerNumber(it.prisonerNumber)) doReturn null
+    }
+
+    whenever(
+      allocationRepository.findByPrisonCodePrisonerStatusStartingOnOrBeforeDate(
+        prison.code,
+        PrisonerStatus.PENDING,
+        TimeSource.today(),
+      ),
+    ) doReturn listOf(pendingAllocation)
+
+    pendingAllocation.prisonerStatus isEqualTo PrisonerStatus.PENDING
+
+    service.allocations(AllocationOperation.STARTING_TODAY)
+
+    pendingAllocation.prisonerStatus isEqualTo PrisonerStatus.PENDING
+
+    verify(allocationRepository, never()).saveAndFlush(pendingAllocation)
+  }
+
+  private fun prisoner(allocation: Allocation, status: Prisoner.InOutStatus): Prisoner =
+    PrisonerSearchPrisonerFixture.instance(prisonerNumber = allocation.prisonerNumber, inOutStatus = status)
 
   private fun Allocation.verifyIsActive() {
     prisonerStatus isEqualTo PrisonerStatus.ACTIVE

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
@@ -392,18 +392,16 @@ class ManageAllocationsServiceTest {
       prisonerNumber = "1",
       startDate = TimeSource.yesterday(),
       prisonerStatus = PrisonerStatus.PENDING,
-    ).also {
-      whenever(searchApiClient.findByPrisonerNumber(it.prisonerNumber)) doReturn prisoner(it, Prisoner.InOutStatus.IN)
-    }
+    )
 
     val pendingAllocationToday: Allocation = allocation().copy(
       allocationId = 2,
       prisonerNumber = "2",
       startDate = TimeSource.today(),
       prisonerStatus = PrisonerStatus.PENDING,
-    ).also {
-      whenever(searchApiClient.findByPrisonerNumber(it.prisonerNumber)) doReturn prisoner(it, Prisoner.InOutStatus.IN)
-    }
+    )
+
+    whenever(searchApiClient.findByPrisonerNumbers(listOf("1", "2"))) doReturn Mono.just(listOf(prisoner(pendingAllocationYesterday, Prisoner.InOutStatus.IN), prisoner(pendingAllocationToday, Prisoner.InOutStatus.IN)))
 
     whenever(
       allocationRepository.findByPrisonCodePrisonerStatusStartingOnOrBeforeDate(
@@ -436,18 +434,16 @@ class ManageAllocationsServiceTest {
       prisonerNumber = "1",
       startDate = TimeSource.yesterday(),
       prisonerStatus = PrisonerStatus.PENDING,
-    ).also {
-      whenever(searchApiClient.findByPrisonerNumber(it.prisonerNumber)) doReturn prisoner(it, Prisoner.InOutStatus.OUT)
-    }
+    )
 
     val pendingAllocationToday: Allocation = allocation().copy(
       allocationId = 2,
       prisonerNumber = "2",
       startDate = TimeSource.today(),
       prisonerStatus = PrisonerStatus.PENDING,
-    ).also {
-      whenever(searchApiClient.findByPrisonerNumber(it.prisonerNumber)) doReturn prisoner(it, Prisoner.InOutStatus.OUT)
-    }
+    )
+
+    whenever(searchApiClient.findByPrisonerNumbers(listOf("1", "2"))) doReturn Mono.just(listOf(prisoner(pendingAllocationYesterday, Prisoner.InOutStatus.OUT), prisoner(pendingAllocationToday, Prisoner.InOutStatus.OUT)))
 
     whenever(
       allocationRepository.findByPrisonCodePrisonerStatusStartingOnOrBeforeDate(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandlerTest.kt
@@ -131,7 +131,7 @@ class ActivitiesChangedEventHandlerTest {
     allocations.subList(0, 2).forEach {
       it.prisonerStatus isEqualTo PrisonerStatus.AUTO_SUSPENDED
       it.suspendedBy isEqualTo "Activities Management Service"
-      it.suspendedReason isEqualTo "Temporary absence"
+      it.suspendedReason isEqualTo "Temporarily released or transferred"
       it.suspendedTime isCloseTo TimeSource.now()
     }
 

--- a/src/test/resources/test_data/seed-allocations-due-to-expire.sql
+++ b/src/test/resources/test_data/seed-allocations-due-to-expire.sql
@@ -25,5 +25,8 @@ values (2, 2, 'English AM', 1, 'L1', 'Location 1', 10, current_date - 1, null);
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (1, 1, 'A11111A', 10001, 1, current_date - 10, null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, current_timestamp - 5, 'Activities Management Service', 'Temporarily released from prison', 'AUTO_SUSPENDED');
 
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (2, 2, 'A11111A', 10001, 1, current_date + 1, null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'PENDING');
+
 insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
 values (1, 'PVI', 'A11111A', 10001, '2023-06-23', 2, 2, 'Fred Bloggs', 'PENDING', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);


### PR DESCRIPTION
**DO NOT MERGE**

The jobs for allocation activation and ending now has to consider whether pending allocations should be started/suspend/ended depending on the prisoners active status and/or location in relation to when the allocation was made.  As part of this we also now look at their latest last move based on them being out or their current prison or in at at a different prison.  If they have been out of the prison the allocation was made for more days than is allowed based on the max days out in the prison regime config then the allocation(s) will be ended.