### PR TITLE
SAA-1361 VLB Server Side Validation

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesService.kt
@@ -65,7 +65,6 @@ class AppointmentSeriesService(
     checkCaseloadAccess(request.prisonCode!!)
 
     request.failIfMaximumAppointmentInstancesExceeded()
-    // Should fail when category is VLB and extra information is mandatory
     request.failIfCategoryIsVideoLink()
     val categoryDescription = request.categoryDescription()
     val locationDescription = request.locationDescription()
@@ -114,6 +113,7 @@ class AppointmentSeriesService(
   }
 
   private fun AppointmentSeriesCreateRequest.failIfCategoryIsVideoLink() {
+    // Should fail when category is VLB and extra information is mandatory
     if (categoryCode == "VLB") {
       require(extraInformation?.isNotEmpty() == true) {
         "Enter the court name and any extra information"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesService.kt
@@ -65,6 +65,8 @@ class AppointmentSeriesService(
     checkCaseloadAccess(request.prisonCode!!)
 
     request.failIfMaximumAppointmentInstancesExceeded()
+    // Should fail when category is VLB and extra information is mandatory
+    request.failIfCategoryIsVideoLink()
     val categoryDescription = request.categoryDescription()
     val locationDescription = request.locationDescription()
     val prisonNumberBookingIdMap = request.createNumberBookingIdMap()
@@ -108,6 +110,14 @@ class AppointmentSeriesService(
     val repeatCount = schedule?.numberOfAppointments ?: 1
     require(prisonerNumbers.size * repeatCount <= maxAppointmentInstances) {
       "You cannot schedule more than ${maxAppointmentInstances / prisonerNumbers.size} appointments for this number of attendees."
+    }
+  }
+
+  private fun AppointmentSeriesCreateRequest.failIfCategoryIsVideoLink() {
+    if (categoryCode == "VLB") {
+      require(extraInformation?.isNotEmpty() == true) {
+        "Enter the court name and any extra information"
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesService.kt
@@ -65,7 +65,7 @@ class AppointmentSeriesService(
     checkCaseloadAccess(request.prisonCode!!)
 
     request.failIfMaximumAppointmentInstancesExceeded()
-    request.failIfCategoryIsVideoLink()
+    request.failIfCategoryIsVideoLinkAndMissingExtraInfo()
     val categoryDescription = request.categoryDescription()
     val locationDescription = request.locationDescription()
     val prisonNumberBookingIdMap = request.createNumberBookingIdMap()
@@ -112,7 +112,7 @@ class AppointmentSeriesService(
     }
   }
 
-  private fun AppointmentSeriesCreateRequest.failIfCategoryIsVideoLink() {
+  private fun AppointmentSeriesCreateRequest.failIfCategoryIsVideoLinkAndMissingExtraInfo() {
     // Should fail when category is VLB and extra information is mandatory
     if (categoryCode == "VLB") {
       require(extraInformation?.isNotEmpty() == true) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
@@ -66,7 +66,7 @@ class AppointmentService(
     val startTimeInMs = System.currentTimeMillis()
     val now = LocalDateTime.now()
 
-    request.failIfCategoryIsVideoLink()
+    request.failIfCategoryIsVideoLinkAndMissingExtraInfo()
 
     val appointment = appointmentRepository.findOrThrowNotFound(appointmentId)
     val appointmentSeries = appointment.appointmentSeries
@@ -200,7 +200,7 @@ class AppointmentService(
 
     return cancelledAppointmentSeries
   }
-  private fun AppointmentUpdateRequest.failIfCategoryIsVideoLink() {
+  private fun AppointmentUpdateRequest.failIfCategoryIsVideoLinkAndMissingExtraInfo() {
     // Should fail when category is VLB and extra information is mandatory
     if (categoryCode == "VLB") {
       require(extraInformation?.isNotEmpty() == true) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
@@ -66,7 +66,6 @@ class AppointmentService(
     val startTimeInMs = System.currentTimeMillis()
     val now = LocalDateTime.now()
 
-    // Should fail when category is VLB and extra information is mandatory
     request.failIfCategoryIsVideoLink()
 
     val appointment = appointmentRepository.findOrThrowNotFound(appointmentId)
@@ -202,6 +201,7 @@ class AppointmentService(
     return cancelledAppointmentSeries
   }
   private fun AppointmentUpdateRequest.failIfCategoryIsVideoLink() {
+    // Should fail when category is VLB and extra information is mandatory
     if (categoryCode == "VLB") {
       require(extraInformation?.isNotEmpty() == true) {
         "Enter the court name and any extra information"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentService.kt
@@ -66,6 +66,9 @@ class AppointmentService(
     val startTimeInMs = System.currentTimeMillis()
     val now = LocalDateTime.now()
 
+    // Should fail when category is VLB and extra information is mandatory
+    request.failIfCategoryIsVideoLink()
+
     val appointment = appointmentRepository.findOrThrowNotFound(appointmentId)
     val appointmentSeries = appointment.appointmentSeries
     val appointmentsToUpdate = appointmentSeries.applyToAppointments(appointment, request.applyTo, "update")
@@ -197,5 +200,12 @@ class AppointmentService(
     }
 
     return cancelledAppointmentSeries
+  }
+  private fun AppointmentUpdateRequest.failIfCategoryIsVideoLink() {
+    if (categoryCode == "VLB") {
+      require(extraInformation?.isNotEmpty() == true) {
+        "Enter the court name and any extra information"
+      }
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesServiceTest.kt
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.AdditionalAnswers
@@ -806,7 +807,7 @@ class AppointmentSeriesServiceTest {
   }
 
   @Test
-  fun `failIfCategoryIsVideoLink should throw exception when category is VLB and extraInformation is empty`() {
+  fun `failIfCategoryIsVideoLinkAndMissingExtraInfo should throw exception when category is VLB and extraInformation is empty`() {
     val request = appointmentSeriesCreateRequest(categoryCode = vlbCategoryCode, extraInformation = "")
 
     assertThrows<IllegalArgumentException> {
@@ -815,23 +816,26 @@ class AppointmentSeriesServiceTest {
   }
 
   @Test
-  fun `failIfCategoryIsVideoLink should not throw exception when category is not VLB and extraInformation is empty`() {
+  fun `failIfCategoryIsVideoLinkAndMissingExtraInfo should not throw exception when category is not VLB and extraInformation is empty`() {
     addCaseloadIdToRequestHeader(prisonCode)
     val request = appointmentSeriesCreateRequest(categoryCode = categoryCode, internalLocationId = internalLocationId, extraInformation = "")
 
-    service.createAppointmentSeries(request, principal)
-    appointmentSeriesEntityCaptor.firstValue.appointments().single().extraInformation isEqualTo null
+    assertDoesNotThrow {
+      service.createAppointmentSeries(request, principal)
+    }
   }
 
   @Test
-  fun `failIfCategoryIsVideoLink should not throw exception when category is VLB and extraInformation is not empty`() {
+  fun `failIfCategoryIsVideoLinkAndMissingExtraInfo should not throw exception when category is VLB and extraInformation is not empty`() {
     addCaseloadIdToRequestHeader(prisonCode)
     val request = appointmentSeriesCreateRequest(categoryCode = vlbCategoryCode, internalLocationId = internalLocationId, inCell = true, extraInformation = "Extra information - Video Link of Session Court")
 
     whenever(referenceCodeService.getScheduleReasonsMap(ScheduleReasonEventType.APPOINTMENT))
       .thenReturn(mapOf(vlbCategoryCode to appointmentCategoryReferenceCode(categoryCode, "Video Link Booking")))
 
-    service.createAppointmentSeries(request, principal)
+    assertDoesNotThrow {
+      service.createAppointmentSeries(request, principal)
+    }
     appointmentSeriesEntityCaptor.firstValue.appointments().single().extraInformation isEqualTo "Extra information - Video Link of Session Court"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentServiceTest.kt
@@ -4,9 +4,13 @@ import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentCancelDomainService
@@ -18,12 +22,15 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.userDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.CancelAppointmentsJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.UpdateAppointmentsJob
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.CaseloadAccessException
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.FakeSecurityContext
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.addCaseloadIdToRequestHeader
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.clearCaseloadIdFromRequestHeader
+import java.security.Principal
 import java.util.Optional
-
+@ExtendWith(FakeSecurityContext::class)
 class AppointmentServiceTest {
   private val appointmentRepository: AppointmentRepository = mock()
   private val referenceCodeService: ReferenceCodeService = mock()
@@ -34,6 +41,7 @@ class AppointmentServiceTest {
   private val appointmentCancelDomainService: AppointmentCancelDomainService = mock()
   private val updateAppointmentsJob: UpdateAppointmentsJob = mock()
   private val cancelAppointmentsJob: CancelAppointmentsJob = mock()
+  private lateinit var principal: Principal
 
   private val service = AppointmentService(
     appointmentRepository,
@@ -46,6 +54,11 @@ class AppointmentServiceTest {
     updateAppointmentsJob,
     cancelAppointmentsJob,
   )
+
+  @BeforeEach
+  fun setUp() {
+    principal = SecurityContextHolder.getContext().authentication
+  }
 
   @AfterEach
   fun tearDown() {
@@ -105,5 +118,14 @@ class AppointmentServiceTest {
     val entity = appointmentSeries.appointments().first()
     whenever(appointmentRepository.findById(entity.appointmentId)).thenReturn(Optional.of(entity))
     assertThatThrownBy { service.getAppointmentDetailsById(entity.appointmentId) }.isInstanceOf(CaseloadAccessException::class.java)
+  }
+
+  @Test
+  fun `failIfCategoryIsVideoLink should throw exception when category is VLB and extraInformation is empty`() {
+    val request = AppointmentUpdateRequest(categoryCode = "VLB", extraInformation = "")
+
+    assertThrows<IllegalArgumentException> {
+      service.updateAppointment(1L, request, principal)
+    }
   }
 }


### PR DESCRIPTION
[](url)Ensure server-side validation is in place for the 'extra information' field in the VLB appointment process, prior to confirmation.
**Before:**

<img width="779" alt="Screenshot 2023-12-07 at 10 39 43" src="https://github.com/ministryofjustice/hmpps-activities-management-api/assets/139761909/1ece962b-3923-4cf5-afb2-4e3d0f1b2142">

**After**
<img width="682" alt="Screenshot 2023-12-07 at 11 15 01" src="https://github.com/ministryofjustice/hmpps-activities-management-api/assets/139761909/c43b2bd6-e983-4966-8664-99229e215aac">


