### PR TITLE
SAA-1389 changes for paid and unpaid activities when allocating to an activity.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -240,7 +240,7 @@ data class ActivitySchedule(
 
   fun allocatePrisoner(
     prisonerNumber: PrisonerNumber,
-    payBand: PrisonPayBand,
+    payBand: PrisonPayBand?,
     bookingId: Long,
     startDate: LocalDate = LocalDate.now(),
     endDate: LocalDate? = null,
@@ -270,7 +270,7 @@ data class ActivitySchedule(
         prisonerNumber = prisonerNumber.toString(),
         prisonerStatus = if (startDate.isAfter(LocalDate.now())) PrisonerStatus.PENDING else PrisonerStatus.ACTIVE,
         bookingId = bookingId,
-        payBand = payBand,
+        initialPayBand = payBand,
         startDate = startDate,
         allocatedBy = allocatedBy,
         allocatedTime = LocalDateTime.now().truncatedTo(ChronoUnit.MINUTES),
@@ -350,6 +350,8 @@ data class ActivitySchedule(
     removeRedundantSlots(updates).let { updatedAllocationIds.addAll(it) }
     return updatedAllocationIds
   }
+
+  fun isPaid() = activity.isPaid()
 
   private fun removeRedundantSlots(updates: Map<Pair<Int, Pair<LocalTime, LocalTime>>, Set<DayOfWeek>>): AllocationIds {
     val slotsToRemove = slots.filterNot { updates.containsKey(Pair(it.weekNumber, it.startTime to it.endTime)) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Allocation.kt
@@ -30,8 +30,8 @@ data class Allocation(
   @Schema(description = "Indicates whether this allocation is to an activity within the 'Not in work' category")
   val isUnemployment: Boolean = false,
 
-  @Schema(description = "Where a prison uses pay bands to differentiate earnings, this is the pay band given to this prisoner")
-  val prisonPayBand: PrisonPayBand,
+  @Schema(description = "Where a prison uses pay bands to differentiate earnings, this is the pay band given to this prisoner. Will be null for unpaid activities.")
+  val prisonPayBand: PrisonPayBand?,
 
   @Schema(description = "The date when the prisoner will start the activity", example = "2022-09-10")
   @JsonFormat(pattern = "yyyy-MM-dd")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/PrisonerAllocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/PrisonerAllocationRequest.kt
@@ -17,10 +17,9 @@ data class PrisonerAllocationRequest(
   val prisonerNumber: String?,
 
   @Schema(
-    description = "Where a prison uses pay bands to differentiate earnings, this is the pay band code given to this prisoner",
+    description = "Where a prison uses pay bands to differentiate earnings, this is the pay band code given to this prisoner. Can be null for unpaid activities.",
     example = "1",
   )
-  @field:NotNull(message = "Pay band must be supplied")
   val payBandId: Long? = null,
 
   @Schema(description = "The future date when the prisoner will start the activity", example = "2022-09-10")

--- a/src/main/resources/migrations/common/V2023.11.24__pay_band_optional_on_allocation.sql
+++ b/src/main/resources/migrations/common/V2023.11.24__pay_band_optional_on_allocation.sql
@@ -1,0 +1,1 @@
+ALTER TABLE allocation ALTER COLUMN prison_pay_band_id drop not null;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -89,7 +89,7 @@ internal fun activityEntity(
       this.addEligibilityRule(eligibilityRuleOver21)
     }
     if (!noSchedules) {
-      this.addSchedule(activitySchedule(this, activityScheduleId = activityId, timestamp))
+      this.addSchedule(activitySchedule(this, activityScheduleId = activityId, timestamp, paid = paid))
     }
     if (!noPayBands) {
       this.addPay(
@@ -198,6 +198,7 @@ internal fun activitySchedule(
   noAllocations: Boolean = false,
   noInstances: Boolean = false,
   noExclusions: Boolean = false,
+  paid: Boolean = true,
 ) =
   ActivitySchedule(
     activityScheduleId = activityScheduleId,
@@ -216,7 +217,7 @@ internal fun activitySchedule(
       this.allocatePrisoner(
         prisonerNumber = "A1234AA".toPrisonerNumber(),
         bookingId = 10001,
-        payBand = lowPayBand,
+        payBand = if (paid) lowPayBand else null,
         allocatedBy = "Mr Blogs",
         startDate = startDate ?: activity.startDate,
       )
@@ -227,7 +228,7 @@ internal fun activitySchedule(
         this.allocatePrisoner(
           prisonerNumber = "A1111BB".toPrisonerNumber(),
           bookingId = 20002,
-          payBand = lowPayBand,
+          payBand = if (paid) lowPayBand else null,
           allocatedBy = "Mr Blogs",
           startDate = startDate ?: activity.startDate,
         ).apply { this.updateExclusion(slot, daysOfWeek) }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -997,9 +997,9 @@ class ActivityIntegrationTest : IntegrationTestBase() {
 
     with(webTestClient.updateActivity(pentonvillePrisonCode, 1, newPay).schedules.first()) {
       assertThat(allocations).hasSize(3)
-      assertThat(allocations[0].prisonPayBand.id).isEqualTo(3)
-      assertThat(allocations[1].prisonPayBand.id).isEqualTo(3)
-      assertThat(allocations[2].prisonPayBand.id).isEqualTo(2)
+      assertThat(allocations[0].prisonPayBand?.id).isEqualTo(3)
+      assertThat(allocations[1].prisonPayBand?.id).isEqualTo(3)
+      assertThat(allocations[2].prisonPayBand?.id).isEqualTo(2)
     }
 
     verify(eventsPublisher, times(3)).send(eventCaptor.capture())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AllocationTest.kt
@@ -166,7 +166,7 @@ class AllocationTest : ModelTest() {
       assertThat(endDate).isEqualTo(entity.endDate)
       assertThat(allocatedTime).isEqualTo(entity.allocatedTime)
       assertThat(allocatedBy).isEqualTo(entity.allocatedBy)
-      assertThat(prisonPayBand).isEqualTo(entity.payBand.toModel())
+      assertThat(prisonPayBand).isEqualTo(entity.payBand?.toModel())
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleControllerTest.kt
@@ -49,9 +49,6 @@ class ActivityScheduleControllerTest : ControllerTestBase<ActivityScheduleContro
 
   override fun controller() = ActivityScheduleController(activityScheduleService, candidatesService, waitingListService)
 
-  private fun MockMvc.getActivityScheduleCapacity(activityScheduleId: Long) =
-    get("/schedules/{activityScheduleId}/capacity", activityScheduleId)
-
   @Test
   fun `200 response when get allocations by schedule identifier`() {
     val expectedAllocations = activityEntity().schedules().first().allocations().toModelAllocations()
@@ -135,16 +132,15 @@ class ActivityScheduleControllerTest : ControllerTestBase<ActivityScheduleContro
   @Test
   fun `400 response when allocate offender to a schedule request constraints are violated`() {
     with(
-      mockMvc.allocate(1, PrisonerAllocationRequest(prisonerNumber = null, payBandId = null))
+      mockMvc.allocate(1, PrisonerAllocationRequest(prisonerNumber = null))
         .andExpect { status { isBadRequest() } }
         .andReturn().response,
     ) {
       assertThat(contentAsString).contains("Prisoner number must be supplied")
-      assertThat(contentAsString).contains("Pay band must be supplied")
     }
 
     with(
-      mockMvc.allocate(1, PrisonerAllocationRequest(prisonerNumber = "TOOMANYCHARACTERS", payBandId = 1))
+      mockMvc.allocate(1, PrisonerAllocationRequest(prisonerNumber = "TOOMANYCHARACTERS"))
         .andExpect { status { isBadRequest() } }
         .andReturn().response,
     ) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
@@ -982,7 +982,7 @@ class ActivityServiceTest {
 
     with(activityCaptor.firstValue) {
       assertThat(activityPay()).hasSize(1)
-      assertThat(schedules().first().allocations().first().payBand.prisonPayBandId).isEqualTo(updateActivityRequest.pay!!.first().payBandId)
+      assertThat(schedules().first().allocations().first().payBand?.prisonPayBandId).isEqualTo(updateActivityRequest.pay!!.first().payBandId)
     }
 
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, 0L)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
@@ -816,7 +816,7 @@ class MigrateActivityServiceTest {
           assertThat(prisonerNumber).isEqualTo("A1234BB")
           assertThat(prisonerStatus).isEqualTo(PrisonerStatus.PENDING)
           assertThat(startDate).isEqualTo(LocalDate.now().plusDays(1))
-          assertThat(payBand.nomisPayBand).isEqualTo("1".toInt())
+          assertThat(payBand?.nomisPayBand).isEqualTo("1".toInt())
           assertThat(endDate).isNull()
         }
       }
@@ -1030,7 +1030,7 @@ class MigrateActivityServiceTest {
       with(activityScheduleCaptor.firstValue) {
         with(allocations().last()) {
           assertThat(prisonerStatus).isEqualTo(PrisonerStatus.PENDING)
-          assertThat(payBand.nomisPayBand).isEqualTo(lowPayBand.nomisPayBand)
+          assertThat(payBand?.nomisPayBand).isEqualTo(lowPayBand.nomisPayBand)
         }
       }
     }

--- a/src/test/resources/__files/activity/activity-entity-3.json
+++ b/src/test/resources/__files/activity/activity-entity-3.json
@@ -21,5 +21,6 @@
   "minimumIncentiveLevel": "Basic",
   "riskLevel": "high",
   "createdTime": "2022-06-26T14:38:00",
-  "createdBy": "activities-management-admin-1"
+  "createdBy": "activities-management-admin-1",
+  "paid": true
 }


### PR DESCRIPTION
**MEDIUM RISK**

The is the second part of the API changes for the creation of paid or unpaid activities.  This changes the allocation journey to enforce pay band rules i.e. cannot have a pay band for unpaid activity. Pay band becomes nullable on allocations.

The first PR can be viewed [here](https://github.com/ministryofjustice/hmpps-activities-management-api/pull/697)

Still to do in separate PR's:

- Changes to attendance for unpaid activities.
- Change the update Activity journey to check if paid or unpaid. Can't change if activity has any allocations.