### PR TITLE
SAA-1362: Remove existing exclusions which would not sync to nomis on a change of a slot

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/CollectionExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/CollectionExt.kt
@@ -2,3 +2,11 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common
 
 fun <T, R> Collection<T>.ifNotEmpty(block: (Collection<T>) -> R): R? =
   this.takeIf { it.isNotEmpty() }?.let { block(this) }
+
+fun <T> Collection<T>.containsAny(otherCollection: Collection<T>): Boolean {
+  return this.intersect(otherCollection.toSet()).isNotEmpty()
+}
+
+fun <T> Set<T>.intersectIfNotNull(otherSet: Set<T>?): Set<T> {
+  return if (otherSet != null) this.intersect(otherSet.toSet()) else this
+}


### PR DESCRIPTION
We have already established that exclusions cannot be created on slots where the slot exists across multiple weeks in a multi-week schedule.

This PR is needed to remove existing exclusions which exist on a slot, if another slot is added on to another week in the schedule, so that the sync can happen successfully.