### PR TITLE
SAA-1280: Adding a landing 3 to Wing R in the location mapping file.

### DIFF
--- a/src/main/resources/whereabouts/patterns/RSI.properties
+++ b/src/main/resources/whereabouts/patterns/RSI.properties
@@ -54,4 +54,5 @@ RSI_G-Wing_South\ Landing\ 3=RSI-G-3-.+S+
 RSI_R-Wing=RSI-R-.+
 RSI_R-Wing_Landing\ 1=RSI-R-1-.+
 RSI_R-Wing_Landing\ 2=RSI-R-2-.+
+RSI_R-Wing_Landing\ 3=RSI-R-3-.+
 RSI_CSU=RSI-S-.+


### PR DESCRIPTION
This was not present in Whereabouts location mappings either, so is either a new set of cells or the wing was not previously using the Whereabouts unlock lists.