### PR TITLE
SAA-1345 job to automatically retry messages on DLQ's and reduce the level of manual intervention.

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/templates/queue-housekeeping-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/queue-housekeeping-cronjob.yaml
@@ -1,0 +1,24 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: hmpps-activities-management-api-queue-housekeeping
+spec:
+  schedule: "*/10 * * * *"
+  concurrencyPolicy: Forbid
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 600
+  successfulJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      # Tidy up all jobs after 4 days
+      ttlSecondsAfterFinished: 345600
+      template:
+        spec:
+          containers:
+            - name: housekeeping
+              image: ghcr.io/ministryofjustice/hmpps-devops-tools
+              args:
+                - /bin/sh
+                - -c
+                - curl --retry 2 -XPUT http://hmpps-activities-management-api/queue-admin/retry-all-dlqs
+          restartPolicy: Never

--- a/helm_deploy/hmpps-activities-management-api/values.yaml
+++ b/helm_deploy/hmpps-activities-management-api/values.yaml
@@ -24,6 +24,10 @@ generic-service:
           deny all;
           return 401;
         }
+        location /queue-admin/retry-all-dlqs {
+          deny all;
+          return 401;
+        }
 
   # Used to access resources like SQS queues and SNS topics
   serviceAccountName: hmpps-activities-management-api

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/ResourceServerConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/ResourceServerConfiguration.kt
@@ -32,6 +32,7 @@ class ResourceServerConfiguration {
           "/swagger-ui.html",
           "/h2-console/**",
           "/job/**", // This endpoint is secured in the ingress rather than the app so that it can be called from within the namespace without requiring authentication
+          "/queue-admin/retry-all-dlqs", // This endpoint is secured in the ingress rather than the app so that it can be called from within the namespace without requiring authentication
         ).forEach { authorize(it, permitAll) }
         authorize(anyRequest, authenticated)
       }


### PR DESCRIPTION
At the moment when messages are put onto the DLQ's it requires manual intervention to retry them.  This change automates the retry.

Note: It will still raise an alert if the retry fails.