### PR TITLE
SAA-1334 changes to support the capture of release events whether they succeed or fail as events of interest.

### DIFF
--- a/docker-compose-localstack.yml
+++ b/docker-compose-localstack.yml
@@ -45,6 +45,15 @@ services:
       - $PWD/wiremock-docker:/home/wiremock
     command: --verbose --global-response-templating --port=8081
 
+  prisoner-search-api:
+    image: rodolpheche/wiremock:latest
+    container_name: prisoner-search-api
+    ports:
+      - "8092:8081"
+    volumes:
+      - $PWD/wiremock-docker:/home/wiremock
+    command: --verbose --global-response-templating --port=8081
+
   oauth-server:
     image: rodolpheche/wiremock:latest
     container_name: oauth-server

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -29,6 +29,7 @@ inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>(
 @Service
 class PrisonApiClient(private val prisonApiWebClient: WebClient) {
 
+  @Deprecated("Use prisoner search API client in place of this if it has what is needed.")
   fun getPrisonerDetails(
     prisonerNumber: String,
     fullInfo: Boolean = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEvents.kt
@@ -54,12 +54,16 @@ interface InboundEvent {
   fun eventType(): String
 }
 
+interface InboundReleaseEvent : InboundEvent {
+  fun prisonCode(): String
+}
+
 interface EventOfInterest
 
 // ------------ Offender released from prison events ------------------------------------------
 
-data class OffenderReleasedEvent(val additionalInformation: ReleaseInformation) : InboundEvent {
-  fun prisonCode() = additionalInformation.prisonId
+data class OffenderReleasedEvent(val additionalInformation: ReleaseInformation) : InboundReleaseEvent {
+  override fun prisonCode() = additionalInformation.prisonId
   override fun prisonerNumber() = additionalInformation.nomsNumber
   override fun eventType() = InboundEventType.OFFENDER_RELEASED.eventType
   fun isTemporary() = listOf("TEMPORARY_ABSENCE_RELEASE", "SENT_TO_COURT").contains(additionalInformation.reason)
@@ -123,13 +127,13 @@ data class NonAssociationInformation(val nomsNumber: String, val bookingId: Long
 data class AppointmentsChangedEvent(
   val personReference: PersonReference,
   val additionalInformation: AppointmentsChangedInformation,
-) : InboundEvent {
+) : InboundReleaseEvent {
   override fun prisonerNumber(): String =
     personReference.identifiers.first { it.type == "NOMS" }.value
 
   override fun eventType() = InboundEventType.APPOINTMENTS_CHANGED.eventType
 
-  fun prisonCode() = additionalInformation.prisonId
+  override fun prisonCode() = additionalInformation.prisonId
 
   fun cancelAppointments() = additionalInformation.action == "YES"
 }
@@ -137,8 +141,8 @@ data class AppointmentsChangedEvent(
 data class ActivitiesChangedEvent(
   val personReference: PersonReference,
   val additionalInformation: ActivitiesChangedInformation,
-) : InboundEvent {
-  fun prisonCode() = additionalInformation.prisonId
+) : InboundReleaseEvent {
+  override fun prisonCode() = additionalInformation.prisonId
 
   fun action() = Action.entries.firstOrNull { it.name == additionalInformation.action }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEventsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEventsService.kt
@@ -27,13 +27,11 @@ class InboundEventsService(
     log.debug("Processing inbound event {}", event.eventType())
 
     when (event) {
-      is ActivitiesChangedEvent -> activitiesChangedEventHandler.handle(event)
-        .onFailure { interestingEventHandler.handle(event) }
-
-      is OffenderReceivedEvent -> receivedEventHandler.handle(event).onFailure { interestingEventHandler.handle(event) }
-      is OffenderReleasedEvent -> releasedEventHandler.handle(event).onFailure { interestingEventHandler.handle(event) }
+      is ActivitiesChangedEvent -> activitiesChangedEventHandler.handle(event).run { interestingEventHandler.handle(event) }
+      is AppointmentsChangedEvent -> appointmentsChangedEventHandler.handle(event).run { interestingEventHandler.handle(event) }
+      is OffenderReceivedEvent -> receivedEventHandler.handle(event).run { interestingEventHandler.handle(event) }
+      is OffenderReleasedEvent -> releasedEventHandler.handle(event).run { interestingEventHandler.handle(event) }
       is EventOfInterest -> interestingEventHandler.handle(event)
-      is AppointmentsChangedEvent -> appointmentsChangedEventHandler.handle(event)
       else -> log.warn("Unsupported event ${event.javaClass.name}")
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
@@ -2,17 +2,19 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events
 
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiApplicationClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.InmateDetail
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiApplicationClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventReview
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventReviewRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.ActivitiesChangedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.AlertsUpdatedEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.AppointmentsChangedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.CellMoveEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.InboundEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.InboundReleaseEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.IncentivesDeletedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.IncentivesInsertedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.IncentivesUpdatedEvent
@@ -26,7 +28,7 @@ class InterestingEventHandler(
   private val rolloutPrisonRepository: RolloutPrisonRepository,
   private val allocationRepository: AllocationRepository,
   private val eventReviewRepository: EventReviewRepository,
-  private val prisonApiClient: PrisonApiApplicationClient,
+  private val prisonerSearchApiClient: PrisonerSearchApiApplicationClient,
 ) : EventHandler<InboundEvent> {
   companion object {
     private val log = LoggerFactory.getLogger(this::class.java)
@@ -35,51 +37,76 @@ class InterestingEventHandler(
   override fun handle(event: InboundEvent): Outcome {
     log.debug("Checking for interesting event: {}", event)
 
-    prisonApiClient.getPrisonerDetails(event.prisonerNumber(), fullInfo = false).block()
-      ?.let { prisoner ->
-        if (rolloutPrisonRepository.findByCode(prisoner.agencyId!!)
-          ?.isActivitiesRolledOut() == true
+    if (event is InboundReleaseEvent) return recordRelease(event)
+
+    prisonerSearchApiClient.findByPrisonerNumber(event.prisonerNumber())?.let { prisoner ->
+      if (rolloutPrisonRepository.findByCode(prisoner.prisonId!!)?.isActivitiesRolledOut() == true) {
+        if (allocationRepository.findByPrisonCodePrisonerNumberPrisonerStatus(
+            prisonCode = prisoner.prisonId,
+            prisonerNumber = prisoner.prisonerNumber,
+            prisonerStatus = arrayOf(PrisonerStatus.ACTIVE, PrisonerStatus.PENDING),
+          ).isNotEmpty()
         ) {
-          if (allocationRepository.findByPrisonCodeAndPrisonerNumber(
-              prisoner.agencyId,
-              prisoner.offenderNo!!,
-            ).hasActiveOrPendingAllocations()
-          ) {
-            val saved = eventReviewRepository.saveAndFlush(
-              EventReview(
-                eventTime = LocalDateTime.now(),
-                eventType = event.eventType(),
-                eventData = this.getEventMessage(event, prisoner),
-                prisonCode = prisoner.agencyId,
-                prisonerNumber = prisoner.offenderNo,
-                bookingId = prisoner.bookingId?.toInt(),
-              ),
-            )
-            log.debug("Saved interesting event ID ${saved.eventReviewId} - ${event.eventType()} - for ${prisoner.offenderNo}")
-            return Outcome.success()
-          } else {
-            log.info("${prisoner.offenderNo} has no active or pending allocations at ${prisoner.agencyId}")
-          }
+          val saved = eventReviewRepository.saveAndFlush(
+            EventReview(
+              eventTime = LocalDateTime.now(),
+              eventType = event.eventType(),
+              eventData = event.getEventMessage(prisoner),
+              prisonCode = prisoner.prisonId,
+              prisonerNumber = prisoner.prisonerNumber,
+              bookingId = prisoner.bookingId?.toInt(),
+            ),
+          )
+          log.debug("Saved interesting event ID ${saved.eventReviewId} - ${event.eventType()} - for ${prisoner.prisonerNumber}")
+          return Outcome.success()
         } else {
-          log.debug("${prisoner.agencyId} is not a rolled out prison")
+          log.info("${prisoner.prisonerNumber} has no active or pending allocations at ${prisoner.prisonId}")
         }
+      } else {
+        log.debug("${prisoner.prisonId} is not a rolled out prison")
       }
+    }
     return Outcome.failed()
   }
 
-  private fun getEventMessage(event: InboundEvent, prisoner: InmateDetail) =
-    when (event) {
-      is AlertsUpdatedEvent -> "Alerts updated for  ${prisoner.lastName}, ${prisoner.firstName} (${prisoner.offenderNo})"
-      is CellMoveEvent -> "Cell move for ${prisoner.lastName}, ${prisoner.firstName} (${prisoner.offenderNo})"
-      is NonAssociationsChangedEvent -> "Non-associations for ${prisoner.lastName}, ${prisoner.firstName} (${prisoner.offenderNo})"
-      is IncentivesInsertedEvent -> "Incentive review created for ${prisoner.lastName}, ${prisoner.firstName} (${prisoner.offenderNo})"
-      is IncentivesUpdatedEvent -> "Incentive review updated for ${prisoner.lastName}, ${prisoner.firstName} (${prisoner.offenderNo})"
-      is IncentivesDeletedEvent -> "Incentive review deleted for ${prisoner.lastName}, ${prisoner.firstName} (${prisoner.offenderNo})"
-      is OffenderReceivedEvent -> "Prisoner received into prison ${prisoner.agencyId}, ${prisoner.lastName}, ${prisoner.firstName} (${prisoner.offenderNo})"
-      is OffenderReleasedEvent -> "Prisoner released from prison ${prisoner.agencyId}, ${prisoner.lastName}, ${prisoner.firstName} (${prisoner.offenderNo})"
-      else -> "Unknown event for ${prisoner.lastName}, ${prisoner.firstName} (${prisoner.offenderNo})"
+  private fun recordRelease(releaseEvent: InboundReleaseEvent): Outcome {
+    if (rolloutPrisonRepository.findByCode(releaseEvent.prisonCode())?.isActivitiesRolledOut() == true) {
+      prisonerSearchApiClient.findByPrisonerNumber(releaseEvent.prisonerNumber())?.let { prisoner ->
+        val saved = eventReviewRepository.saveAndFlush(
+          EventReview(
+            eventTime = LocalDateTime.now(),
+            eventType = releaseEvent.eventType(),
+            eventData = releaseEvent.getEventMessage(prisoner),
+            prisonCode = prisoner.prisonId,
+            prisonerNumber = releaseEvent.prisonerNumber(),
+            bookingId = prisoner.bookingId?.toInt(),
+          ),
+        )
+        log.debug("Saved interesting event ID ${saved.eventReviewId} - ${releaseEvent.eventType()} - for ${releaseEvent.prisonerNumber()}")
+        return Outcome.success()
+      }
+    } else {
+      log.debug("${releaseEvent.prisonCode()} is not a rolled out prison")
     }
 
-  private fun List<Allocation>.hasActiveOrPendingAllocations() =
-    this.any { it.status(PrisonerStatus.ACTIVE, PrisonerStatus.PENDING) }
+    return Outcome.success()
+  }
+
+  private fun InboundEvent.getEventMessage(prisoner: Prisoner): String {
+    val prisonerDetails = "${prisoner.lastName}, ${prisoner.firstName} (${prisoner.prisonerNumber})"
+
+    return when (this) {
+      is ActivitiesChangedEvent -> "Activities changed '${action()?.name}' for $prisonerDetails"
+      is AlertsUpdatedEvent -> "Alerts updated for $prisonerDetails"
+      is AppointmentsChangedEvent -> "Appointments changed '${additionalInformation.action}' for $prisonerDetails"
+      is CellMoveEvent -> "Cell move for $prisonerDetails"
+      is NonAssociationsChangedEvent -> "Non-associations for $prisonerDetails"
+      is IncentivesInsertedEvent -> "Incentive review created for $prisonerDetails"
+      is IncentivesUpdatedEvent -> "Incentive review updated for $prisonerDetails"
+      is IncentivesDeletedEvent -> "Incentive review deleted for $prisonerDetails"
+      is OffenderReceivedEvent -> "Prisoner received into prison ${prisoner.prisonId}, $prisonerDetails"
+      is OffenderReleasedEvent -> "Prisoner released from prison ${prisoner.prisonId}, $prisonerDetails"
+      else -> "Unknown event for $prisonerDetails"
+    }
+  }
 }

--- a/src/main/resources/application-localstack.yml
+++ b/src/main/resources/application-localstack.yml
@@ -38,7 +38,7 @@ prison:
 
 prisoner-search:
   api:
-    url: https://prisoner-search-dev.prison.service.justice.gov.uk
+    url: http://localhost:8092
     timeout: 10s
 
 case-notes:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -182,11 +182,13 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
   @Test
   @Sql("classpath:test_data/seed-activity-id-1.sql")
   fun `prisoner alerts updated`() {
-    prisonApiMockServer.stubGetPrisonerDetails(
-      prisonerNumber = "A11111A",
-      fullInfo = false,
-      extraInfo = null,
-      jsonFileSuffix = "",
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumber(
+      PrisonerSearchPrisonerFixture.instance(
+        prisonId = pentonvillePrisonCode,
+        prisonerNumber = "A11111A",
+        inOutStatus = Prisoner.InOutStatus.OUT,
+        status = "INACTIVE OUT",
+      ),
     )
 
     service.process(alertsUpdatedEvent(prisonerNumber = "A11111A"))
@@ -195,7 +197,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
 
     assertThat(interestingEvent.eventType).isEqualTo("prison-offender-search.prisoner.alerts-updated")
     assertThat(interestingEvent.prisonerNumber).isEqualTo("A11111A")
-    assertThat(interestingEvent.eventData).isEqualTo("Alerts updated for  HARRISON, TIM (A11111A)")
+    assertThat(interestingEvent.eventData).isEqualTo("Alerts updated for Harrison, Tim (A11111A)")
   }
 
   @Test
@@ -373,6 +375,15 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:test_data/seed-appointments-changed-event.sql")
   fun `no appointments are cancelled when appointments changed event received with action set to NO`() {
     val appointmentIds = listOf(200L, 201L, 202L, 203L, 210L, 211L, 212L)
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumber(
+      PrisonerSearchPrisonerFixture.instance(
+        prisonId = moorlandPrisonCode,
+        prisonerNumber = "A1234BC",
+        inOutStatus = Prisoner.InOutStatus.OUT,
+        status = "INACTIVE OUT",
+      ),
+    )
+
     prisonApiMockServer.stubGetPrisonerDetails(
       prisonerNumber = "A1234BC",
       fullInfo = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEventsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEventsServiceTest.kt
@@ -40,47 +40,67 @@ class InboundEventsServiceTest {
 
   @Test
   fun `inbound released event is processed by release event handler`() {
-    val inboundEvent = offenderReleasedEvent(moorlandPrisonCode, "123456")
-    service.process(inboundEvent)
-    verify(releasedEventHandler).handle(inboundEvent)
+    val offenderReleasedEvent = offenderReleasedEvent(moorlandPrisonCode, "123456")
+    service.process(offenderReleasedEvent)
+    verify(releasedEventHandler).handle(offenderReleasedEvent)
+  }
+
+  @Test
+  fun `inbound released event is handled as an interesting event`() {
+    val offenderReleasedEvent = offenderReleasedEvent(moorlandPrisonCode, "123456")
+    service.process(offenderReleasedEvent)
+    verify(interestingEventHandler).handle(offenderReleasedEvent)
+  }
+
+  @Test
+  fun `inbound activities changed event is processed by release event handler`() {
+    val activitiesChangedEvent = activitiesChangedEvent(prisonId = moorlandPrisonCode, prisonerNumber = "123456", action = Action.END)
+    service.process(activitiesChangedEvent)
+    verify(activitiesChangedEventHandler).handle(activitiesChangedEvent)
+  }
+
+  @Test
+  fun `inbound activities changed event is handled as an interesting event`() {
+    val activitiesChangedEvent = activitiesChangedEvent(prisonId = moorlandPrisonCode, prisonerNumber = "123456", action = Action.END)
+    service.process(activitiesChangedEvent)
+    verify(interestingEventHandler).handle(activitiesChangedEvent)
   }
 
   @Test
   fun `inbound received event is processed by received event handler`() {
-    val inboundEvent = offenderReceivedFromTemporaryAbsence(moorlandPrisonCode, "123456")
-    service.process(inboundEvent)
-    verify(receivedEventHandler).handle(inboundEvent)
-  }
-
-  @Test
-  fun `inbound released event failure is handled as an interesting event`() {
-    whenever(releasedEventHandler.handle(any())).thenReturn(Outcome.failed())
-    val inboundEvent = offenderReleasedEvent(moorlandPrisonCode, "123456")
-    service.process(inboundEvent)
-    verify(releasedEventHandler).handle(inboundEvent)
-    verify(interestingEventHandler).handle(inboundEvent)
+    val offenderReceivedEvent = offenderReceivedFromTemporaryAbsence(moorlandPrisonCode, "123456")
+    service.process(offenderReceivedEvent)
+    verify(receivedEventHandler).handle(offenderReceivedEvent)
   }
 
   @Test
   fun `inbound received event failure is handled as an interesting event`() {
-    whenever(receivedEventHandler.handle(any())).thenReturn(Outcome.failed())
-    val inboundEvent = offenderReceivedFromTemporaryAbsence(moorlandPrisonCode, "123456")
-    service.process(inboundEvent)
-    verify(receivedEventHandler).handle(inboundEvent)
-    verify(interestingEventHandler).handle(inboundEvent)
+    val offenderReceivedEvent = offenderReceivedFromTemporaryAbsence(moorlandPrisonCode, "123456").also {
+      whenever(receivedEventHandler.handle(it)).thenReturn(Outcome.failed())
+    }
+    service.process(offenderReceivedEvent)
+    verify(receivedEventHandler).handle(offenderReceivedEvent)
+    verify(interestingEventHandler).handle(offenderReceivedEvent)
   }
 
   @Test
   fun `inbound interesting event is processed by interesting event handler`() {
-    val inboundEvent = cellMoveEvent("123456")
-    service.process(inboundEvent)
-    verify(interestingEventHandler).handle(inboundEvent)
+    val cellMoveEvent = cellMoveEvent("123456")
+    service.process(cellMoveEvent)
+    verify(interestingEventHandler).handle(cellMoveEvent)
   }
 
   @Test
   fun `inbound appointments changed event is processed by appointments changed event handler`() {
-    val inboundEvent = appointmentsChangedEvent("123456")
-    service.process(inboundEvent)
-    verify(appointmentsChangedEventHandler).handle(inboundEvent)
+    val appointmentsChangedEvent = appointmentsChangedEvent("123456")
+    service.process(appointmentsChangedEvent)
+    verify(appointmentsChangedEventHandler).handle(appointmentsChangedEvent)
+  }
+
+  @Test
+  fun `inbound appointments changed event is processed by  interesting event handler`() {
+    val appointmentsChangedEvent = appointmentsChangedEvent("123456")
+    service.process(appointmentsChangedEvent)
+    verify(interestingEventHandler).handle(appointmentsChangedEvent)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
@@ -1,158 +1,279 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.handlers
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import reactor.core.publisher.Mono
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiApplicationClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.InmateDetail
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiApplicationClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventReview
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rolloutPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventReviewRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.Action
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.InboundEventType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.activitiesChangedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.alertsUpdatedEvent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.appointmentsChangedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.cellMoveEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.iepReviewInsertedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.offenderReceivedFromTemporaryAbsence
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.offenderReleasedEvent
-import java.time.LocalDate
 
 class InterestingEventHandlerTest {
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock()
   private val allocationRepository: AllocationRepository = mock()
   private val eventReviewRepository: EventReviewRepository = mock()
-  private val prisonApiClient: PrisonApiApplicationClient = mock()
+  private val prisonerSearchApiClient: PrisonerSearchApiApplicationClient = mock()
+  private val eventReviewCaptor = argumentCaptor<EventReview>()
 
   private val handler =
-    InterestingEventHandler(rolloutPrisonRepository, allocationRepository, eventReviewRepository, prisonApiClient)
-
-  private val prisoner = InmateDetail(
-    agencyId = "PVI",
-    offenderNo = "123456",
-    inOutStatus = "IN",
-    firstName = "Bob",
-    lastName = "Bobson",
-    activeFlag = true,
-    offenderId = 1L,
-    rootOffenderId = 1L,
-    status = "IN",
-    dateOfBirth = LocalDate.of(2001, 10, 1),
-  )
+    InterestingEventHandler(
+      rolloutPrisonRepository,
+      allocationRepository,
+      eventReviewRepository,
+      prisonerSearchApiClient,
+    )
 
   @BeforeEach
   fun beforeTests() {
-    reset(rolloutPrisonRepository, allocationRepository, eventReviewRepository, prisonApiClient)
-    rolloutPrisonRepository.stub {
-      on { findByCode(pentonvillePrisonCode) } doReturn rolloutPrison()
-    }
-    whenever(prisonApiClient.getPrisonerDetails("123456", fullInfo = false)).doReturn(Mono.just(prisoner))
-    whenever(eventReviewRepository.saveAndFlush(any<EventReview>())).doReturn(EventReview(eventReviewId = 1))
+    whenever(rolloutPrisonRepository.findByCode(pentonvillePrisonCode)) doReturn rolloutPrison()
+    whenever(eventReviewRepository.saveAndFlush(any<EventReview>())) doReturn EventReview(eventReviewId = 1)
   }
 
   @Test
   fun `stores an interesting event when active allocations exist`() {
+    mockPrisoner()
+
+    val activeAllocations =
+      listOf(allocation().copy(allocationId = 1, prisonerNumber = "123456", prisonerStatus = PrisonerStatus.ACTIVE))
+    mockAllocations(pentonvillePrisonCode, "123456", activeAllocations)
+
     val inboundEvent = cellMoveEvent("123456")
-    val activeAllocations = listOf(allocation().copy(allocationId = 1, prisonerNumber = "123456", prisonerStatus = PrisonerStatus.ACTIVE))
-    whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
-      .doReturn(activeAllocations)
 
-    val outcome = handler.handle(inboundEvent)
+    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
 
-    assertThat(outcome.isSuccess()).isTrue
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
-    verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
-    verify(eventReviewRepository).saveAndFlush(any<EventReview>())
+    verify(allocationRepository).findByPrisonCodePrisonerNumberPrisonerStatus(pentonvillePrisonCode, "123456", PrisonerStatus.ACTIVE, PrisonerStatus.PENDING)
+    verify(eventReviewRepository).saveAndFlush(eventReviewCaptor.capture())
+
+    with(eventReviewCaptor.firstValue) {
+      bookingId isEqualTo 1
+      eventData isEqualTo "Cell move for Bobson, Bob (123456)"
+      eventTime isCloseTo TimeSource.now()
+      eventType isEqualTo InboundEventType.CELL_MOVE.eventType
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "123456"
+    }
   }
 
   @Test
   fun `stores an interesting event when pending allocations exist`() {
+    mockPrisoner(bookId = 2)
+
+    val activeAllocations =
+      listOf(allocation().copy(allocationId = 1, prisonerNumber = "123456", prisonerStatus = PrisonerStatus.PENDING))
+    mockAllocations(pentonvillePrisonCode, "123456", activeAllocations)
+
     val inboundEvent = cellMoveEvent("123456")
-    val activeAllocations = listOf(allocation().copy(allocationId = 1, prisonerNumber = "123456", prisonerStatus = PrisonerStatus.PENDING))
-    whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
-      .doReturn(activeAllocations)
 
-    val outcome = handler.handle(inboundEvent)
+    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
 
-    assertThat(outcome.isSuccess()).isTrue
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
-    verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
-    verify(eventReviewRepository).saveAndFlush(any<EventReview>())
+    verify(allocationRepository).findByPrisonCodePrisonerNumberPrisonerStatus(pentonvillePrisonCode, "123456", PrisonerStatus.ACTIVE, PrisonerStatus.PENDING)
+    verify(eventReviewRepository).saveAndFlush(eventReviewCaptor.capture())
+
+    with(eventReviewCaptor.firstValue) {
+      bookingId isEqualTo 2
+      eventData isEqualTo "Cell move for Bobson, Bob (123456)"
+      eventTime isCloseTo TimeSource.now()
+      eventType isEqualTo InboundEventType.CELL_MOVE.eventType
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "123456"
+    }
   }
 
   @Test
   fun `stores an iep-review-inserted event despite the reason and prisonId being null`() {
-    val inboundEvent = iepReviewInsertedEvent("123456")
+    mockPrisoner(firstname = "Bobby")
+
     val activeAllocations = listOf(allocation().copy(allocationId = 1, prisonerNumber = "123456"))
-    whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
-      .doReturn(activeAllocations)
+    mockAllocations(pentonvillePrisonCode, "123456", activeAllocations)
 
-    val outcome = handler.handle(inboundEvent)
+    val inboundEvent = iepReviewInsertedEvent("123456")
 
-    assertThat(outcome.isSuccess()).isTrue
+    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
+
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
-    verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
-    verify(eventReviewRepository).saveAndFlush(any<EventReview>())
+    verify(allocationRepository).findByPrisonCodePrisonerNumberPrisonerStatus(pentonvillePrisonCode, "123456", PrisonerStatus.ACTIVE, PrisonerStatus.PENDING)
+    verify(eventReviewRepository).saveAndFlush(eventReviewCaptor.capture())
+
+    with(eventReviewCaptor.firstValue) {
+      bookingId isEqualTo 1
+      eventData isEqualTo "Incentive review created for Bobson, Bobby (123456)"
+      eventTime isCloseTo TimeSource.now()
+      eventType isEqualTo InboundEventType.INCENTIVES_INSERTED.eventType
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "123456"
+    }
   }
 
   @Test
   fun `stores a received event when allocations exist`() {
-    val inboundEvent = offenderReceivedFromTemporaryAbsence(pentonvillePrisonCode, "123456")
+    mockPrisoner(lastname = "Geldof")
+
     val activeAllocations = listOf(allocation().copy(allocationId = 1, prisonerNumber = "123456"))
-    whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
-      .doReturn(activeAllocations)
+    mockAllocations(pentonvillePrisonCode, "123456", activeAllocations)
 
-    val outcome = handler.handle(inboundEvent)
+    val inboundEvent = offenderReceivedFromTemporaryAbsence(pentonvillePrisonCode, "123456")
 
-    assertThat(outcome.isSuccess()).isTrue
+    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
+
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
-    verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
-    verify(eventReviewRepository).saveAndFlush(any<EventReview>())
+    verify(allocationRepository).findByPrisonCodePrisonerNumberPrisonerStatus(pentonvillePrisonCode, "123456", PrisonerStatus.ACTIVE, PrisonerStatus.PENDING)
+    verify(eventReviewRepository).saveAndFlush(eventReviewCaptor.capture())
+
+    with(eventReviewCaptor.firstValue) {
+      bookingId isEqualTo 1
+      eventData isEqualTo "Prisoner received into prison PVI, Geldof, Bob (123456)"
+      eventTime isCloseTo TimeSource.now()
+      eventType isEqualTo InboundEventType.OFFENDER_RECEIVED.eventType
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "123456"
+    }
   }
 
   @Test
-  fun `stores a released event when allocations exist`() {
-    val inboundEvent = offenderReleasedEvent(pentonvillePrisonCode, "123456")
-    val activeAllocations = listOf(allocation().copy(allocationId = 1, prisonerNumber = "123456"))
-    whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
-      .doReturn(activeAllocations)
+  fun `stores an offender released event`() {
+    mockPrisoner(prisonCode = moorlandPrisonCode)
+    whenever(rolloutPrisonRepository.findByCode(moorlandPrisonCode)) doReturn rolloutPrison()
+    val inboundEvent = offenderReleasedEvent(moorlandPrisonCode, "123456")
 
-    val outcome = handler.handle(inboundEvent)
+    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
 
-    assertThat(outcome.isSuccess()).isTrue
-    verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
-    verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
-    verify(eventReviewRepository).saveAndFlush(any<EventReview>())
+    verify(rolloutPrisonRepository).findByCode(moorlandPrisonCode)
+    verify(eventReviewRepository).saveAndFlush(eventReviewCaptor.capture())
+
+    with(eventReviewCaptor.firstValue) {
+      bookingId isEqualTo 1
+      eventData isEqualTo "Prisoner released from prison MDI, Bobson, Bob (123456)"
+      eventTime isCloseTo TimeSource.now()
+      eventType isEqualTo InboundEventType.OFFENDER_RELEASED.eventType
+      prisonCode isEqualTo moorlandPrisonCode
+      prisonerNumber isEqualTo "123456"
+    }
   }
 
   @Test
   fun `stores an alerts updated event`() {
-    val inboundEvent = alertsUpdatedEvent(prisonerNumber = "123456")
-    val activeAllocations = listOf(allocation().copy(allocationId = 1, prisonerNumber = "123456"))
-    whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
-      .doReturn(activeAllocations)
+    mockPrisoner(prisonerNum = "ABC1234")
 
-    val outcome = handler.handle(inboundEvent)
+    val activeAllocations = listOf(allocation().copy(allocationId = 1, prisonerNumber = "ABC1234"))
+    mockAllocations(pentonvillePrisonCode, "ABC1234", activeAllocations)
 
-    assertThat(outcome.isSuccess()).isTrue
+    val inboundEvent = alertsUpdatedEvent(prisonerNumber = "ABC1234")
+
+    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
+
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
-    verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
-    verify(eventReviewRepository).saveAndFlush(any<EventReview>())
+    verify(allocationRepository).findByPrisonCodePrisonerNumberPrisonerStatus(pentonvillePrisonCode, "ABC1234", PrisonerStatus.ACTIVE, PrisonerStatus.PENDING)
+    verify(eventReviewRepository).saveAndFlush(eventReviewCaptor.capture())
+
+    with(eventReviewCaptor.firstValue) {
+      bookingId isEqualTo 1
+      eventData isEqualTo "Alerts updated for Bobson, Bob (ABC1234)"
+      eventTime isCloseTo TimeSource.now()
+      eventType isEqualTo InboundEventType.ALERTS_UPDATED.eventType
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "ABC1234"
+    }
+  }
+
+  @Test
+  fun `stores an activities changed event with action END`() {
+    mockPrisoner(prisonerNum = "ABC1234")
+    val inboundEvent =
+      activitiesChangedEvent(prisonId = pentonvillePrisonCode, prisonerNumber = "ABC1234", action = Action.END)
+
+    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
+
+    verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
+    verifyNoInteractions(allocationRepository)
+    verify(eventReviewRepository).saveAndFlush(eventReviewCaptor.capture())
+
+    with(eventReviewCaptor.firstValue) {
+      bookingId isEqualTo 1
+      eventData isEqualTo "Activities changed 'END' for Bobson, Bob (ABC1234)"
+      eventTime isCloseTo TimeSource.now()
+      eventType isEqualTo InboundEventType.ACTIVITIES_CHANGED.eventType
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "ABC1234"
+    }
+  }
+
+  @Test
+  fun `stores an activities changed event with action SUSPEND`() {
+    mockPrisoner(prisonerNum = "ABC1234")
+    val inboundEvent =
+      activitiesChangedEvent(prisonId = pentonvillePrisonCode, prisonerNumber = "ABC1234", action = Action.SUSPEND)
+
+    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
+
+    verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
+    verifyNoInteractions(allocationRepository)
+    verify(eventReviewRepository).saveAndFlush(eventReviewCaptor.capture())
+
+    with(eventReviewCaptor.firstValue) {
+      bookingId isEqualTo 1
+      eventData isEqualTo "Activities changed 'SUSPEND' for Bobson, Bob (ABC1234)"
+      eventTime isCloseTo TimeSource.now()
+      eventType isEqualTo InboundEventType.ACTIVITIES_CHANGED.eventType
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "ABC1234"
+    }
+  }
+
+  @Test
+  fun `stores an appointments changed event with action YES`() {
+    mockPrisoner(prisonerNum = "ABC1234")
+    val inboundEvent =
+      appointmentsChangedEvent(prisonId = pentonvillePrisonCode, prisonerNumber = "ABC1234", action = "YES")
+
+    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
+
+    verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
+    verifyNoInteractions(allocationRepository)
+    verify(eventReviewRepository).saveAndFlush(eventReviewCaptor.capture())
+
+    with(eventReviewCaptor.firstValue) {
+      bookingId isEqualTo 1
+      eventData isEqualTo "Appointments changed 'YES' for Bobson, Bob (ABC1234)"
+      eventTime isCloseTo TimeSource.now()
+      eventType isEqualTo InboundEventType.APPOINTMENTS_CHANGED.eventType
+      prisonCode isEqualTo pentonvillePrisonCode
+      prisonerNumber isEqualTo "ABC1234"
+    }
   }
 
   @Test
   fun `ignores prisoners in prisons which are not rolled out`() {
+    mockPrisoner()
     val inboundEvent = cellMoveEvent("123456")
     rolloutPrisonRepository.stub {
       on { findByCode(pentonvillePrisonCode) } doReturn
@@ -163,9 +284,8 @@ class InterestingEventHandlerTest {
         )
     }
 
-    val outcome = handler.handle(inboundEvent)
+    handler.handle(inboundEvent).also { it.isSuccess() isBool false }
 
-    assertThat(outcome.isSuccess()).isFalse
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
     verifyNoInteractions(allocationRepository)
     verifyNoInteractions(eventReviewRepository)
@@ -173,15 +293,43 @@ class InterestingEventHandlerTest {
 
   @Test
   fun `ignores events for a prisoner with no active allocations`() {
+    mockPrisoner()
+    mockAllocations(pentonvillePrisonCode, "123456", emptyList())
     val inboundEvent = cellMoveEvent("123456")
-    whenever(allocationRepository.findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456"))
-      .doReturn(emptyList())
 
-    val outcome = handler.handle(inboundEvent)
+    handler.handle(inboundEvent).also { it.isSuccess() isBool false }
 
-    assertThat(outcome.isSuccess()).isFalse
     verify(rolloutPrisonRepository).findByCode(pentonvillePrisonCode)
-    verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(pentonvillePrisonCode, "123456")
+    verify(allocationRepository).findByPrisonCodePrisonerNumberPrisonerStatus(pentonvillePrisonCode, "123456", PrisonerStatus.ACTIVE, PrisonerStatus.PENDING)
     verifyNoInteractions(eventReviewRepository)
+  }
+
+  private fun mockAllocations(prisonCode: String, prisonerNumber: String, allocations: List<Allocation>) {
+    whenever(
+      allocationRepository.findByPrisonCodePrisonerNumberPrisonerStatus(
+        prisonCode,
+        prisonerNumber,
+        PrisonerStatus.ACTIVE,
+        PrisonerStatus.PENDING,
+      ),
+    ) doReturn allocations
+  }
+
+  private fun mockPrisoner(
+    prisonCode: String = pentonvillePrisonCode,
+    prisonerNum: String = "123456",
+    firstname: String = "Bob",
+    lastname: String = "Bobson",
+    bookId: Int = 1,
+  ) {
+    val prisoner: Prisoner = mock {
+      on { prisonId } doReturn prisonCode
+      on { prisonerNumber } doReturn prisonerNum
+      on { firstName } doReturn firstname
+      on { lastName } doReturn lastname
+      on { bookingId } doReturn bookId.toString()
+    }
+
+    whenever(prisonerSearchApiClient.findByPrisonerNumber(prisonerNum)) doReturn prisoner
   }
 }

--- a/wiremock-docker/__files/prisoner-search-api/prisoners/G7806VO.json
+++ b/wiremock-docker/__files/prisoner-search-api/prisoners/G7806VO.json
@@ -1,0 +1,50 @@
+{
+  "prisonerNumber": "G7806VO",
+  "pncNumber": "99/58816L",
+  "pncNumberCanonicalShort": "99/58816L",
+  "pncNumberCanonicalLong": "1999/58816L",
+  "croNumber": "45815/99U",
+  "bookingId": "754207",
+  "bookNumber": "38458A",
+  "firstName": "JOHN",
+  "middleNames": "FRANK",
+  "lastName": "DOE",
+  "dateOfBirth": "1986-06-27",
+  "gender": "Male",
+  "ethnicity": "White: Eng./Welsh/Scot./N.Irish/British",
+  "youthOffender": false,
+  "status": "ACTIVE OUT",
+  "lastMovementTypeCode": "TAP",
+  "lastMovementReasonCode": "C3",
+  "inOutStatus": "OUT",
+  "prisonId": "LEI",
+  "prisonName": "Leeds",
+  "cellLocation": "2-1-007",
+  "aliases": [
+    {
+      "firstName": "EGVANING",
+      "middleNames": "ROCHICA",
+      "lastName": "VANERY",
+      "dateOfBirth": "1986-07-31",
+      "gender": "Male",
+      "ethnicity": "White: Gypsy or Irish Traveller"
+    }
+  ],
+  "alerts": [],
+  "legalStatus": "RECALL",
+  "imprisonmentStatus": "FTR_HDC",
+  "imprisonmentStatusDescription": "Fixed Term Recall while on HDC",
+  "recall": true,
+  "indeterminateSentence": false,
+  "receptionDate": "2020-07-20",
+  "locationDescription": "Leeds (HMP & YOI)",
+  "restrictedPatient": false,
+  "currentIncentive": {
+    "level": {
+      "code": "STD",
+      "description": "Standard"
+    },
+    "dateTime": "2020-07-20T10:36:53",
+    "nextReviewDate": "2021-07-20"
+  }
+}

--- a/wiremock-docker/mappings/prison_search_api_get_by_prisoner_number.json
+++ b/wiremock-docker/mappings/prison_search_api_get_by_prisoner_number.json
@@ -1,0 +1,16 @@
+{
+  "request" : {
+    "urlPathPattern" : "/prisoner/.*",
+    "method" : "GET"
+  },
+  "response" : {
+    "status" : 200,
+    "headers": {
+      "Content-Type": "application/json"
+    },
+    "bodyFileName" : "prisoner-search-api/prisoners/{{request.pathSegments.[1]}}.json",
+    "transformers": [
+      "response-template"
+    ]
+  }
+}


### PR DESCRIPTION
**LOW RISK**

The decision has been made to provide users with the visibility of all release related events for their caseload in the change of circumstances screens in the UI.  The changes in this PR ensure all of the current release events are recorded regardless of whether they succeed or fail so they can then be displayed accordingly.

Example activities change release event as seen in the UI when running locally. Related [PR](https://github.com/ministryofjustice/hmpps-activities-management-api/pull/649)

![image](https://github.com/ministryofjustice/hmpps-activities-management-api/assets/60104344/d897d46e-4f00-4c43-b5a4-39977e65bdfa)

