### PR TITLE
SAA-1278 record activities change event as event of interest when can not determine the release. Should not throw an exception.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/ActivitiesChangedEventHandler.kt
@@ -114,7 +114,10 @@ class ActivitiesChangedEventHandler(
       when {
         prisoner.isTemporarilyReleased() -> DeallocationReason.TEMPORARILY_RELEASED
         prisoner.isPermanentlyReleased() -> DeallocationReason.RELEASED
-        else -> throw IllegalStateException("Unable to determine release reason for prisoner ${event.prisonerNumber()}")
+        else -> {
+          log.warn("Unable to determine release reason for prisoner ${event.prisonerNumber()}, prisoner status ${prisoner.status}, at prison ${prisoner.prisonId} for event $event")
+          null
+        }
       }
     }
 }


### PR DESCRIPTION
Because an exception was being thrown the event is not being recorded as an event of interest.  It should be recorded as an event of interest so the prison can deal with it instead.

Note this is partial fix.  There is a problem with the logic for determining the actual release reason by the looks of it.