### PR TITLE
SAA-1480 reducing the data requested (and load) from prison API in the interesting event handler as we don't need the extra information.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -192,7 +192,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
   fun `prisoner alerts updated`() {
     prisonApiMockServer.stubGetPrisonerDetails(
       InmateDetailFixture.instance(offenderNo = "A11111A", agencyId = pentonvillePrisonCode),
-      fullInfo = true,
+      fullInfo = false,
     )
 
     service.process(alertsUpdatedEvent(prisonerNumber = "A11111A"))
@@ -390,7 +390,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
 
     prisonApiMockServer.stubGetPrisonerDetails(
       InmateDetailFixture.instance(offenderNo = "A1234BC", agencyId = moorlandPrisonCode),
-      fullInfo = true,
+      fullInfo = false,
     )
 
     allocationRepository.findAll().filter { it.prisonerNumber == "A11111A" }.onEach {
@@ -648,7 +648,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
 
     prisonApiMockServer.stubGetPrisonerDetails(
       InmateDetailFixture.instance(offenderNo = "A22222A", agencyId = moorlandPrisonCode),
-      fullInfo = true,
+      fullInfo = false,
     )
 
     assertThatAllocationsAreActiveFor("A22222A")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandlerTest.kt
@@ -10,10 +10,8 @@ import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
-import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiApplicationClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.InmateDetail
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiApplicationClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.EventReview
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
@@ -42,7 +40,6 @@ class InterestingEventHandlerTest {
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock()
   private val allocationRepository: AllocationRepository = mock()
   private val eventReviewRepository: EventReviewRepository = mock()
-  private val prisonerSearchApiClient: PrisonerSearchApiApplicationClient = mock()
   private val prisonApiClient: PrisonApiApplicationClient = mock()
   private val eventReviewCaptor = argumentCaptor<EventReview>()
 
@@ -335,6 +332,6 @@ class InterestingEventHandlerTest {
       on { bookingId } doReturn bookId
     }
 
-    whenever(prisonApiClient.getPrisonerDetails(prisonerNum)) doReturn Mono.just(prisoner)
+    whenever(prisonApiClient.getPrisonerDetailsLite(prisonerNum)) doReturn prisoner
   }
 }


### PR DESCRIPTION
The interesting event handler has been requesting full prisoner information from prison-api when it doesn't actually need it.  

The impact of doing so means prison-api has to do a lot more work in terms of servicing the requests here.

This change means we are asking for minimal information which in turns reduces the load on an already heavy hit prison-api.