### PR TITLE
SAA-1385 introducing support for paid and unpaid activities on creation.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -75,6 +75,8 @@ data class Activity(
   var updatedTime: LocalDateTime? = null,
 
   var updatedBy: String? = null,
+
+  val paid: Boolean,
 ) {
 
   var endDate: LocalDate? = null
@@ -168,6 +170,10 @@ data class Activity(
     pieceRate: Int?,
     pieceRateItems: Int?,
   ) {
+    require(paid) {
+      "Unpaid activity '$summary' cannot have pay rates added to it"
+    }
+
     require(activityPay().none { it.payBand == payBand && it.incentiveNomisCode == incentiveNomisCode }) {
       "The pay band and incentive level combination must be unique for each pay rate"
     }
@@ -292,6 +298,7 @@ data class Activity(
     endDate = endDate,
     createdTime = createdTime,
     activityState = getActivityState(),
+    paid = paid,
   )
 
   @Override

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -76,7 +76,7 @@ data class Activity(
 
   var updatedBy: String? = null,
 
-  val paid: Boolean,
+  private var paid: Boolean,
 ) {
 
   var endDate: LocalDate? = null
@@ -300,6 +300,8 @@ data class Activity(
     activityState = getActivityState(),
     paid = paid,
   )
+
+  fun isPaid() = paid
 
   @Override
   override fun toString(): String {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Activity.kt
@@ -93,6 +93,9 @@ data class Activity(
 
   @Schema(description = "The list of minimum education levels that can apply to this activity")
   val minimumEducationLevel: List<ActivityMinimumEducationLevel> = emptyList(),
+
+  @Schema(description = "Whether the activity is a paid activity", example = "true")
+  val paid: Boolean,
 )
 
 enum class PayPerSession { H, F }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityLite.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityLite.kt
@@ -74,4 +74,7 @@ data class ActivityLite(
 
   @Schema(description = "Whether the activity is live or archived", example = "live")
   val activityState: ActivityState,
+
+  @Schema(description = "Whether the activity is a paid activity", example = "true")
+  val paid: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
+import jakarta.validation.constraints.AssertTrue
 import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.Max
 import jakarta.validation.constraints.Min
@@ -42,6 +43,9 @@ data class ActivityCreateRequest(
 
   @Schema(description = "Flag to indicate if the activity carried out outside of the prison", example = "false")
   var outsideWork: Boolean,
+
+  @Schema(description = "Flag to indicate if the activity is a paid activity. It true then pay rates are required, if false then no pay rates should be provided", example = "true")
+  val paid: Boolean = true,
 
   @Schema(
     description = "Indicates whether the activity session is a (F)ull day or a (H)alf day (for payment purposes). ",
@@ -140,4 +144,7 @@ data class ActivityCreateRequest(
 
   @Schema(description = "Whether the schedule runs on bank holidays", example = "true")
   val runsOnBankHoliday: Boolean = false,
-)
+) {
+  @AssertTrue(message = "Unpaid activity cannot have pay rates associated with it")
+  private fun isUnpaid() = paid || pay.isEmpty()
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
@@ -146,5 +146,8 @@ data class ActivityCreateRequest(
   val runsOnBankHoliday: Boolean = false,
 ) {
   @AssertTrue(message = "Unpaid activity cannot have pay rates associated with it")
-  private fun isUnpaid() = paid || pay.isEmpty()
+  private fun isUnpaid() = pay.isEmpty() || paid
+
+  @AssertTrue(message = "Paid activity must have at least one pay rate associated with it")
+  private fun isPaid() = pay.isNotEmpty() || !paid
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityUpdateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityUpdateRequest.kt
@@ -93,7 +93,7 @@ data class ActivityUpdateRequest(
   val minimumEducationLevel: List<ActivityMinimumEducationLevelCreateRequest>? = null,
 
   @field:Valid
-  @Schema(description = "The list of pay rates that can apply to this activity")
+  @Schema(description = "The list of pay rates that can apply to this activity. Must be null or empty if the activity is unpaid")
   val pay: List<ActivityPayCreateRequest>? = null,
 
   @field:Min(value = 1, message = "Schedule weeks must be either 1 or 2")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -138,6 +138,7 @@ class ActivityService(
 
     require(request.startDate!! > LocalDate.now()) { "Activity start date must be in the future" }
     require((request.locationId != null) xor request.offWing xor request.onWing xor request.inCell) { "Activity location can only be maximum one of offWing, onWing, inCell, or a specified location" }
+    require(request.paid || request.pay.isEmpty()) { "Unpaid activity cannot have pay rates associated with it" }
 
     val category = activityCategoryRepository.findOrThrowIllegalArgument(request.categoryId!!)
     val tier = request.tierCode?.let { eventTierRepository.findByCodeOrThrowIllegalArgument(it) }
@@ -165,6 +166,7 @@ class ActivityService(
       minimumIncentiveLevel = request.minimumIncentiveLevel!!,
       createdTime = LocalDateTime.now(),
       createdBy = createdBy,
+      paid = request.paid,
     ).apply {
       this.organiser = organiser
       endDate = request.endDate

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -139,6 +139,7 @@ class ActivityService(
     require(request.startDate!! > LocalDate.now()) { "Activity start date must be in the future" }
     require((request.locationId != null) xor request.offWing xor request.onWing xor request.inCell) { "Activity location can only be maximum one of offWing, onWing, inCell, or a specified location" }
     require(request.paid || request.pay.isEmpty()) { "Unpaid activity cannot have pay rates associated with it" }
+    require(!request.paid || request.pay.isNotEmpty()) { "Paid activity must have at least one pay rate associated with it" }
 
     val category = activityCategoryRepository.findOrThrowIllegalArgument(request.categoryId!!)
     val tier = request.tierCode?.let { eventTierRepository.findByCodeOrThrowIllegalArgument(it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
@@ -247,6 +247,7 @@ class MigrateActivityService(
       createdBy = MIGRATION_USER,
       updatedTime = LocalDateTime.now(),
       updatedBy = MIGRATION_USER,
+      paid = true,
     ).apply {
       endDate = request.endDate
     }.apply {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -84,6 +84,7 @@ fun transform(activity: EntityActivity) =
     updatedTime = activity.updatedTime,
     updatedBy = activity.updatedBy,
     minimumEducationLevel = activity.activityMinimumEducationLevel().toModel(),
+    paid = activity.paid,
   )
 
 /*

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -84,7 +84,7 @@ fun transform(activity: EntityActivity) =
     updatedTime = activity.updatedTime,
     updatedBy = activity.updatedBy,
     minimumEducationLevel = activity.activityMinimumEducationLevel().toModel(),
-    paid = activity.paid,
+    paid = activity.isPaid(),
   )
 
 /*

--- a/src/main/resources/migrations/common/V2023.11.23__add_paid_column_to_activity.sql
+++ b/src/main/resources/migrations/common/V2023.11.23__add_paid_column_to_activity.sql
@@ -1,0 +1,5 @@
+ALTER TABLE activity ADD COLUMN paid boolean;
+
+UPDATE activity SET paid = true;
+
+ALTER TABLE activity ALTER COLUMN paid SET NOT NULL;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -74,6 +74,7 @@ class ActivityScheduleTest {
         allocated = 2,
         createdTime = LocalDate.now().atStartOfDay(),
         activityState = ActivityState.LIVE,
+        paid = true,
       ),
       scheduleWeeks = 1,
       slots = listOf(
@@ -145,6 +146,7 @@ class ActivityScheduleTest {
           allocated = 2,
           createdTime = LocalDate.now().atStartOfDay(),
           activityState = ActivityState.LIVE,
+          paid = true,
         ),
         scheduleWeeks = 1,
         slots = listOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
@@ -83,6 +83,7 @@ class ActivityTest {
       allocated = 0,
       createdTime = LocalDate.now().atStartOfDay(),
       activityState = ActivityState.LIVE,
+      paid = true,
     )
     assertThat(activityEntity().copy(attendanceRequired = false).toModelLite()).isEqualTo(expectedModel)
   }
@@ -124,6 +125,7 @@ class ActivityTest {
         allocated = 2,
         createdTime = LocalDate.now().atStartOfDay(),
         activityState = ActivityState.LIVE,
+        paid = true,
       ),
     )
 
@@ -351,8 +353,8 @@ class ActivityTest {
   }
 
   @Test
-  fun `can add pay bands to activity`() {
-    val activity = activityEntity(noPayBands = true).also { assertThat(it.activityPay()).isEmpty() }
+  fun `can add pay bands to paid activity`() {
+    val activity = activityEntity(noPayBands = true, paid = true).also { assertThat(it.activityPay()).isEmpty() }
 
     activity.addPay(
       incentiveNomisCode = "BAS",
@@ -392,6 +394,23 @@ class ActivityTest {
         activity = activity,
       ),
     )
+  }
+
+  @Test
+  fun `cannot add pay bands to unpaid activity`() {
+    val activity = activityEntity(noPayBands = true, paid = false).also { assertThat(it.activityPay()).isEmpty() }
+
+    assertThatThrownBy {
+      activity.addPay(
+        incentiveNomisCode = "BAS",
+        incentiveLevel = "Basic",
+        payBand = lowPayBand,
+        rate = 30,
+        pieceRate = 40,
+        pieceRateItems = 50,
+      )
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Unpaid activity 'Maths' cannot have pay rates added to it")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -63,6 +63,7 @@ internal fun activityEntity(
   inCell: Boolean = false,
   onWing: Boolean = false,
   riskLevel: String = "high",
+  paid: Boolean = true,
 ) =
   Activity(
     activityId = activityId,
@@ -79,6 +80,7 @@ internal fun activityEntity(
     createdBy = "test",
     inCell = inCell,
     onWing = onWing,
+    paid = paid,
   ).apply {
     this.organiser = organiser
     this.endDate = endDate
@@ -358,6 +360,7 @@ internal fun activityCreateRequest(
   educationLevel: ReferenceCode? = null,
   studyArea: ReferenceCode? = null,
   eligibilityRules: Set<EligibilityRule> = setOf(eligibilityRuleOver21),
+  paid: Boolean = true,
 ) =
   ActivityCreateRequest(
     prisonCode = prisonCode,
@@ -392,6 +395,7 @@ internal fun activityCreateRequest(
     slots = listOf(Slot(weekNumber = 1, timeSlot = "AM", monday = true)),
     onWing = false,
     offWing = false,
+    paid = paid,
   )
 
 internal fun ActivityScheduleSlot.runEveryDayOfWeek() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingL
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Slot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityMinimumEducationLevelCreateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityPayCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transform
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -375,7 +376,7 @@ internal fun activityCreateRequest(
     tierCode = eventTier().code,
     organiserCode = eventOrganiser().code,
     eligibilityRuleIds = eligibilityRules.map { it.eligibilityRuleId },
-    pay = emptyList(),
+    pay = if (paid) listOf(ActivityPayCreateRequest(incentiveNomisCode = "123", incentiveLevel = "level", payBandId = 1)) else emptyList(),
     riskLevel = "high",
     minimumIncentiveNomisCode = "BAS",
     minimumIncentiveLevel = "Basic",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -315,6 +315,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           allocated = 4,
           createdTime = LocalDateTime.of(2022, 9, 21, 0, 0, 0),
           activityState = ActivityState.LIVE,
+          paid = true,
         ),
         slots = listOf(
           ActivityScheduleSlot(
@@ -369,6 +370,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           allocated = 4,
           createdTime = LocalDateTime.of(2022, 9, 21, 0, 0, 0),
           activityState = ActivityState.LIVE,
+          paid = true,
         ),
         slots = listOf(
           ActivityScheduleSlot(
@@ -425,6 +427,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           allocated = 2,
           createdTime = LocalDateTime.of(2022, 9, 21, 0, 0, 0),
           activityState = ActivityState.LIVE,
+          paid = true,
         ),
         slots = listOf(
           ActivityScheduleSlot(
@@ -495,6 +498,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           allocated = 2,
           createdTime = LocalDateTime.of(2022, 9, 21, 0, 0, 0),
           activityState = ActivityState.LIVE,
+          paid = true,
         ),
         slots = listOf(
           ActivityScheduleSlot(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
@@ -58,6 +58,7 @@ class PrisonIntegrationTest : IntegrationTestBase() {
         allocated = 4,
         createdTime = LocalDateTime.of(2022, 9, 21, 0, 0, 0),
         activityState = ActivityState.LIVE,
+        paid = true,
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.adjudic
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentCategoryReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.prisonerTransfer
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.read
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userCaseLoads
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userDetail
 import java.time.LocalDate
@@ -338,7 +339,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
     )
   }
 
-  fun stubGetReferenceCode(domain: String, referenceCode: String, jsonResponseFile: String) {
+  fun stubGetReferenceCode(domain: String, referenceCode: String, jsonResponseFile: String): ReferenceCode {
     stubFor(
       WireMock.get(WireMock.urlEqualTo("/api/reference-domains/domains/$domain/codes/$referenceCode"))
         .willReturn(
@@ -348,6 +349,8 @@ class PrisonApiMockServer : WireMockServer(8999) {
             .withStatus(200),
         ),
     )
+
+    return mapper.read(jsonResponseFile)
   }
 
   fun stubGetLocationsForAppointments(prisonCode: String, locationId: Long) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleInstanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleInstanceTest.kt
@@ -56,6 +56,7 @@ class ActivityScheduleInstanceTest : ModelTest() {
           allocated = 5,
           createdTime = LocalDateTime.now(),
           activityState = ActivityState.LIVE,
+          paid = true,
         ),
         description = "Some Desc",
         capacity = 10,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleLiteTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleLiteTest.kt
@@ -38,6 +38,7 @@ class ActivityScheduleLiteTest : ModelTest() {
         allocated = 5,
         createdTime = LocalDateTime.now(),
         activityState = ActivityState.LIVE,
+        paid = true,
       ),
       description = "Some Desc",
       capacity = 10,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleTest.kt
@@ -38,6 +38,7 @@ class ActivityScheduleTest : ModelTest() {
         allocated = 5,
         createdTime = LocalDate.now().atStartOfDay(),
         activityState = ActivityState.LIVE,
+        paid = true,
       ),
       description = "Some Desc",
       capacity = 10,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityTest.kt
@@ -40,6 +40,7 @@ class ActivityTest : ModelTest() {
       minimumIncentiveNomisCode = "N1",
       updatedBy = "TestUser",
       updatedTime = originalCreatedTime,
+      paid = true,
     )
 
     val json = objectMapper.writeValueAsString(activity)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequestTest.kt
@@ -53,11 +53,23 @@ class ActivityCreateRequestTest {
   }
 
   @Test
-  fun `Unpaid activity cannot have pay rates`() {
-    val unpaidActivity = activityCreateRequest(paid = false).copy(pay = listOf(ActivityPayCreateRequest(incentiveLevel = "1", incentiveNomisCode = "2", payBandId = 1)))
+  fun `Paid activity must have pay rates`() {
+    val paidActivityNoPay = activityCreateRequest(paid = true).copy(pay = emptyList())
 
     assertThat(
-      validator.validate(unpaidActivity),
+      validator.validate(paidActivityNoPay),
+    ).satisfiesOnlyOnce {
+      assertThat(it.propertyPath.toString()).isEqualTo("paid")
+      assertThat(it.message).isEqualTo("Paid activity must have at least one pay rate associated with it")
+    }
+  }
+
+  @Test
+  fun `Unpaid activity cannot have pay rates`() {
+    val unpaidActivityWithPay = activityCreateRequest(paid = false).copy(pay = listOf(ActivityPayCreateRequest(incentiveLevel = "1", incentiveNomisCode = "2", payBandId = 1)))
+
+    assertThat(
+      validator.validate(unpaidActivityWithPay),
     ).satisfiesOnlyOnce {
       assertThat(it.propertyPath.toString()).isEqualTo("unpaid")
       assertThat(it.message).isEqualTo("Unpaid activity cannot have pay rates associated with it")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequestTest.kt
@@ -51,4 +51,16 @@ class ActivityCreateRequestTest {
       assertThat(it.message).isEqualTo("Schedule weeks must be either 1 or 2")
     }
   }
+
+  @Test
+  fun `Unpaid activity cannot have pay rates`() {
+    val unpaidActivity = activityCreateRequest(paid = false).copy(pay = listOf(ActivityPayCreateRequest(incentiveLevel = "1", incentiveNomisCode = "2", payBandId = 1)))
+
+    assertThat(
+      validator.validate(unpaidActivity),
+    ).satisfiesOnlyOnce {
+      assertThat(it.propertyPath.toString()).isEqualTo("unpaid")
+      assertThat(it.message).isEqualTo("Unpaid activity cannot have pay rates associated with it")
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityControllerTest.kt
@@ -282,6 +282,7 @@ class ActivityControllerTest : ControllerTestBase<ActivityController>() {
           allocated = 10,
           createdTime = LocalDateTime.now(),
           activityState = ActivityState.LIVE,
+          paid = true,
         ),
         slots = listOf(
           ActivityScheduleSlot(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/PrisonControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/PrisonControllerTest.kt
@@ -75,6 +75,7 @@ class PrisonControllerTest : ControllerTestBase<PrisonController>() {
         allocated = 10,
         createdTime = LocalDateTime.now(),
         activityState = ActivityState.LIVE,
+        paid = true,
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
@@ -283,6 +283,17 @@ class ActivityServiceTest {
   }
 
   @Test
+  fun `createActivity - fails when unpaid activity has pay rates`() {
+    val createActivityRequestWithPayRates = mapper.read<ActivityCreateRequest>("activity/activity-create-request-1.json")
+      .copy(startDate = TimeSource.tomorrow(), paid = false)
+
+    assertThatThrownBy {
+      service().createActivity(createActivityRequestWithPayRates, "SCH_ACTIVITY")
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Unpaid activity cannot have pay rates associated with it")
+  }
+
+  @Test
   fun `createActivity - start date must be in the future`() {
     assertThatThrownBy {
       service().createActivity(
@@ -925,7 +936,7 @@ class ActivityServiceTest {
   @Test
   fun `updateActivity - update pay`() {
     val updateActivityRequest: ActivityUpdateRequest = mapper.read("activity/activity-update-request-3.json")
-    val activityEntity: ActivityEntity = mapper.read("activity/activity-entity-1.json")
+    val activityEntity: ActivityEntity = activityEntity(noPayBands = true).copy(activityId = 17)
 
     whenever(
       activityRepository.findByActivityIdAndPrisonCodeWithFilters(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceFixture.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceFixture.kt
@@ -52,6 +52,7 @@ object ScheduledInstanceFixture {
         riskLevel = "high",
         createdTime = LocalDateTime.of(2022, 10, 1, 12, 0, 0),
         createdBy = "CREATED BY",
+        paid = true,
       ),
       description = "DESCRIPTION $activityScheduleId",
       internalLocationId = locationId,

--- a/src/test/resources/test_data/seed-activities-changed-event-deletes-attendances.sql
+++ b/src/test/resources/test_data/seed-activities-changed-event-deletes-attendances.sql
@@ -4,11 +4,11 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '00:01:00', '00:02:00', '13:00:00', '16:30:00', '23:58:00', '23:59:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-changed-event.sql
+++ b/src/test/resources/test_data/seed-activity-changed-event.sql
@@ -4,8 +4,8 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '00:01:00', '00:02:00', '13:00:00', '16:30:00', '23:58:00', '23:59:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-for-attendance-marking.sql
+++ b/src/test/resources/test_data/seed-activity-for-attendance-marking.sql
@@ -1,8 +1,8 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-for-events.sql
+++ b/src/test/resources/test_data/seed-activity-for-events.sql
@@ -1,8 +1,8 @@
 --
 -- Test data for scheduled events multiple activities.
 --
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-for-with-exclusions.sql
+++ b/src/test/resources/test_data/seed-activity-for-with-exclusions.sql
@@ -1,8 +1,8 @@
 --
 -- Test data for scheduled events multiple activities.
 --
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-1.sql
+++ b/src/test/resources/test_data/seed-activity-id-1.sql
@@ -1,8 +1,8 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-10.sql
+++ b/src/test/resources/test_data/seed-activity-id-10.sql
@@ -1,8 +1,8 @@
 --
 -- One activity with one schedule, one slot and one instance but no allocations
 --
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (10, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (10, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
 values (1, 10, 'Geography AM', 1, 'L1', 'Location MDI 1', 10, '2022-10-01');

--- a/src/test/resources/test_data/seed-activity-id-11.sql
+++ b/src/test/resources/test_data/seed-activity-id-11.sql
@@ -1,8 +1,8 @@
 --
 -- Test data for activity offender deallocation for an activity ending today.  Note one allocation is already ended, 3 are not.  This is to ensure it does not try end it again.
 --
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date -1, current_date, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date -1, current_date, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-12.sql
+++ b/src/test/resources/test_data/seed-activity-id-12.sql
@@ -1,8 +1,8 @@
 --
 -- Test data for activity offender deallocation for an activity with no end date. Only one of the 3 allocations should be deallocated
 --
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date -1, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date -1, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-13.sql
+++ b/src/test/resources/test_data/seed-activity-id-13.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-14.sql
+++ b/src/test/resources/test_data/seed-activity-id-14.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-15.sql
+++ b/src/test/resources/test_data/seed-activity-id-15.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-16.sql
+++ b/src/test/resources/test_data/seed-activity-id-16.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-17.sql
+++ b/src/test/resources/test_data/seed-activity-id-17.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-18.sql
+++ b/src/test/resources/test_data/seed-activity-id-18.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 125, 1),

--- a/src/test/resources/test_data/seed-activity-id-19.sql
+++ b/src/test/resources/test_data/seed-activity-id-19.sql
@@ -1,8 +1,8 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, activity_organiser_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 2, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, activity_organiser_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 2, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (0, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-2.sql
+++ b/src/test/resources/test_data/seed-activity-id-2.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 2, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-20.sql
+++ b/src/test/resources/test_data/seed-activity-id-20.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-21.sql
+++ b/src/test/resources/test_data/seed-activity-id-21.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-22.sql
+++ b/src/test/resources/test_data/seed-activity-id-22.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-23.sql
+++ b/src/test/resources/test_data/seed-activity-id-23.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-24.sql
+++ b/src/test/resources/test_data/seed-activity-id-24.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, true, true, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, true, true, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-25.sql
+++ b/src/test/resources/test_data/seed-activity-id-25.sql
@@ -1,8 +1,8 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-26.sql
+++ b/src/test/resources/test_data/seed-activity-id-26.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths 1', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths 1', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);
@@ -7,8 +7,8 @@ values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
 values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths 2', 'Maths Level 2', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (2, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths 2', 'Maths Level 2', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (2, 2, 'BAS', 'Basic', 11, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-27.sql
+++ b/src/test/resources/test_data/seed-activity-id-27.sql
@@ -1,6 +1,6 @@
 -- Activity 1
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
@@ -15,8 +15,8 @@ insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_
 values (1, 1, '10:00:00', '11:00:00', true);
 
 -- Activity 2
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (2, 2, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-3.sql
+++ b/src/test/resources/test_data/seed-activity-id-3.sql
@@ -1,14 +1,14 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 2, 2, true, false, false, false, 'H', 'Geography', 'Geography Level 1', '2022-10-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'MDI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-11-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (2, 'MDI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-11-01', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (3, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (3, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (4, 'PVI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (4, 'PVI', 2, 2, true, false, false, false, 'H', 'English', 'English Level 2', '2022-10-21', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 101, 0, 0);

--- a/src/test/resources/test_data/seed-activity-id-4.sql
+++ b/src/test/resources/test_data/seed-activity-id-4.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (4, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', current_timestamp, 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (4, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', current_timestamp, 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 4, 'BAS', 'Basic', 1, 125, 125, 1),

--- a/src/test/resources/test_data/seed-activity-id-5.sql
+++ b/src/test/resources/test_data/seed-activity-id-5.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (5, 'PVI', 1, 1, false, false, false, false, 'H', 'Gym', 'Gym induction', current_date, null, 'high', 'BAS', 'Basic', current_timestamp, 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (5, 'PVI', 1, 1, false, false, false, false, 'H', 'Gym', 'Gym induction', current_date, null, 'high', 'BAS', 'Basic', current_timestamp, 'SEED USER', true);
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
 values (1, 5, 'Gym induction AM', 1, 'L1', 'Location 1', 10, current_date);

--- a/src/test/resources/test_data/seed-activity-id-6.sql
+++ b/src/test/resources/test_data/seed-activity-id-6.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 8, 1, true, false, false, false, 'H', 'Retirement', 'Basic retirement', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 8, 1, true, false, false, false, 'H', 'Retirement', 'Basic retirement', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-7.sql
+++ b/src/test/resources/test_data/seed-activity-id-7.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-8.sql
+++ b/src/test/resources/test_data/seed-activity-id-8.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, true, true, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, true, true, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-id-9.sql
+++ b/src/test/resources/test_data/seed-activity-id-9.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (9, 'MDI', 1, 1, true, true, true, true, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', current_timestamp, 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (9, 'MDI', 1, 1, true, true, true, true, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', current_timestamp, 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 9, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-multi-week-schedule-1.sql
+++ b/src/test/resources/test_data/seed-activity-multi-week-schedule-1.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, true, true, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, true, true, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-update-end-date.sql
+++ b/src/test/resources/test_data/seed-activity-update-end-date.sql
@@ -1,8 +1,8 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-update-slot.sql
+++ b/src/test/resources/test_data/seed-activity-update-slot.sql
@@ -1,8 +1,8 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-activity-with-old-instances.sql
+++ b/src/test/resources/test_data/seed-activity-with-old-instances.sql
@@ -1,8 +1,8 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Instance test', 'Instance test', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Instance test', 'Instance test', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-allocations-due-to-expire.sql
+++ b/src/test/resources/test_data/seed-allocations-due-to-expire.sql
@@ -4,11 +4,11 @@
 INSERT INTO prison_regime (prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES('PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 10, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 10, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', current_date - 10, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', current_date - 10, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-allocations-pending.sql
+++ b/src/test/resources/test_data/seed-allocations-pending.sql
@@ -4,8 +4,8 @@
 INSERT INTO prison_regime (prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES('PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-attendances-for-today.sql
+++ b/src/test/resources/test_data/seed-attendances-for-today.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 125, 1),

--- a/src/test/resources/test_data/seed-attendances-two-days-old-waiting.sql
+++ b/src/test/resources/test_data/seed-attendances-two-days-old-waiting.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 15, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 15, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 125, 1),

--- a/src/test/resources/test_data/seed-attendances-yesterdays-completed.sql
+++ b/src/test/resources/test_data/seed-attendances-yesterdays-completed.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 1, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 1, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 125, 1),

--- a/src/test/resources/test_data/seed-attendances-yesterdays-waiting.sql
+++ b/src/test/resources/test_data/seed-attendances-yesterdays-waiting.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 1, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 1, null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 125, 1),

--- a/src/test/resources/test_data/seed-attendances.sql
+++ b/src/test/resources/test_data/seed-attendances.sql
@@ -1,5 +1,5 @@
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
@@ -67,8 +67,8 @@ values (3, '2022-10-10', '18:00:00', '20:00:00', false, null, null, null, null);
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
 values (6, 3, 'A11111A', null, null, null, null, 'WAITING', null, null, null);
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'MDI', 4, 1, true, false, false, false, 'H', 'Gym', 'Gym', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (2, 'MDI', 4, 1, true, false, false, false, 'H', 'Gym', 'Gym', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (2, 2, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-offender-for-release.sql
+++ b/src/test/resources/test_data/seed-offender-for-release.sql
@@ -1,11 +1,11 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-offender-received-event-cancel-suspensions.sql
+++ b/src/test/resources/test_data/seed-offender-received-event-cancel-suspensions.sql
@@ -4,8 +4,8 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '00:01:00', '00:02:00', '13:00:00', '16:30:00', '23:58:00', '23:59:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);

--- a/src/test/resources/test_data/seed-offender-released-event-deletes-attendances.sql
+++ b/src/test/resources/test_data/seed-offender-released-event-deletes-attendances.sql
@@ -4,8 +4,8 @@
 INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
 VALUES(3, 'PVI', '00:01:00', '00:02:00', '13:00:00', '16:30:00', '23:58:00', '23:59:00');
 
-insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER');
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, minimum_incentive_nomis_code, minimum_incentive_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', 'BAS', 'Basic', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);


### PR DESCRIPTION
**MEDIUM RISK**

The is the first part of the API changes for the creation of paid or unpaid activities.  It does not cater for updates.

Still to do in separate PR's:

- Change the allocation journey to enforce pay band rules i.e. cannot have a pay band for unpaid activity. Pay band becomes nullable on allocations.
- Change the update Activity journey to check if paid or unpaid. Can't change if activity has any allocations.

Note: a significant number of the changed files in this PR are seed SQL files for the integration tests allowing for the new paid column.