### PR TITLE
SAA-1337 pulled job times out into reusable env vars so can have differenent job times for each environment where needed.

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/templates/create-scheduled-instances-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/create-scheduled-instances-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: create-scheduled-instances
 spec:
-  schedule: "0 3 * * *" # 3am every day
+  schedule: "{{ .Values.cron.createScheduledInstances }}"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 43200

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-activate-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-activate-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: activate-allocations
 spec:
-  schedule: "0 2 * * *" # 2am every day
+  schedule:  "{{ .Values.cron.allocationsActivate }}"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 43200

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: deallocate-allocations
 spec:
-  schedule: "0 22 * * *" # 10pm every day
+  schedule:  "{{ .Values.cron.allocationsDeallocate }}"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 43200

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-appointment-attendees-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-appointment-attendees-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: manage-appointment-attendees
 spec:
-  schedule: "30 2 * * *" # 02:30am every day
+  schedule:  "{{ .Values.cron.appointmentAttendees }}"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 43200

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-attendance-records-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-attendance-records-cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: manage-attendance-records
 spec:
-  schedule: "0 4 * * *" # 4am every day
+  schedule:  "{{ .Values.cron.attendanceRecords }}"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 43200

--- a/helm_deploy/hmpps-activities-management-api/values.yaml
+++ b/helm_deploy/hmpps-activities-management-api/values.yaml
@@ -112,3 +112,10 @@ generic-service:
 
 generic-prometheus-alerts:
   targetApplication: hmpps-activities-management-api
+
+cron:
+  allocationsDeallocate: "0 22 * * *"
+  allocationsActivate: "0 2 * * *"
+  appointmentAttendees: "30 2 * * *"
+  createScheduledInstances: "0 3 * * *"
+  attendanceRecords: "0 4 * * *"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -24,3 +24,11 @@ generic-service:
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev
+
+# We are overriding the times in development due to core service dependencies being switched off overnight e.g. prisoner search API.
+cron:
+  allocationsDeallocate: "30 21 * * *"
+  allocationsActivate: "30 6 * * *"
+  appointmentAttendees: "30 6 * * *"
+  createScheduledInstances: "45 6 * * *"
+  attendanceRecords: "0 7 * * *"


### PR DESCRIPTION
**LOW (MEDIUM?) RISK**

Pulled out the job times into env vars in the helm config so we can alter the times at which jobs run for each environment where needed.

The driver for this is due to the fact some core services we use are turned off overnight.  The also means we can remove any jobs which have currently been manually applied to dev as a temporary workaround.