### PR TITLE
SAA-1322 when we receive an END in an activities change event we should always end allocations if there are any.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/PrisonerAllocationHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/PrisonerAllocationHandlerTest.kt
@@ -65,12 +65,12 @@ class PrisonerAllocationHandlerTest {
       ),
     ) doReturn previouslyActiveAllocations.plus(pendingAllocation)
 
-    handler.deallocate(moorlandPrisonCode, "123456", DeallocationReason.RELEASED)
+    handler.deallocate(moorlandPrisonCode, "123456", DeallocationReason.TEMPORARILY_RELEASED)
 
     previouslyActiveAllocations.forEach {
       assertThat(it.status(PrisonerStatus.ENDED)).isTrue
       assertThat(it.deallocatedBy).isEqualTo("Activities Management Service")
-      assertThat(it.deallocatedReason).isEqualTo(DeallocationReason.RELEASED)
+      assertThat(it.deallocatedReason).isEqualTo(DeallocationReason.TEMPORARILY_RELEASED)
       assertThat(it.deallocatedTime)
         .isCloseTo(LocalDateTime.now(), Assertions.within(60, ChronoUnit.SECONDS))
     }
@@ -78,7 +78,7 @@ class PrisonerAllocationHandlerTest {
     verify(waitingListService).declinePendingOrApprovedApplications(
       moorlandPrisonCode,
       "123456",
-      "Released",
+      "Temporarily released or transferred",
       "Activities Management Service",
     )
   }
@@ -117,7 +117,7 @@ class PrisonerAllocationHandlerTest {
     verify(waitingListService).declinePendingOrApprovedApplications(
       moorlandPrisonCode,
       "123456",
-      "Released",
+      "Released from prison",
       "Activities Management Service",
     )
   }
@@ -146,7 +146,7 @@ class PrisonerAllocationHandlerTest {
     verify(waitingListService).declinePendingOrApprovedApplications(
       moorlandPrisonCode,
       "123456",
-      "Released",
+      "Released from prison",
       "Activities Management Service",
     )
   }


### PR DESCRIPTION
This is different to AC 6 on the parent ticket [here](https://dsdmoj.atlassian.net/browse/SAA-1311).

Not ending a prisoners allocations when a user has explicitly chosen to END is having ramifications in production.  Allocations are not always being ended even though prisoners have left the prison. Messages are getting stuck on DLQ's as well causing alerts.

The rules with regards to determining a release/deallocation reason have been relaxed also.  Our recording of a deallocation reason should not stop allocations from being ended.