### PR TITLE
SAA-1357 add missing call to monitoring service where a subsequent job can fail (not run) due to the first not working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The serivce uses [Sentry.IO](https://ministryofjustice.sentry.io/) to raise aler
 
 Rules for alerts can be configured [here](https://ministryofjustice.sentry.io/alerts/rules/).
 
-For Sentry integration to work it requires the environment variable `SENTRY_DSN` to be set up in Kubernettes an environment. This value for this can be found [here](https://ministryofjustice.sentry.io/settings/projects/hmpps-activities-management/keys/).
+For Sentry integration to work it requires the environment variable `SENTRY_DSN` to be set up in Kubernettes. This value for this can be found [here](https://ministryofjustice.sentry.io/settings/projects/hmpps-activities-management/keys/).
 
 ```
 echo -n '<SENTRY_DSN_GOES_HERE>' | base64

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/SafeJobRunner.kt
@@ -39,7 +39,9 @@ class SafeJobRunner(private val jobRepository: JobRepository, private val monito
       } else {
         log.warn("Ignoring job ${job.jobType} due to failure in a dependent job.")
 
-        jobRepository.saveAndFlush(Job.failed(job.jobType, LocalDateTime.now()))
+        jobRepository.saveAndFlush(Job.failed(job.jobType, LocalDateTime.now())).also { failedJob ->
+          monitoringService.capture("Dependant job '${failedJob.jobType}' for job id '${failedJob.jobId}' failed")
+        }
       }
     }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
@@ -83,6 +83,8 @@ class ManageAttendancesService(
                 log.info("Sending sync event for attendance ID ${saved.attendanceId} ${saved.prisonerNumber} ${saved.scheduledInstance.activitySchedule.description}")
                 outboundEventsService.send(OutboundEvent.PRISONER_ATTENDANCE_CREATED, saved.attendanceId)
               }
+            }.onFailure {
+              log.error("Error occurred saving attendances", it)
             }
           }
         }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MonitoringService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MonitoringService.kt
@@ -23,6 +23,6 @@ class MonitoringService {
 
   fun capture(message: String) {
     // This checks for the presence of the Sentry environment variable SENTRY_DSN, if is disabled if not found.
-    if (Sentry.isEnabled()) Sentry.captureMessage(message)
+    if (Sentry.isEnabled()) Sentry.captureMessage(message) else log.info("Monitoring service is disabled, logging message instead: $message")
   }
 }


### PR DESCRIPTION
Adding (missed) call to monitoring service in the safe job runner.