### PR TITLE
SAA-1412 enable offender merge updates in preprod and prod.

### DIFF
--- a/helm_deploy/hmpps-activities-management-api/values.yaml
+++ b/helm_deploy/hmpps-activities-management-api/values.yaml
@@ -72,7 +72,7 @@ generic-service:
     FEATURE_AUDIT_SERVICE_HMPPS_ENABLED: false
     FEATURE_AUDIT_SERVICE_LOCAL_ENABLED: true
     FEATURE_MIGRATE_SPLIT_REGIME_ENABLED: false
-    FEATURE_OFFENDER_MERGE_ENABLED: false
+    FEATURE_OFFENDER_MERGE_ENABLED: true
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -20,7 +20,6 @@ generic-service:
     FEATURE_EVENTS_SNS_ENABLED: true
     FEATURE_AUDIT_SERVICE_HMPPS_ENABLED: true
     SENTRY_ENVIRONMENT: development
-    FEATURE_OFFENDER_MERGE_ENABLED: true
 
 # CloudPlatform AlertManager receiver to route prometheus alerts to slack
 # See https://user-guide.cloud-platform.service.justice.gov.uk/documentation/monitoring-an-app/how-to-create-alarms.html#creating-your-own-custom-alerts

--- a/src/main/resources/migrations/common/V2023.12.15__add_index_to_local_audit.sql
+++ b/src/main/resources/migrations/common/V2023.12.15__add_index_to_local_audit.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_local_audit_prison_code_prisoner_number on local_audit(prison_code, prisoner_number);
+CREATE INDEX IF NOT EXISTS idx_local_audit_prisoner_number on local_audit(prisoner_number);


### PR DESCRIPTION
Also improving indexing on the local audit table which the offender merge process will use when retrieving and updating prisoner audit records.