### PR TITLE
SAA-1456 correcting the console appender should now mean the configuration is picked up correctly and not falling back to the Spring Boot default.

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -7,9 +7,9 @@
     <springProperty scope="context" name="app" source="spring.application.name"/>
 
     <appender name="consoleAppender" class="ch.qos.logback.core.ConsoleAppender">
-        <layout class="ch.qos.logback.classic.PatternLayout">
-            <Pattern>${LOG_PATTERN}</Pattern>
-        </layout>
+        <encoder>
+            <pattern>${LOG_PATTERN}</pattern>
+        </encoder>
     </appender>
 
     <logger name="uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.HmppsActivitiesManagementApiKt" additivity="false"  level="DEBUG">


### PR DESCRIPTION
If you look at the console output when the service starts you can see the logging configuration was not being picked up.

The way in which the console appender is configured has changed since we inherited the original from the Kotlin template.