### PR TITLE
SAA-1415 fix to paid toggle on Activity. Calling with the same set value results in no actual change to the activity ergo not firing validation when not needed.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -81,6 +81,8 @@ data class Activity(
 ) {
   var paid: Boolean = isPaid
     set(value) {
+      if (field == value) return // no op, ignore
+
       if (schedules().any { it.allocations().isNotEmpty() }) {
         throw IllegalArgumentException("Paid attribute cannot be updated for allocated activity '$activityId'")
       }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
@@ -629,15 +629,26 @@ class ActivityTest {
   }
 
   @Test
-  fun `cannot update paid attribute on activity when allocated`() {
+  fun `cannot update paid attribute on paid activity when allocated`() {
     val activity = activityEntity()
 
     assertThatThrownBy { activity.paid = false }
       .isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Paid attribute cannot be updated for allocated activity '1'")
 
+    // no op so allowed
+    assertDoesNotThrow { activity.paid = true }
+  }
+
+  @Test
+  fun `cannot update paid attribute on unpaid activity when allocated`() {
+    val activity = activityEntity(noPayBands = true, paid = false).also { assertThat(it.activityPay()).isEmpty() }
+
     assertThatThrownBy { activity.paid = true }
       .isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Paid attribute cannot be updated for allocated activity '1'")
+
+    // no op so allowed
+    assertDoesNotThrow { activity.paid = false }
   }
 }


### PR DESCRIPTION
Setting the paid attribute on the Activity with same value should result in no actual change to the activity.

As it stood it was firing some validation that shouldn't have been even if the value had not changed.