### PR TITLE
SAA-1258: Cancel appointment post transaction sync events

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentEntityListener.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentEntityListener.kt
@@ -37,15 +37,9 @@ class AppointmentEntityListener {
   fun onUpdate(entity: Appointment) {
     entity.attendees().forEach { attendee ->
       runCatching {
-        outboundEventsService.send(
-          when {
-            entity.isCancelled() -> OutboundEvent.APPOINTMENT_INSTANCE_CANCELLED
-            entity.isDeleted -> OutboundEvent.APPOINTMENT_INSTANCE_DELETED
-
-            else -> { OutboundEvent.APPOINTMENT_INSTANCE_UPDATED }
-          },
-          attendee.appointmentAttendeeId,
-        )
+        if (!entity.isCancelled() && !entity.isDeleted) {
+          outboundEventsService.send(OutboundEvent.APPOINTMENT_INSTANCE_UPDATED, attendee.appointmentAttendeeId)
+        }
       }.onFailure {
         log.error(
           "Failed to send appointment instance updated event for appointment instance id ${attendee.appointmentAttendeeId}",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentEntityListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentEntityListenerTest.kt
@@ -10,7 +10,6 @@ import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentSeriesEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
-import java.time.LocalDateTime
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @ActiveProfiles("test")
@@ -30,28 +29,6 @@ class AppointmentEntityListenerTest(@Autowired private val listener: Appointment
 
     appointment.attendees().forEach {
       verify(outboundEventsService).send(OutboundEvent.APPOINTMENT_INSTANCE_UPDATED, it.appointmentAttendeeId)
-    }
-    verifyNoMoreInteractions(outboundEventsService)
-  }
-
-  @Test
-  fun `appointment instance cancelled events raised on appointment update when appointment is cancelled`() {
-    appointment.cancelledTime = LocalDateTime.now()
-    listener.onUpdate(appointment)
-
-    appointment.attendees().forEach {
-      verify(outboundEventsService).send(OutboundEvent.APPOINTMENT_INSTANCE_CANCELLED, it.appointmentAttendeeId)
-    }
-    verifyNoMoreInteractions(outboundEventsService)
-  }
-
-  @Test
-  fun `appointment instance deleted events raised on appointment update when appointment is deleted`() {
-    appointment.isDeleted = true
-    listener.onUpdate(appointment)
-
-    appointment.attendees().forEach {
-      verify(outboundEventsService).send(OutboundEvent.APPOINTMENT_INSTANCE_DELETED, it.appointmentAttendeeId)
     }
     verifyNoMoreInteractions(outboundEventsService)
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentIntegrationTest.kt
@@ -270,6 +270,7 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
     }
 
     verify(eventsPublisher, times(1)).send(eventCaptor.capture())
+    verifyNoMoreInteractions(eventsPublisher)
 
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo("appointments.appointment-instance.updated")
@@ -303,6 +304,7 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
     }
 
     verify(eventsPublisher, times(1)).send(eventCaptor.capture())
+    verifyNoMoreInteractions(eventsPublisher)
 
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo("appointments.appointment-instance.cancelled")
@@ -333,6 +335,7 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
     assertThat(appointmentSeries.appointments).isEmpty()
 
     verify(eventsPublisher, times(1)).send(eventCaptor.capture())
+    verifyNoMoreInteractions(eventsPublisher)
 
     with(eventCaptor.firstValue) {
       assertThat(eventType).isEqualTo("appointments.appointment-instance.deleted")
@@ -366,6 +369,7 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
     }
 
     verify(eventsPublisher, times(4)).send(eventCaptor.capture())
+    verifyNoMoreInteractions(eventsPublisher)
 
     with(eventCaptor.allValues) {
       assertThat(map { it.additionalInformation }).containsAll(
@@ -415,6 +419,7 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
     }
 
     verify(eventsPublisher, times(4)).send(eventCaptor.capture())
+    verifyNoMoreInteractions(eventsPublisher)
 
     with(eventCaptor.allValues) {
       assertThat(map { it.additionalInformation }).containsAll(
@@ -652,6 +657,7 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
     }
 
     verify(eventsPublisher, times(6)).send(eventCaptor.capture())
+    verifyNoMoreInteractions(eventsPublisher)
 
     with(eventCaptor.allValues.filter { it.eventType == "appointments.appointment-instance.created" }) {
       assertThat(size).isEqualTo(2)


### PR DESCRIPTION
## Overview

Updates appointment cancellation code to wrap transactions in `newSpringTransaction` then publishes sync events after cancellations have been persisted.