### PR TITLE
SAA-1415: Connection pool settings to cater for high load during migrations.

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,8 +65,12 @@ spring:
     password: ${DB_PASS}
     hikari:
       pool-name: Activities-DB-CP
-      connectionTimeout: 1000
-      validationTimeout: 500
+      connectionTimeout: 5000
+      validationTimeout: 2000
+      minimumIdle: 10
+      maximumPoolSize: 50
+      idleTimeout: 300000
+      maxLifetime: 1200000
 
   flyway:
     locations: classpath:/migrations/common,classpath:/migrations/prod
@@ -121,6 +125,10 @@ online:
 applications:
   max-appointment-instances: ${MAX_APPOINTMENT_INSTANCES}
   max-sync-appointment-instance-actions: ${MAX_SYNC_APPOINTMENT_INSTANCE_ACTIONS}
+
+hmpps:
+  sqs:
+    queueAdminRole: ACTIVITY_QUEUE_ADMIN
 
 springdoc:
   swagger-ui:


### PR DESCRIPTION
There are two changes here:

1. Adjust connection pool size, idle time and wait times so that it will grow to cater for high-activity during migrations.
2. Set the queue admin role to ROLE_ACTIVITY_QUEUE_ADMIN that we can give to our personal clients.