### PR TITLE
SAA-1383: Fixed allocation end date logic

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -123,7 +123,7 @@ data class Allocation(
     this.apply {
       if (prisonerStatus == PrisonerStatus.ENDED) throw IllegalStateException("Allocation with ID '$allocationId' is already deallocated.")
       if (date.isBefore(LocalDate.now())) throw IllegalArgumentException("Planned deallocation date must not be in the past.")
-      if (maybeEndDate() != null && date.isAfter(maybeEndDate())) throw IllegalArgumentException("Planned date cannot be after ${maybeEndDate()}.")
+      if (activitySchedule.endDate != null && date.isAfter(activitySchedule.endDate)) throw IllegalArgumentException("Planned deallocation date cannot be after activity schedule end date, ${activitySchedule.endDate}.")
 
       if (plannedDeallocation == null) {
         plannedDeallocation = PlannedDeallocation(
@@ -144,9 +144,9 @@ data class Allocation(
 
   private fun maybeEndDate() =
     when {
+      endDate != null -> endDate
       activitySchedule.endDate != null -> activitySchedule.endDate
       activitySchedule.activity.endDate != null -> activitySchedule.activity.endDate
-      endDate != null -> endDate
       else -> null
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -213,7 +213,7 @@ class AllocationTest {
     assertThatThrownBy {
       allocationNoEndDate.deallocateOn(tomorrow, DeallocationReason.TRANSFERRED, "by test")
     }.isInstanceOf(IllegalArgumentException::class.java)
-      .hasMessage("Planned date cannot be after $today.")
+      .hasMessage("Planned deallocation date cannot be after activity schedule end date, $today.")
   }
 
   @Test


### PR DESCRIPTION
## Overview

Small change to fix a bug where an updated allocation end date is validated against the existing allocation end date.