### PR TITLE
SAA-1294 fixes issue whereby checking we have any alloctions of interest before taking any further action in events, if no allocations then should ignore event.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AllocationRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AllocationRepository.kt
@@ -34,7 +34,11 @@ interface AllocationRepository : JpaRepository<Allocation, Long> {
       "  AND a.prisonerStatus IN (:prisonerStatus) " +
       "  AND a.activitySchedule.activity.prisonCode = :prisonCode",
   )
-  fun findByPrisonCodePrisonerNumberPrisonerStatus(prisonCode: String, prisonerNumber: String, vararg prisonerStatus: PrisonerStatus): List<Allocation>
+  fun findByPrisonCodePrisonerNumberPrisonerStatus(
+    prisonCode: String,
+    prisonerNumber: String,
+    vararg prisonerStatus: PrisonerStatus,
+  ): List<Allocation>
 
   @Query(
     value =
@@ -64,4 +68,17 @@ interface AllocationRepository : JpaRepository<Allocation, Long> {
       """,
   )
   fun findBookingAllocationCountsByPrisonAndPrisonerStatus(prisonCode: String, prisonerStatus: PrisonerStatus): List<BookingCount>
+
+  @Query(
+    "select case when count(a) > 0 then true else false end " +
+      "from Allocation a " +
+      "where a.activitySchedule.activity.prisonCode = :prisonCode " +
+      "and a.prisonerNumber = :prisonerNumber " +
+      "and a.prisonerStatus IN (:prisonerStatus)",
+  )
+  fun existAtPrisonForPrisoner(
+    prisonCode: String,
+    prisonerNumber: String,
+    prisonerStatus: Collection<PrisonerStatus>,
+  ): Boolean
 }


### PR DESCRIPTION
The activities changed event and prisoner release event both have the same issue of looking up prisoner details in external API's before checking we actually have any allocations of interest.

If there are no allocations of interest then it should not even bother looking up in the externals API's.

This fix resolves that issue.