### PR TITLE
SAA-1335 capture the released prison code in the stored event data for clarity.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
@@ -97,16 +97,16 @@ class InterestingEventHandler(
     val prisonerDetails = "${prisoner.lastName}, ${prisoner.firstName} (${prisoner.prisonerNumber})"
 
     return when (this) {
-      is ActivitiesChangedEvent -> "Activities changed '${action()?.name}' for $prisonerDetails"
+      is ActivitiesChangedEvent -> "Activities changed '${action()?.name}' from prison ${this.prisonCode()}, for $prisonerDetails"
       is AlertsUpdatedEvent -> "Alerts updated for $prisonerDetails"
-      is AppointmentsChangedEvent -> "Appointments changed '${additionalInformation.action}' for $prisonerDetails"
+      is AppointmentsChangedEvent -> "Appointments changed '${additionalInformation.action}' from prison ${this.prisonCode()}, for $prisonerDetails"
       is CellMoveEvent -> "Cell move for $prisonerDetails"
       is NonAssociationsChangedEvent -> "Non-associations for $prisonerDetails"
       is IncentivesInsertedEvent -> "Incentive review created for $prisonerDetails"
       is IncentivesUpdatedEvent -> "Incentive review updated for $prisonerDetails"
       is IncentivesDeletedEvent -> "Incentive review deleted for $prisonerDetails"
       is OffenderReceivedEvent -> "Prisoner received into prison ${prisoner.prisonId}, $prisonerDetails"
-      is OffenderReleasedEvent -> "Prisoner released from prison ${prisoner.prisonId}, $prisonerDetails"
+      is OffenderReleasedEvent -> "Prisoner released from prison ${this.prisonCode()}, $prisonerDetails"
       else -> "Unknown event for $prisonerDetails"
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
@@ -161,7 +161,8 @@ class InterestingEventHandlerTest {
 
   @Test
   fun `stores an offender released event`() {
-    mockPrisoner(prisonCode = moorlandPrisonCode)
+    // Note prison code is different to that of the event because they have been release to Pentonville
+    mockPrisoner(prisonCode = pentonvillePrisonCode)
     whenever(rolloutPrisonRepository.findByCode(moorlandPrisonCode)) doReturn rolloutPrison()
     val inboundEvent = offenderReleasedEvent(moorlandPrisonCode, "123456")
 
@@ -220,7 +221,7 @@ class InterestingEventHandlerTest {
 
     with(eventReviewCaptor.firstValue) {
       bookingId isEqualTo 1
-      eventData isEqualTo "Activities changed 'END' for Bobson, Bob (ABC1234)"
+      eventData isEqualTo "Activities changed 'END' from prison PVI, for Bobson, Bob (ABC1234)"
       eventTime isCloseTo TimeSource.now()
       eventType isEqualTo InboundEventType.ACTIVITIES_CHANGED.eventType
       prisonCode isEqualTo pentonvillePrisonCode
@@ -242,7 +243,7 @@ class InterestingEventHandlerTest {
 
     with(eventReviewCaptor.firstValue) {
       bookingId isEqualTo 1
-      eventData isEqualTo "Activities changed 'SUSPEND' for Bobson, Bob (ABC1234)"
+      eventData isEqualTo "Activities changed 'SUSPEND' from prison PVI, for Bobson, Bob (ABC1234)"
       eventTime isCloseTo TimeSource.now()
       eventType isEqualTo InboundEventType.ACTIVITIES_CHANGED.eventType
       prisonCode isEqualTo pentonvillePrisonCode
@@ -264,7 +265,7 @@ class InterestingEventHandlerTest {
 
     with(eventReviewCaptor.firstValue) {
       bookingId isEqualTo 1
-      eventData isEqualTo "Appointments changed 'YES' for Bobson, Bob (ABC1234)"
+      eventData isEqualTo "Appointments changed 'YES' from prison PVI, for Bobson, Bob (ABC1234)"
       eventTime isCloseTo TimeSource.now()
       eventType isEqualTo InboundEventType.APPOINTMENTS_CHANGED.eventType
       prisonCode isEqualTo pentonvillePrisonCode


### PR DESCRIPTION
**LOW RISK**

Small tweak to include the release prison code in the event review data when capturing and storing releases for event review presented on the change in circumstances screen in the UI.