### PR TITLE
SAA-1325 jobs should throw runtime exception on safe job failure to ensure alerts get propagated accordingly.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
@@ -2,21 +2,24 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Job
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 
 @Component
-class SafeJobRunner(private val jobRepository: JobRepository) {
+@Transactional
+class SafeJobRunner(private val jobRepository: JobRepository, private val transactionHandler: TransactionHandler) {
 
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
   fun runJob(jobDefinition: JobDefinition) {
-    runSafe(jobDefinition)
+    runSafe(jobDefinition).onFailure { throw RuntimeException("Failure occurred running job ${jobDefinition.jobType}") }
   }
 
   /**
@@ -26,20 +29,26 @@ class SafeJobRunner(private val jobRepository: JobRepository) {
    */
   fun runDependentJobs(vararg jobDefinitions: JobDefinition) {
     val success = AtomicBoolean(true)
+    var failedJob: JobDefinition? = null
 
     jobDefinitions.forEach { job ->
       if (success.get()) {
         runSafe(job)
           .onFailure {
             success.set(false)
-
-            log.warn("Failure occurred running job ${job.jobType}")
+            failedJob = job
           }
       } else {
         log.warn("Ignoring job ${job.jobType} due to failure in a dependent job.")
 
-        jobRepository.saveAndFlush(Job.failed(job.jobType, LocalDateTime.now()))
+        transactionHandler.newSpringTransaction {
+          jobRepository.saveAndFlush(Job.failed(job.jobType, LocalDateTime.now()))
+        }
       }
+    }
+
+    if (!success.get()) {
+      throw RuntimeException("Failure occurred running job ${failedJob!!.jobType}")
     }
   }
 
@@ -53,7 +62,9 @@ class SafeJobRunner(private val jobRepository: JobRepository) {
       .onFailure {
         log.error("Failed to run ${jobDefinition.jobType} job", it)
 
-        jobRepository.saveAndFlush(Job.failed(jobDefinition.jobType, startedAt))
+        transactionHandler.newSpringTransaction {
+          jobRepository.saveAndFlush(Job.failed(jobDefinition.jobType, startedAt))
+        }
       }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Job
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
@@ -11,7 +10,6 @@ import java.time.LocalDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 
 @Component
-@Transactional
 class SafeJobRunner(private val jobRepository: JobRepository, private val transactionHandler: TransactionHandler) {
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -107,9 +107,6 @@ class ManageAllocationsService(
       date,
     )
 
-  private fun List<ActivitySchedule>.allocationsDueToStartOnOrBefore(date: LocalDate) =
-    flatMap { it.allocations().filter { allocation -> allocation.startDate <= date } }
-
   private fun allocationsDueToEnd(): Map<ActivitySchedule, List<Allocation>> =
     LocalDate.now().let { today ->
       forEachRolledOutPrison()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
@@ -15,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocati
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason.ENDED
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason.TEMPORARILY_RELEASED
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus.ACTIVE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus.AUTO_SUSPENDED
@@ -32,6 +34,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqual
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.movement
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.WaitingListRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSearchPrisonerFixture
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
@@ -50,6 +53,9 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
   @Autowired
   private lateinit var waitingListRepository: WaitingListRepository
 
+  @Autowired
+  private lateinit var jobRepository: JobRepository
+
   @Sql("classpath:test_data/seed-activity-id-11.sql")
   @Test
   fun `deallocate offenders for activity ending today`() {
@@ -63,7 +69,15 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
       none { it.isStatus(ALLOCATED, DECLINED, REMOVED) } isBool true
     }
 
+    jobRepository.findAll() hasSize 0
+
     webTestClient.manageAllocations(withDeallocate = true)
+
+    with(jobRepository.findAll()) {
+      this hasSize 2
+      single { it.jobType == JobType.DEALLOCATE_EXPIRING }.also { it.successful isBool true }
+      single { it.jobType == JobType.DEALLOCATE_ENDING }.also { it.successful isBool true }
+    }
 
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, 1L)
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, 2L)
@@ -131,7 +145,15 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
       prisonerAllocation(PENDING).prisonerNumber isEqualTo "A11111A"
     }
 
+    jobRepository.findAll() hasSize 0
+
     webTestClient.manageAllocations(withDeallocate = true)
+
+    with(jobRepository.findAll()) {
+      this hasSize 2
+      single { it.jobType == JobType.DEALLOCATE_EXPIRING }.also { it.successful isBool true }
+      single { it.jobType == JobType.DEALLOCATE_ENDING }.also { it.successful isBool true }
+    }
 
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, 1L)
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, 2L)
@@ -193,9 +215,42 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
 
     webTestClient.manageAllocations(withActivate = true)
 
+    with(jobRepository.findAll().single()) {
+      jobType isEqualTo JobType.ALLOCATE
+      successful isBool true
+    }
+
     with(allocationRepository.findAll()) {
       prisoner("PAST") isStatus AUTO_SUSPENDED
       prisoner("TODAY") isStatus AUTO_SUSPENDED
+      prisoner("FUTURE") isStatus PENDING
+    }
+  }
+
+  @Sql("classpath:test_data/seed-allocations-pending.sql")
+  @Test
+  fun `allocation job failure is recorded when an error occurs during execution`() {
+    listOf("PAST", "TODAY", "FUTURE").map { prisonerNumber ->
+      PrisonerSearchPrisonerFixture.instance(
+        prisonerNumber = prisonerNumber,
+        inOutStatus = Prisoner.InOutStatus.IN,
+      )
+    }.also { prisoners -> prisonerSearchApiMockServer.stubBadRequestSearchByPrisonerNumbers(listOf("PAST", "TODAY"), prisoners) }
+
+    jobRepository.findAll() hasSize 0
+
+    webTestClient.manageAllocations(withActivate = true)
+
+    with(jobRepository.findAll().single()) {
+      jobType isEqualTo JobType.ALLOCATE
+      successful isBool false
+    }
+
+    verifyNoInteractions(outboundEventsService)
+
+    with(allocationRepository.findAll()) {
+      prisoner("PAST") isStatus PENDING
+      prisoner("TODAY") isStatus PENDING
       prisoner("FUTURE") isStatus PENDING
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -50,6 +50,16 @@ class PrisonerSearchApiMockServer : WireMockServer(8111) {
     )
   }
 
+  fun stubBadRequestSearchByPrisonerNumbers(prisonerNumbers: List<String>, prisoners: List<Prisoner>) {
+    stubFor(
+      WireMock.post(WireMock.urlEqualTo("/prisoner-search/prisoner-numbers"))
+        .withRequestBody(equalToJson(mapper.writeValueAsString(PrisonerNumbers(prisonerNumbers = prisonerNumbers)), true, true))
+        .willReturn(
+          WireMock.badRequest(),
+        ),
+    )
+  }
+
   fun stubSearchByPrisonerNumberNotFound(prisonerNumber: String) {
     stubFor(
       WireMock.post(WireMock.urlEqualTo("/prisoner-search/prisoner-numbers"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/AppointmentMetricsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/AppointmentMetricsJobTest.kt
@@ -17,11 +17,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobR
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.DailyAppointmentMetricsService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ScheduleReasonEventType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDate
 
 class AppointmentMetricsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock()
   private val prisonApiClient: PrisonApiApplicationClient = mock()
   private val service: DailyAppointmentMetricsService = mock()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CancelAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CancelAppointmentsJobTest.kt
@@ -15,11 +15,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentCancelRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDateTime
 
 class CancelAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
   private val service: AppointmentCancelDomainService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = CancelAppointmentsJob(safeJobRunner, service)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateAppointmentsJobTest.kt
@@ -21,11 +21,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSeriesRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.util.Optional
 
 class CreateAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
   private val appointmentSeriesRepository: AppointmentSeriesRepository = mock()
   private val appointmentRepository: AppointmentRepository = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateScheduledInstancesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateScheduledInstancesJobTest.kt
@@ -11,12 +11,13 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType.SCHEDULES
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageScheduledInstancesService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 
 @ExtendWith(MockitoExtension::class)
 class CreateScheduledInstancesJobTest {
   private val service: ManageScheduledInstancesService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = CreateScheduledInstancesJob(service, safeJobRunner)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/DeleteMigratedAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/DeleteMigratedAppointmentsJobTest.kt
@@ -11,11 +11,12 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MigrateAppointmentService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDate
 
 class DeleteMigratedAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
   private val service: MigrateAppointmentService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = DeleteMigratedAppointmentsJob(safeJobRunner, service)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -11,11 +11,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAllocationsService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 
 class ManageAllocationsJobTest {
   private val deallocationService: ManageAllocationsService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
   private val job = ManageAllocationsJob(deallocationService, safeJobRunner)
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAppointmentAttendeesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAppointmentAttendeesJobTest.kt
@@ -15,11 +15,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rollout
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAppointmentService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDate
 
 class ManageAppointmentAttendeesJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock()
   private val service: ManageAppointmentService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
@@ -12,11 +12,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AttendanceOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAttendancesService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 
 class ManageAttendanceRecordsJobTest {
   private val attendancesService: ManageAttendancesService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
   private val job = ManageAttendanceRecordsJob(attendancesService, safeJobRunner)
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/UpdateAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/UpdateAppointmentsJobTest.kt
@@ -16,11 +16,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.A
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSearchPrisonerFixture
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDateTime
 
 class UpdateAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
   private val service: AppointmentUpdateDomainService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = UpdateAppointmentsJob(safeJobRunner, service)

--- a/src/test/resources/test_data/clean-all-data.sql
+++ b/src/test/resources/test_data/clean-all-data.sql
@@ -33,4 +33,7 @@ truncate table appointment_series restart identity;
 truncate table appointment_set_appointment_series restart identity;
 truncate table appointment_set restart identity;
 
+--Common
+truncate table job restart identity;
+
 SET REFERENTIAL_INTEGRITY TRUE;


### PR DESCRIPTION
Errors do not get propagated on safe job execution, as a result we are not seeing DPS alerts when a job fails to execute.

To date this has not been a problem in production.  It was noticed in dev due to external API services we use being disabled out of normal office hours e.g. prison search API is turned off late evening and comes back online at approx 6:20 UTC.

A runtime exception will now be thrown when a job fails to execute cleanly.  Note we still record the failure in the activities DB.