### PR TITLE
SAA-1357 configure Sentry to use external environment variables e.g. SENTRY_ENVIRONMENT.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MonitoringService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MonitoringService.kt
@@ -18,7 +18,10 @@ class MonitoringService {
   }
 
   init {
-    log.info("Monitoring service is ${if (Sentry.isEnabled()) "enabled" else "disabled"}")
+    // Setting this to true enables configuration via environment variables e.g. SENTRY_ENVIRONMENT
+    Sentry.init { options -> options.isEnableExternalConfiguration = true }
+
+    log.info("Monitoring service is ${if (Sentry.isEnabled()) "enabled in environment '${Sentry.getCurrentHub().options.environment}'" else "disabled"}")
   }
 
   fun capture(message: String) {


### PR DESCRIPTION
Apologies I missed this.  I made an assumption because SENTRY_DSN environment var is read without this setting.