### PR TITLE
SAA-1335 use prison code off event for release events only.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/Movement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/overrides/Movement.kt
@@ -5,7 +5,7 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 
 /**
- * Overriding `toAgency` field. It can be null despite being non-nullable in the API specification.
+ * Overriding `fromAgency' and 'toAgency` fields. Both can be null despite being non-nullable in the API specification.
  */
 data class Movement(
   @get:JsonProperty("offenderNo", required = true) val offenderNo: String,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
@@ -77,7 +77,8 @@ class InterestingEventHandler(
             eventTime = LocalDateTime.now(),
             eventType = releaseEvent.eventType(),
             eventData = releaseEvent.getEventMessage(prisoner),
-            prisonCode = prisoner.prisonId,
+            // Release events use the prison code from the release event. The prisoner prison code could be different because they are released!
+            prisonCode = releaseEvent.prisonCode(),
             prisonerNumber = releaseEvent.prisonerNumber(),
             bookingId = prisoner.bookingId?.toInt(),
           ),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/PrisonApiTypesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/model/PrisonApiTypesTest.kt
@@ -48,4 +48,11 @@ class PrisonApiTypesTest {
 
     assertThat(field.returnType.isMarkedNullable).isTrue
   }
+
+  @Test
+  fun `toAgency field on overridden Movement DTO type should be nullable`() {
+    val field = Movement::class.declaredMembers.first { it.name == "toAgency" }
+
+    assertThat(field.returnType.isMarkedNullable).isTrue
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
@@ -207,7 +207,8 @@ class InterestingEventHandlerTest {
 
   @Test
   fun `stores an activities changed event with action END`() {
-    mockPrisoner(prisonerNum = "ABC1234")
+    // Note prison code is different to that of the event because they have been release to Moorland
+    mockPrisoner(prisonerNum = "ABC1234", prisonCode = moorlandPrisonCode)
     val inboundEvent =
       activitiesChangedEvent(prisonId = pentonvillePrisonCode, prisonerNumber = "ABC1234", action = Action.END)
 


### PR DESCRIPTION
Small change CoC for release events.  Would have done this on the original PR bit having issues with github.

We should record the prison id/code from the release event itself and not where the prisoner currently is as this may be different and if it was different it would not show up on the prison they were released from on the CoC UI.