### PR TITLE
SAA-1427 reducing default heap size to fix OOM errors on PODs. Prod is still at 1024.

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/values.yaml
+++ b/helm_deploy/hmpps-activities-management-api/values.yaml
@@ -34,7 +34,7 @@ generic-service:
 
   # Environment variables to load into the deployment
   env:
-    JAVA_OPTS: "-Xmx512m"
+    JAVA_OPTS: "-Xmx256m"
     SERVER_PORT: "8080"
     SPRING_PROFILES_ACTIVE: "logstash"
     APPLICATIONINSIGHTS_CONNECTION_STRING: "InstrumentationKey=$(APPINSIGHTS_INSTRUMENTATIONKEY)"


### PR DESCRIPTION
This is what DEV would have been at prior to enabling the use of the JAVA_OPTS env var.

The is intentional as this should help highlight slow areas in the API and focus on optimising it where possible.