### PR TITLE
Revert "SAA-1325 jobs should throw runtime exception on safe job failure to ensure alerts get propagated accordingly."

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
@@ -5,19 +5,18 @@ import org.springframework.stereotype.Component
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Job
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDateTime
 import java.util.concurrent.atomic.AtomicBoolean
 
 @Component
-class SafeJobRunner(private val jobRepository: JobRepository, private val transactionHandler: TransactionHandler) {
+class SafeJobRunner(private val jobRepository: JobRepository) {
 
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
   }
 
   fun runJob(jobDefinition: JobDefinition) {
-    runSafe(jobDefinition).onFailure { throw RuntimeException("Failure occurred running job ${jobDefinition.jobType}") }
+    runSafe(jobDefinition)
   }
 
   /**
@@ -27,26 +26,20 @@ class SafeJobRunner(private val jobRepository: JobRepository, private val transa
    */
   fun runDependentJobs(vararg jobDefinitions: JobDefinition) {
     val success = AtomicBoolean(true)
-    var failedJob: JobDefinition? = null
 
     jobDefinitions.forEach { job ->
       if (success.get()) {
         runSafe(job)
           .onFailure {
             success.set(false)
-            failedJob = job
+
+            log.warn("Failure occurred running job ${job.jobType}")
           }
       } else {
         log.warn("Ignoring job ${job.jobType} due to failure in a dependent job.")
 
-        transactionHandler.newSpringTransaction {
-          jobRepository.saveAndFlush(Job.failed(job.jobType, LocalDateTime.now()))
-        }
+        jobRepository.saveAndFlush(Job.failed(job.jobType, LocalDateTime.now()))
       }
-    }
-
-    if (!success.get()) {
-      throw RuntimeException("Failure occurred running job ${failedJob!!.jobType}")
     }
   }
 
@@ -60,9 +53,7 @@ class SafeJobRunner(private val jobRepository: JobRepository, private val transa
       .onFailure {
         log.error("Failed to run ${jobDefinition.jobType} job", it)
 
-        transactionHandler.newSpringTransaction {
-          jobRepository.saveAndFlush(Job.failed(jobDefinition.jobType, startedAt))
-        }
+        jobRepository.saveAndFlush(Job.failed(jobDefinition.jobType, startedAt))
       }
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -107,6 +107,9 @@ class ManageAllocationsService(
       date,
     )
 
+  private fun List<ActivitySchedule>.allocationsDueToStartOnOrBefore(date: LocalDate) =
+    flatMap { it.allocations().filter { allocation -> allocation.startDate <= date } }
+
   private fun allocationsDueToEnd(): Map<ActivitySchedule, List<Allocation>> =
     LocalDate.now().let { today ->
       forEachRolledOutPrison()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonerSearchApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonerSearchApiMockServer.kt
@@ -50,16 +50,6 @@ class PrisonerSearchApiMockServer : WireMockServer(8111) {
     )
   }
 
-  fun stubBadRequestSearchByPrisonerNumbers(prisonerNumbers: List<String>, prisoners: List<Prisoner>) {
-    stubFor(
-      WireMock.post(WireMock.urlEqualTo("/prisoner-search/prisoner-numbers"))
-        .withRequestBody(equalToJson(mapper.writeValueAsString(PrisonerNumbers(prisonerNumbers = prisonerNumbers)), true, true))
-        .willReturn(
-          WireMock.badRequest(),
-        ),
-    )
-  }
-
   fun stubSearchByPrisonerNumberNotFound(prisonerNumber: String) {
     stubFor(
       WireMock.post(WireMock.urlEqualTo("/prisoner-search/prisoner-numbers"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/AppointmentMetricsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/AppointmentMetricsJobTest.kt
@@ -17,12 +17,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobR
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.DailyAppointmentMetricsService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ScheduleReasonEventType
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDate
 
 class AppointmentMetricsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock()
   private val prisonApiClient: PrisonApiApplicationClient = mock()
   private val service: DailyAppointmentMetricsService = mock()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CancelAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CancelAppointmentsJobTest.kt
@@ -15,12 +15,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentCancelRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDateTime
 
 class CancelAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
   private val service: AppointmentCancelDomainService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = CancelAppointmentsJob(safeJobRunner, service)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateAppointmentsJobTest.kt
@@ -21,12 +21,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentSeriesRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.util.Optional
 
 class CreateAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
   private val appointmentSeriesRepository: AppointmentSeriesRepository = mock()
   private val appointmentRepository: AppointmentRepository = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateScheduledInstancesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateScheduledInstancesJobTest.kt
@@ -11,13 +11,12 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType.SCHEDULES
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageScheduledInstancesService
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 
 @ExtendWith(MockitoExtension::class)
 class CreateScheduledInstancesJobTest {
   private val service: ManageScheduledInstancesService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = CreateScheduledInstancesJob(service, safeJobRunner)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/DeleteMigratedAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/DeleteMigratedAppointmentsJobTest.kt
@@ -11,12 +11,11 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MigrateAppointmentService
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDate
 
 class DeleteMigratedAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
   private val service: MigrateAppointmentService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = DeleteMigratedAppointmentsJob(safeJobRunner, service)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -11,12 +11,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAllocationsService
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 
 class ManageAllocationsJobTest {
   private val deallocationService: ManageAllocationsService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
   private val job = ManageAllocationsJob(deallocationService, safeJobRunner)
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAppointmentAttendeesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAppointmentAttendeesJobTest.kt
@@ -15,12 +15,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rollout
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAppointmentService
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDate
 
 class ManageAppointmentAttendeesJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock()
   private val service: ManageAppointmentService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
@@ -12,12 +12,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AttendanceOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAttendancesService
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 
 class ManageAttendanceRecordsJobTest {
   private val attendancesService: ManageAttendancesService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
   private val job = ManageAttendanceRecordsJob(attendancesService, safeJobRunner)
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunnerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunnerTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -11,14 +10,13 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Job
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
 class SafeJobRunnerTest {
 
   private val jobRepository: JobRepository = mock()
-  private val runner = SafeJobRunner(jobRepository, TransactionHandler())
+  private val runner = SafeJobRunner(jobRepository)
   private val jobEntityCaptor = argumentCaptor<Job>()
 
   @Test
@@ -58,10 +56,7 @@ class SafeJobRunnerTest {
 
   @Test
   fun `runs job with error`() {
-    assertThatThrownBy {
-      runner.runJob(JobDefinition(JobType.ATTENDANCE_CREATE) { throw RuntimeException("it failed") })
-    }.isInstanceOf(RuntimeException::class.java)
-      .hasMessage("Failure occurred running job ${JobType.ATTENDANCE_CREATE}")
+    runner.runJob(JobDefinition(JobType.ATTENDANCE_CREATE) { throw RuntimeException("it failed") })
 
     verify(jobRepository).saveAndFlush(jobEntityCaptor.capture())
 
@@ -74,13 +69,10 @@ class SafeJobRunnerTest {
 
   @Test
   fun `runs dependent jobs with error on first job`() {
-    assertThatThrownBy {
-      runner.runDependentJobs(
-        JobDefinition(JobType.ATTENDANCE_CREATE) { throw RuntimeException("first job failed") },
-        JobDefinition(JobType.DEALLOCATE_ENDING) {},
-      )
-    }.isInstanceOf(RuntimeException::class.java)
-      .hasMessage("Failure occurred running job ${JobType.ATTENDANCE_CREATE}")
+    runner.runDependentJobs(
+      JobDefinition(JobType.ATTENDANCE_CREATE) { throw RuntimeException("first job failed") },
+      JobDefinition(JobType.DEALLOCATE_ENDING) {},
+    )
 
     verify(jobRepository, times(2)).saveAndFlush(jobEntityCaptor.capture())
 
@@ -99,13 +91,10 @@ class SafeJobRunnerTest {
 
   @Test
   fun `runs dependent jobs with error on second job`() {
-    assertThatThrownBy {
-      runner.runDependentJobs(
-        JobDefinition(JobType.ATTENDANCE_CREATE) { },
-        JobDefinition(JobType.DEALLOCATE_ENDING) { throw RuntimeException("first job failed") },
-      )
-    }.isInstanceOf(RuntimeException::class.java)
-      .hasMessage("Failure occurred running job ${JobType.DEALLOCATE_ENDING}")
+    runner.runDependentJobs(
+      JobDefinition(JobType.ATTENDANCE_CREATE) { },
+      JobDefinition(JobType.DEALLOCATE_ENDING) { throw RuntimeException("first job failed") },
+    )
 
     verify(jobRepository, times(2)).saveAndFlush(jobEntityCaptor.capture())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/UpdateAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/UpdateAppointmentsJobTest.kt
@@ -16,12 +16,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.A
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSearchPrisonerFixture
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import java.time.LocalDateTime
 
 class UpdateAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository, TransactionHandler()))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
   private val service: AppointmentUpdateDomainService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = UpdateAppointmentsJob(safeJobRunner, service)

--- a/src/test/resources/test_data/clean-all-data.sql
+++ b/src/test/resources/test_data/clean-all-data.sql
@@ -33,7 +33,4 @@ truncate table appointment_series restart identity;
 truncate table appointment_set_appointment_series restart identity;
 truncate table appointment_set restart identity;
 
---Common
-truncate table job restart identity;
-
 SET REFERENTIAL_INTEGRITY TRUE;


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-activities-management-api#645

This did not have the desired impact.  What I failed to realise/consider is the jobs are run asynchronously (facepalm)