### PR TITLE
SAA-1357 add Sentry integration to capture and raise alerts for all job failures.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
   kotlin("plugin.jpa") version "1.9.20"
   jacoco
   id("org.openapi.generator") version "6.6.0"
+  id("io.sentry.jvm.gradle") version "3.14.0"
 }
 
 allOpen {

--- a/helm_deploy/hmpps-activities-management-api/values.yaml
+++ b/helm_deploy/hmpps-activities-management-api/values.yaml
@@ -98,6 +98,8 @@ generic-service:
     digital-prison-reporting:
       DPR_USER: "DPR_USER"
       DPR_PASSWORD: "DPR_PASSWORD"
+    sentry:
+      sentry_dsn: "SENTRY_DSN"
 
   allowlist:
     office: "217.33.148.210/32"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MonitoringService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MonitoringService.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import io.sentry.Sentry
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+
+/**
+ * Simple service for capturing free text messages in the underlying monitoring tool.
+ *
+ * Extra care must be taken when using this service not to include any PII data in any of the calls.
+ */
+@Service
+class MonitoringService {
+
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  init {
+    log.info("Monitoring service is ${if (Sentry.isEnabled()) "enabled" else "disabled"}")
+  }
+
+  fun capture(message: String) {
+    // This checks for the presence of the Sentry environment variable SENTRY_DSN, if is disabled if not found.
+    if (Sentry.isEnabled()) Sentry.captureMessage(message)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/AppointmentMetricsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/AppointmentMetricsJobTest.kt
@@ -16,12 +16,13 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rollout
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.DailyAppointmentMetricsService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ScheduleReasonEventType
 import java.time.LocalDate
 
 class AppointmentMetricsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock()
   private val prisonApiClient: PrisonApiApplicationClient = mock()
   private val service: DailyAppointmentMetricsService = mock()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CancelAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CancelAppointmentsJobTest.kt
@@ -15,11 +15,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentCancelRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
 import java.time.LocalDateTime
 
 class CancelAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val service: AppointmentCancelDomainService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = CancelAppointmentsJob(safeJobRunner, service)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateAppointmentsJobTest.kt
@@ -11,10 +11,11 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentCreateDomainService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType.CREATE_APPOINTMENTS
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
 
 class CreateAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val appointmentCreateDomainService: AppointmentCreateDomainService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = CreateAppointmentsJob(safeJobRunner, appointmentCreateDomainService)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateScheduledInstancesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/CreateScheduledInstancesJobTest.kt
@@ -11,12 +11,13 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType.SCHEDULES
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageScheduledInstancesService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
 
 @ExtendWith(MockitoExtension::class)
 class CreateScheduledInstancesJobTest {
   private val service: ManageScheduledInstancesService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = CreateScheduledInstancesJob(service, safeJobRunner)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/DeleteMigratedAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/DeleteMigratedAppointmentsJobTest.kt
@@ -11,11 +11,12 @@ import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MigrateAppointmentService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
 import java.time.LocalDate
 
 class DeleteMigratedAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val service: MigrateAppointmentService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = DeleteMigratedAppointmentsJob(safeJobRunner, service)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -11,11 +11,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAllocationsService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
 
 class ManageAllocationsJobTest {
   private val deallocationService: ManageAllocationsService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val job = ManageAllocationsJob(deallocationService, safeJobRunner)
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAppointmentAttendeesJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAppointmentAttendeesJobTest.kt
@@ -14,10 +14,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rollout
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AppointmentAttendeeService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
 
 class ManageAppointmentAttendeesJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock()
   private val service: AppointmentAttendeeService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
@@ -12,11 +12,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AttendanceOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAttendancesService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
 
 class ManageAttendanceRecordsJobTest {
   private val attendancesService: ManageAttendancesService = mock()
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val job = ManageAttendanceRecordsJob(attendancesService, safeJobRunner)
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/UpdateAppointmentsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/UpdateAppointmentsJobTest.kt
@@ -15,12 +15,13 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ApplyTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSearchPrisonerFixture
 import java.time.LocalDateTime
 
 class UpdateAppointmentsJobTest {
   private val jobRepository: JobRepository = mock()
-  private val safeJobRunner = spy(SafeJobRunner(jobRepository))
+  private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val service: AppointmentUpdateDomainService = mock()
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
   private val job = UpdateAppointmentsJob(safeJobRunner, service)


### PR DESCRIPTION
This is the first step towards raising visibility of job failures to the team (mainly the dev team initially).

The intention is to raise both Slack and email alerts.  This requires some initial configuration vi [Sentry.IO](https://sentry.io)

I have set up a project and team in Sentry. Team members will need to log into and join to receive email alerts. You can log in with you Github account.

I have added the relevant secret to the k8s dev namespace.  Once that is proven I will adde to the higher environments.