### PR TITLE
SAA-1373: Migration changes for default activity tiers, zero pay rates, optional pay bands,  rules on paid/unpaid activities

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/EventTierRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/EventTierRepository.kt
@@ -11,7 +11,3 @@ interface EventTierRepository : JpaRepository<EventTier, Long> {
 
 fun EventTierRepository.findByCodeOrThrowIllegalArgument(code: String) =
   this.findByCode(code) ?: throw IllegalArgumentException("Event tier \"$code\" not found")
-
-const val TIER_1_ID = 1L
-const val TIER_2_ID = 2L
-const val FOUNDATION_ID = 3L

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
@@ -122,8 +122,8 @@ class MigrateActivityService(
       return false
     }
 
-    // Something in the request to identify activities that have a split regime - using *SPLIT* for now
-    if (request.description.contains("*SPLIT*")) {
+    // Something in the request to identify activities that have a split regime - using SPLIT for now
+    if (request.description.contains("SPLIT")) {
       return true
     }
 
@@ -146,7 +146,7 @@ class MigrateActivityService(
 
   /**
    * Generic rules for splitting an activity.
-   * The description indicates it is a split regime activity by containing the phrase "*SPLIT*" (temporary method)
+   * The description indicates it is a split regime activity by containing the phrase "SPLIT" (temporary method)
    * Take an activity that includes both AM and PM sessions and split it into 2 activities.
    * Group 1 has the morning sessions in week 1, and afternoon sessions in week 2.
    * Group 2 has the afternoon sessions in week 1, and morning sessions in week 2.
@@ -245,8 +245,8 @@ class MigrateActivityService(
       return description
     }
 
-    // Remove the *SPLIT* label from activity descriptions
-    val newDescription = description.replace(" *SPLIT*", "", true)
+    // Remove the SPLIT label from activity descriptions
+    val newDescription = description.replace(" SPLIT", "", true)
 
     // Add the cohort label e.g. group n, tranche n, cohort n
     val cohortLabel = cohortNames.getValue(prisonCode)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.FeatureS
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityCategory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventOrganiser
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventTier
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
@@ -36,6 +37,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.N
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityCategoryRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventOrganiserRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventTierRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonPayBandRepository
 import java.time.DayOfWeek
@@ -51,6 +53,7 @@ class MigrateActivityServiceTest {
   private val activityCategoryRepository: ActivityCategoryRepository = mock()
   private val prisonPayBandRepository: PrisonPayBandRepository = mock()
   private val featureSwitches: FeatureSwitches = mock()
+  private val eventOrganiserRepository: EventOrganiserRepository = mock()
 
   private val listOfCategories = listOf(
     ActivityCategory(1, "SAA_EDUCATION", "Education", "desc"),
@@ -64,7 +67,14 @@ class MigrateActivityServiceTest {
     ActivityCategory(9, "SAA_OTHER", "Other", "desc"),
   )
 
-  private val listOfTiers = listOf(EventTier(1, "Tier1", "Tier one"))
+  private val listOfTiers = listOf(
+    EventTier(1, "TIER_1", "Tier 1"),
+    EventTier(2, "TIER_2", "Tier 2"),
+    EventTier(3, "FOUNDATION", "Foundation"),
+  )
+
+  private val eventOrganiserOther = EventOrganiser(1L, "OTHER", "Someone else")
+
   private val rolledOutMoorland = rolledOutPrison("MDI")
   private val rolledOutRisley = rolledOutPrison("RSI")
   private val payBandsMoorland = prisonPayBands("MDI")
@@ -85,6 +95,7 @@ class MigrateActivityServiceTest {
     activityCategoryRepository,
     prisonPayBandRepository,
     featureSwitches,
+    eventOrganiserRepository,
   )
 
   private fun getCategory(code: String): ActivityCategory? = listOfCategories.find { it.code == code }
@@ -109,6 +120,7 @@ class MigrateActivityServiceTest {
     fun setupMocks() {
       whenever(activityCategoryRepository.findAll()).thenReturn(listOfCategories)
       whenever(eventTierRepository.findAll()).thenReturn(listOfTiers)
+      whenever(eventOrganiserRepository.findByCode("OTHER")).thenReturn(eventOrganiserOther)
       whenever(rolloutPrisonService.getByPrisonCode("MDI")).thenReturn(rolledOutMoorland)
       whenever(rolloutPrisonService.getByPrisonCode("RSI")).thenReturn(rolledOutRisley)
       whenever(prisonPayBandRepository.findByPrisonCode("MDI")).thenReturn(payBandsMoorland)
@@ -153,7 +165,8 @@ class MigrateActivityServiceTest {
         assertThat(eligibilityRules()).hasSize(0)
         assertThat(activityMinimumEducationLevel()).hasSize(0)
         assertThat(activityCategory).isEqualTo(getCategory("SAA_PRISON_JOBS"))
-        assertThat(activityTier).isEqualTo(getTier("Tier1"))
+        assertThat(activityTier).isEqualTo(getTier("TIER_1"))
+        assertThat(isPaid()).isTrue
 
         // Check the pay rates for this activity
         assertThat(activityPay()).hasSize(1)
@@ -222,6 +235,7 @@ class MigrateActivityServiceTest {
       verify(activityRepository).saveAllAndFlush(activityCaptor.capture())
 
       with(activityCaptor.firstValue[0]) {
+        assertThat(isPaid()).isTrue
         assertThat(activityPay()).hasSize(3)
 
         with(activityPay()[0]) {
@@ -313,6 +327,7 @@ class MigrateActivityServiceTest {
 
       with(activityCaptor.firstValue[0]) {
         assertThat(activityCategory.code).isEqualTo("SAA_EDUCATION")
+        assertThat(isPaid()).isTrue
         assertThat(activityPay()).hasSize(3)
         assertThat(schedules()).hasSize(1)
 
@@ -336,6 +351,7 @@ class MigrateActivityServiceTest {
     @Test
     fun `An in-cell activity - no location code specified`() {
       val nomisPayRates = listOf(NomisPayRate(incentiveLevel = "BAS", nomisPayBand = "1", rate = 110))
+
       val nomisScheduleRules = listOf(
         NomisScheduleRule(
           startTime = LocalTime.of(10, 0),
@@ -362,6 +378,7 @@ class MigrateActivityServiceTest {
 
       with(activityCaptor.firstValue[0]) {
         assertThat(inCell).isTrue
+        assertThat(isPaid()).isTrue
         assertThat(activityPay()).hasSize(1)
         assertThat(schedules()).hasSize(1)
         with(schedules().first()) {
@@ -495,7 +512,7 @@ class MigrateActivityServiceTest {
     }
 
     @Test
-    fun `No pay rates provided will default to a flat rate of zero for all pay bands and incentive levels`() {
+    fun `No pay rates provided will result in an unpaid activity being created`() {
       val nomisPayRates: List<NomisPayRate> = emptyList()
       val nomisScheduleRules = listOf(
         NomisScheduleRule(
@@ -517,9 +534,8 @@ class MigrateActivityServiceTest {
       verify(activityRepository).saveAllAndFlush(activityCaptor.capture())
 
       with(activityCaptor.firstValue[0]) {
-        assertThat(activityPay().size).isEqualTo(9) // BAS, STD, ENH x 3 pay bands
-        assertThat(activityPay().first().rate).isEqualTo(0)
-        assertThat(activityPay().last().rate).isEqualTo(0)
+        assertThat(isPaid()).isFalse
+        assertThat(activityPay()).isNullOrEmpty()
       }
     }
 
@@ -550,7 +566,7 @@ class MigrateActivityServiceTest {
     }
 
     @Test
-    fun `Split regime at Risley creates two activities with generated PM slots`() {
+    fun `Generic split regime rules creates two activities with AM and PM slots according to the rules`() {
       val nomisPayRates = listOf(NomisPayRate(incentiveLevel = "BAS", nomisPayBand = "1", rate = 110))
 
       val nomisScheduleRules = listOf(
@@ -560,12 +576,18 @@ class MigrateActivityServiceTest {
           monday = true,
           tuesday = true,
         ),
+        NomisScheduleRule(
+          startTime = LocalTime.of(14, 0),
+          endTime = LocalTime.of(15, 0),
+          monday = true,
+          tuesday = true,
+        ),
       )
 
-      // Trigger the split regime rules for Risley with " AM" in the description
+      // Trigger the generic split regime rules "*SPLIT*" in the description
       val request = buildActivityMigrateRequest(nomisPayRates, nomisScheduleRules).copy(
         prisonCode = "RSI",
-        description = "Maths AM",
+        description = "Maths *SPLIT*",
       )
 
       // Return dummy activities - we check what is saved, not what is returned
@@ -591,6 +613,7 @@ class MigrateActivityServiceTest {
 
       // Check the content of the 1st Activity entity saved
       with(activityCaptor.firstValue[0]) {
+        assertThat(isPaid()).isTrue
         assertThat(summary).isEqualTo("Maths group 1")
         assertThat(description).isEqualTo("Maths group 1")
         assertThat(startDate).isEqualTo(LocalDate.now().plusDays(1))
@@ -631,8 +654,8 @@ class MigrateActivityServiceTest {
 
           // Check that a PM slot is generated for the same days
           with(slots()[1]) {
-            assertThat(startTime).isEqualTo(LocalTime.of(13, 45))
-            assertThat(endTime).isEqualTo(LocalTime.of(16, 45))
+            assertThat(startTime).isEqualTo(LocalTime.of(14, 0))
+            assertThat(endTime).isEqualTo(LocalTime.of(15, 0))
             assertThat(mondayFlag).isTrue
             assertThat(tuesdayFlag).isTrue
             assertThat(wednesdayFlag).isFalse
@@ -647,6 +670,7 @@ class MigrateActivityServiceTest {
 
       // Check the content of the 2nd Activity entity that was passed into saveAllAndFlush
       with(activityCaptor.firstValue[1]) {
+        assertThat(isPaid()).isTrue
         assertThat(summary).isEqualTo("Maths group 2")
         assertThat(description).isEqualTo("Maths group 2")
         assertThat(startDate).isEqualTo(LocalDate.now().plusDays(1))
@@ -664,20 +688,6 @@ class MigrateActivityServiceTest {
 
           // Check the afternoon slots are generated for week 1
           with(slots()[0]) {
-            assertThat(startTime).isEqualTo(LocalTime.of(13, 45))
-            assertThat(endTime).isEqualTo(LocalTime.of(16, 45))
-            assertThat(mondayFlag).isTrue
-            assertThat(tuesdayFlag).isTrue
-            assertThat(wednesdayFlag).isFalse
-            assertThat(thursdayFlag).isFalse
-            assertThat(fridayFlag).isFalse
-            assertThat(saturdayFlag).isFalse
-            assertThat(sundayFlag).isFalse
-            assertThat(weekNumber).isEqualTo(1)
-          }
-
-          // Check the morning slots are in week 2
-          with(slots()[1]) {
             assertThat(startTime).isEqualTo(LocalTime.of(10, 0))
             assertThat(endTime).isEqualTo(LocalTime.of(11, 0))
             assertThat(mondayFlag).isTrue
@@ -689,6 +699,20 @@ class MigrateActivityServiceTest {
             assertThat(sundayFlag).isFalse
             assertThat(weekNumber).isEqualTo(2)
           }
+
+          // Check the morning slots are in week 2
+          with(slots()[1]) {
+            assertThat(startTime).isEqualTo(LocalTime.of(14, 0))
+            assertThat(endTime).isEqualTo(LocalTime.of(15, 0))
+            assertThat(mondayFlag).isTrue
+            assertThat(tuesdayFlag).isTrue
+            assertThat(wednesdayFlag).isFalse
+            assertThat(thursdayFlag).isFalse
+            assertThat(fridayFlag).isFalse
+            assertThat(saturdayFlag).isFalse
+            assertThat(sundayFlag).isFalse
+            assertThat(weekNumber).isEqualTo(1)
+          }
         }
       }
     }
@@ -697,9 +721,12 @@ class MigrateActivityServiceTest {
     fun `Any unrecognised or invalid incentive level codes in pay rates will be silently ignored`() {
       val nomisPayRates = listOf(
         NomisPayRate(incentiveLevel = "BAS", nomisPayBand = "1", rate = 100),
-        NomisPayRate(incentiveLevel = "XXX", nomisPayBand = "1", rate = 110),
+        NomisPayRate(incentiveLevel = "STD", nomisPayBand = "1", rate = 100),
+        NomisPayRate(incentiveLevel = "ENH", nomisPayBand = "1", rate = 100),
+        NomisPayRate(incentiveLevel = "XXX", nomisPayBand = "1", rate = 110), // This is ignored
         NomisPayRate(incentiveLevel = "ENT", nomisPayBand = "1", rate = 120),
         NomisPayRate(incentiveLevel = "EN2", nomisPayBand = "1", rate = 130),
+        NomisPayRate(incentiveLevel = "EN3", nomisPayBand = "1", rate = 130),
       )
 
       val nomisScheduleRules = listOf(
@@ -722,7 +749,8 @@ class MigrateActivityServiceTest {
       verify(activityRepository).saveAllAndFlush(activityCaptor.capture())
 
       with(activityCaptor.firstValue[0]) {
-        assertThat(activityPay().size).isEqualTo(1)
+        assertThat(isPaid()).isTrue
+        assertThat(activityPay().size).isEqualTo(6)
         assertThat(activityPay().first().rate).isEqualTo(100)
       }
     }
@@ -1188,11 +1216,102 @@ class MigrateActivityServiceTest {
     }
 
     @Test
-    fun `All program services map to tier 1`() {
-      assertThat(service.mapProgramToTier("IND_DTP")).isEqualTo(getTier("Tier1"))
-      assertThat(service.mapProgramToTier("T2ICA")).isEqualTo(getTier("Tier1"))
-      assertThat(service.mapProgramToTier("ANY")).isEqualTo(getTier("Tier1"))
-      assertThat(service.mapProgramToTier("CLNR")).isEqualTo(getTier("Tier1"))
+    fun `Prison services are tier 1`() {
+      assertThat(service.mapProgramToTier("SER_ORD")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Cleaning is tier 1`() {
+      assertThat(service.mapProgramToTier("CLNR_HU4")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Training is tier 1`() {
+      assertThat(service.mapProgramToTier("SKILLS")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Education is tier 1`() {
+      assertThat(service.mapProgramToTier("EDU_OLA")).isEqualTo(getTier("TIER_1"))
+      assertThat(service.mapProgramToTier("EDU_NLA")).isEqualTo(getTier("TIER_1"))
+      assertThat(service.mapProgramToTier("KEY_SKILLS")).isEqualTo(getTier("TIER_1"))
+      assertThat(service.mapProgramToTier("CORECLASS")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Prison industries are tier 1`() {
+      assertThat(service.mapProgramToTier("IND_DTP")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Other occupations are tier 1`() {
+      assertThat(service.mapProgramToTier("OTHOCC")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Induction is tier 1`() {
+      assertThat(service.mapProgramToTier("INDUCTION")).isEqualTo(getTier("TIER_1"))
+      assertThat(service.mapProgramToTier("IAG")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Interventions are tier 1`() {
+      assertThat(service.mapProgramToTier("GROUP")).isEqualTo(getTier("TIER_1"))
+      assertThat(service.mapProgramToTier("ABUSE")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Safer custody is tier 1`() {
+      assertThat(service.mapProgramToTier("SAFE")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Weekend activities are tier 2`() {
+      assertThat(service.mapProgramToTier("WEEKEND")).isEqualTo(getTier("TIER_2"))
+    }
+
+    @Test
+    fun `Other resettlement activities are tier 1`() {
+      assertThat(service.mapProgramToTier("OTRESS")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Chapel and faith is tier 1`() {
+      assertThat(service.mapProgramToTier("CHAPEL")).isEqualTo(getTier("TIER_1"))
+    }
+
+    @Test
+    fun `Domestics are foundational`() {
+      assertThat(service.mapProgramToTier("OTH_DOM")).isEqualTo(getTier("FOUNDATION"))
+    }
+
+    @Test
+    fun `Association is foundational`() {
+      assertThat(service.mapProgramToTier("ASSOC")).isEqualTo(getTier("FOUNDATION"))
+    }
+
+    @Test
+    fun `Unemployed is foundational`() {
+      assertThat(service.mapProgramToTier("OTH_UNE")).isEqualTo(getTier("FOUNDATION"))
+    }
+
+    @Test
+    fun `Segregation is foundation`() {
+      assertThat(service.mapProgramToTier("OTH_SEG")).isEqualTo(getTier("FOUNDATION"))
+    }
+
+    @Test
+    fun `Specific T2 services map to tier 2`() {
+      assertThat(service.mapProgramToTier("T2ICA")).isEqualTo(getTier("TIER_2"))
+      assertThat(service.mapProgramToTier("T2PER")).isEqualTo(getTier("TIER_2"))
+      assertThat(service.mapProgramToTier("T2HCW")).isEqualTo(getTier("TIER_2"))
+      assertThat(service.mapProgramToTier("T2CFA")).isEqualTo(getTier("TIER_2"))
+      assertThat(service.mapProgramToTier("T2OTH")).isEqualTo(getTier("TIER_2"))
+    }
+
+    @Test
+    fun `Unrecognised program services default to tier 2`() {
+      assertThat(service.mapProgramToTier("ANY")).isEqualTo(getTier("TIER_2"))
     }
   }
 
@@ -1284,42 +1403,42 @@ class MigrateActivityServiceTest {
 
     @Test
     fun `Is a split regime but not Risley - use the default cohort label and do not strip AM`() {
-      val description = "Standard name AM"
+      val description = "Standard name *SPLIT*"
       assertThat(service.makeNameWithCohortLabel(true, "LEI", description, 1))
-        .isEqualTo("Standard name AM group 1")
+        .isEqualTo("Standard name group 1")
     }
 
     @Test
-    fun `Is Risley but description does not contain AM - use Risley cohort label`() {
+    fun `Is Risley but description does not contain *SPLIT* - use Risley cohort label`() {
       val description = "Standard name"
       assertThat(service.makeNameWithCohortLabel(true, "RSI", description, 1))
         .isEqualTo("Standard name group 1")
     }
 
     @Test
-    fun `Is a split regime and matches the pattern - use Risley cohort label and remove AM`() {
-      val description = "Maths level one AM"
+    fun `Is a split regime and matches the pattern - use Risley cohort label and remove *SPLIT* label`() {
+      val description = "Maths level one *SPLIT*"
       assertThat(service.makeNameWithCohortLabel(true, "RSI", description, 1))
         .isEqualTo("Maths level one group 1")
     }
 
     @Test
     fun `Is a split regime and matches pattern - generate a new name for cohort 2`() {
-      val description = "Maths level two AM"
+      val description = "Maths level two *SPLIT*"
       assertThat(service.makeNameWithCohortLabel(true, "RSI", description, 2))
         .isEqualTo("Maths level two group 2")
     }
 
     @Test
-    fun `Is a split regime and matches lowercase am token - generate a new name for cohort 1`() {
-      val description = "Split regime am"
+    fun `Is a split regime and matches split token - generate a new name for cohort 1`() {
+      val description = "Split regime *SPLIT*"
       assertThat(service.makeNameWithCohortLabel(true, "RSI", description, 1))
         .isEqualTo("Split regime group 1")
     }
 
     @Test
-    fun `Is Risley, split regime and AM - truncates a long activity name to 50 chars`() {
-      val description = "0123456789 0123456789 0123456789 01234567890 0123456789 AM"
+    fun `Is Risley and split regime  - truncates a long activity name to 50 chars`() {
+      val description = "0123456789 0123456789 0123456789 01234567890 0123456789 *SPLIT*"
       assertThat(service.makeNameWithCohortLabel(true, "RSI", description, 1))
         .isEqualTo("0123456789 0123456789 0123456789 0123456789 group 1")
     }
@@ -1350,29 +1469,29 @@ class MigrateActivityServiceTest {
     )
 
     @Test
-    fun `Not a split regime activity at Risley`() {
+    fun `Not a split regime activity - does not match pattern - at Risley`() {
       val request = templateRequest.copy(prisonCode = "RSI", description = "Maths level one PM")
       whenever(featureSwitches.isEnabled(Feature.MIGRATE_SPLIT_REGIME_ENABLED, false)).thenReturn(true)
       assertThat(service.isSplitRegimeActivity(request)).isEqualTo(false)
     }
 
     @Test
-    fun `Is a split regime activity at Risley`() {
-      val request = templateRequest.copy(prisonCode = "RSI", description = "Maths level one AM")
+    fun `Is a split regime activity - matches pattern - at Risley`() {
+      val request = templateRequest.copy(prisonCode = "RSI", description = "Maths level one *SPLIT*")
       whenever(featureSwitches.isEnabled(Feature.MIGRATE_SPLIT_REGIME_ENABLED, false)).thenReturn(true)
       assertThat(service.isSplitRegimeActivity(request)).isEqualTo(true)
     }
 
     @Test
-    fun `Is not a split regime at Leeds`() {
-      val request = templateRequest.copy(description = "Maths level one AM")
+    fun `Is not a split regime - not in split regime prison list - at Leeds`() {
+      val request = templateRequest.copy(description = "Maths level one *SPLIT*")
       whenever(featureSwitches.isEnabled(Feature.MIGRATE_SPLIT_REGIME_ENABLED, false)).thenReturn(true)
       assertThat(service.isSplitRegimeActivity(request)).isEqualTo(false)
     }
 
     @Test
-    fun `Is not a split regime if the feature flag is not allowing it for Risley`() {
-      val request = templateRequest.copy(prisonCode = "RSI", description = "Maths level one AM")
+    fun `Is not a split regime if the feature flag is not allowing it`() {
+      val request = templateRequest.copy(prisonCode = "RSI", description = "Maths level one *SPLIT*")
       whenever(featureSwitches.isEnabled(Feature.MIGRATE_SPLIT_REGIME_ENABLED, false)).thenReturn(false)
       assertThat(service.isSplitRegimeActivity(request)).isEqualTo(false)
     }


### PR DESCRIPTION
This PR alters the migration endpoint for activities and allocations, to:

* Remove the (unused) Risley-specific split regime rules.
* Implement a generic split regime rule set - for future use.
* Adds additional incentive levels
* Cater for unpaid activities
* Cater for allocations with no pay band - to unpaid activities
* Cater for new rules around pay bands
* Map the NOMIS program service codes to default the activity tiers/organisers
* Implement additional tests for exclusions as part of allocation migration