### PR TITLE
SAA-1300 Absent Reason added to attendance

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -325,6 +325,7 @@ fun transform(attendance: EntityAttendance, caseNotesApiClient: CaseNotesApiClie
         attendance.caseNoteId,
       )?.text
     },
+    otherAbsenceReason = attendance.otherAbsenceReason,
     attendanceHistory = attendance.history()
       .sortedWith(compareBy { attendance.recordedTime })
       .reversed()


### PR DESCRIPTION
I can provide some context regarding the necessary modification. The user interface, specifically the attendance-details.njk file, relies on the `otherAbsenceReason` property from the `attendance` object. However, during the transformation process from Model to Data classes, this particular value is not being assigned.

Resolution:
I have addressed this issue by initializing the `otherAbsenceReason` field within the `attendance` data class.

Verification:
This change has been thoroughly verified, and existing test cases cover this scenario.