### PR TITLE
SAA-1412 using prison API in favour of prisoner search in effort to avoid a race condition when looking up merged prisoner details in prisoner search.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -31,6 +31,8 @@ inline fun <reified T> typeReference() = object : ParameterizedTypeReference<T>(
 @Service
 class PrisonApiClient(private val prisonApiWebClient: WebClient) {
 
+  fun getPrisonerDetailsLite(prisonerNumber: String): InmateDetail? = getPrisonerDetails(prisonerNumber, fullInfo = false).block()
+
   fun getPrisonerDetails(
     prisonerNumber: String,
     fullInfo: Boolean = true,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -707,13 +707,9 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
   fun `offender merged event replaces old prisoner number with new prisoner number`() {
     val (oldNumber, newNumber) = "A11111A" to "B11111B"
 
-    prisonerSearchApiMockServer.stubSearchByPrisonerNumber(
-      PrisonerSearchPrisonerFixture.instance(
-        prisonerNumber = newNumber,
-        inOutStatus = Prisoner.InOutStatus.IN,
-        status = "ACTIVE IN",
-        prisonId = pentonvillePrisonCode,
-      ),
+    prisonApiMockServer.stubGetPrisonerDetails(
+      InmateDetailFixture.instance(offenderNo = newNumber, agencyId = pentonvillePrisonCode),
+      fullInfo = false,
     )
 
     prisonApiMockServer.stubGetPrisonerDetails(


### PR DESCRIPTION
Switching to use prison API for looking up merged offender details instead of prisoner search API.

In the time we have received a prisoner merge event and attempted to process it (which in turn looks up the prisoner details via an external API call) it looks like the prisoner changes have not yet been indexed in prisoner search.

Hopefully moving to prisoner API should remove the race condition.  If it doesn't then we will have to revisit this.