### PR TITLE
SAA-1484 changes the WaitingListService to pull prisoner info from prisoner search API instead of prison API in effort reduce dependency on prison API and improve performance.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExt.kt
@@ -17,6 +17,8 @@ fun Prisoner.isActiveOut(): Boolean = status == "ACTIVE OUT"
 
 fun Prisoner.isActiveIn(): Boolean = status == "ACTIVE IN"
 
+fun Prisoner.isActiveAtPrison(prisonCode: String) = prisonId == prisonCode && (isActiveIn() || isActiveOut())
+
 fun Prisoner.isTemporarilyReleased() =
   (confirmedReleaseDate == null || confirmedReleaseDate.isAfter(LocalDate.now())) && isActiveOut() && lastMovementType() != MovementType.RELEASE
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListService.kt
@@ -12,9 +12,8 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import toPrisonerDeclinedFromWaitingListEvent
 import toPrisonerRemovedFromWaitingListEvent
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.extensions.isActiveInPrison
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.extensions.isActiveOutPrison
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.isActiveAtPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingList
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingListStatus
@@ -42,7 +41,7 @@ class WaitingListService(
   private val waitingListRepository: WaitingListRepository,
   private val waitingListSearchSpecification: WaitingListSearchSpecification,
   private val activityRepository: ActivityRepository,
-  private val prisonApiClient: PrisonApiClient,
+  private val prisonerSearchApiClient: PrisonerSearchApiClient,
   private val telemetryClient: TelemetryClient,
   private val auditService: AuditService,
 ) {
@@ -57,7 +56,7 @@ class WaitingListService(
     scheduleRepository
       .findOrThrowNotFound(id)
       .checkCaseloadAccess()
-      .let { schedule -> waitingListRepository.findByActivitySchedule(schedule).map { it.toModel() } }
+      .let(waitingListRepository::findByActivitySchedule).map(WaitingList::toModel)
 
   @Transactional
   fun addPrisoner(prisonCode: String, request: WaitingListApplicationRequest, createdBy: String) {
@@ -109,7 +108,7 @@ class WaitingListService(
     request.activityId?.let { spec = spec.and(waitingListSearchSpecification.activityIdEqual(it)) }
 
     val pageable: Pageable = PageRequest.of(pageNumber, pageSize, Sort.by("applicationDate"))
-    return waitingListRepository.findAll(spec, pageable).map { it.toModel() }
+    return waitingListRepository.findAll(spec, pageable).map(WaitingList::toModel)
   }
 
   private fun WaitingListApplicationRequest.failIfNotAllowableStatus() {
@@ -146,10 +145,10 @@ class WaitingListService(
   }
 
   private fun getActivePrisonerBookingId(prisonCode: String, request: WaitingListApplicationRequest): Long {
-    val prisonerDetails = prisonApiClient.getPrisonerDetails(request.prisonerNumber!!).block()
+    val prisonerDetails = prisonerSearchApiClient.findByPrisonerNumber(request.prisonerNumber!!)
       ?: throw IllegalArgumentException("Prisoner with ${request.prisonerNumber} not found")
 
-    require(prisonerDetails.isActiveInPrison(prisonCode) || prisonerDetails.isActiveOutPrison(prisonCode)) {
+    require(prisonerDetails.isActiveAtPrison(prisonCode)) {
       "${prisonerDetails.firstName} ${prisonerDetails.lastName} is not resident at this prison"
     }
 
@@ -157,7 +156,7 @@ class WaitingListService(
       "Prisoner ${request.prisonerNumber} has no booking id at prison $prisonCode"
     }
 
-    return prisonerDetails.bookingId
+    return prisonerDetails.bookingId.toLong()
   }
 
   private fun ActivitySchedule.failIfIsNotInWorkCategory() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonersearchapi/extensions/PrisonerExtTest.kt
@@ -1,38 +1,17 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions
 
 import org.junit.jupiter.api.Test
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
-import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.activeInMoorlandPrisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.activeOutMoorlandPrisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.permanentlyReleasedPrisonerToday
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.temporarilyReleasedFromMoorland
 
 class PrisonerExtTest {
-
-  private val temporarilyReleasedFromMoorland = Prisoner(
-    prisonerNumber = "1",
-    firstName = "Freddie",
-    lastName = "Bloggs",
-    dateOfBirth = LocalDate.EPOCH,
-    gender = "Female",
-    status = "ACTIVE OUT",
-    prisonId = moorlandPrisonCode,
-    confirmedReleaseDate = null,
-  )
-
-  private val permanentlyReleasedFromMoorland = Prisoner(
-    prisonerNumber = "1",
-    firstName = "Freddie",
-    lastName = "Bloggs",
-    dateOfBirth = LocalDate.EPOCH,
-    gender = "Female",
-    status = "INACTIVE OUT",
-    prisonId = moorlandPrisonCode,
-    confirmedReleaseDate = TimeSource.today(),
-    lastMovementTypeCode = "REL",
-  )
 
   @Test
   fun `is temporarily released`() {
@@ -49,54 +28,41 @@ class PrisonerExtTest {
 
   @Test
   fun `is permanently released`() {
-    permanentlyReleasedFromMoorland.status isEqualTo "INACTIVE OUT"
-    permanentlyReleasedFromMoorland.isInactiveOut() isBool true
-    permanentlyReleasedFromMoorland.isPermanentlyReleased() isBool true
+    permanentlyReleasedPrisonerToday.status isEqualTo "INACTIVE OUT"
+    permanentlyReleasedPrisonerToday.isInactiveOut() isBool true
+    permanentlyReleasedPrisonerToday.isPermanentlyReleased() isBool true
   }
 
   @Test
   fun `is not permanently released`() {
-    permanentlyReleasedFromMoorland.copy(confirmedReleaseDate = TimeSource.tomorrow()).isPermanentlyReleased() isBool false
+    permanentlyReleasedPrisonerToday.copy(confirmedReleaseDate = TimeSource.tomorrow()).isPermanentlyReleased() isBool false
   }
 
   @Test
   fun `is restricted patient`() {
-    permanentlyReleasedFromMoorland.copy(restrictedPatient = true).isRestrictedPatient() isBool true
-    permanentlyReleasedFromMoorland.copy(restrictedPatient = false).isRestrictedPatient() isBool false
+    permanentlyReleasedPrisonerToday.copy(restrictedPatient = true).isRestrictedPatient() isBool true
+    permanentlyReleasedPrisonerToday.copy(restrictedPatient = false).isRestrictedPatient() isBool false
   }
 
   @Test
   fun `is active in prisoner`() {
-    val activeInPrisoner = Prisoner(
-      prisonerNumber = "1",
-      firstName = "Freddie",
-      lastName = "Bloggs",
-      dateOfBirth = LocalDate.EPOCH,
-      gender = "Female",
-      status = "ACTIVE IN",
-      prisonId = moorlandPrisonCode,
-      confirmedReleaseDate = null,
-    )
+    activeInMoorlandPrisoner.status isEqualTo "ACTIVE IN"
+    activeInMoorlandPrisoner.isActiveIn() isBool true
+  }
 
-    activeInPrisoner.status isEqualTo "ACTIVE IN"
-    activeInPrisoner.isActiveIn() isBool true
+  @Test
+  fun `is active at prison`() {
+    activeInMoorlandPrisoner.isActiveAtPrison(moorlandPrisonCode) isBool true
+    activeInMoorlandPrisoner.isActiveAtPrison(pentonvillePrisonCode) isBool false
+
+    activeOutMoorlandPrisoner.isActiveAtPrison(moorlandPrisonCode) isBool true
+    activeOutMoorlandPrisoner.isActiveAtPrison(pentonvillePrisonCode) isBool false
   }
 
   @Test
   fun `is at different location`() {
-    val activeInPrisoner = Prisoner(
-      prisonerNumber = "1",
-      firstName = "Freddie",
-      lastName = "Bloggs",
-      dateOfBirth = LocalDate.EPOCH,
-      gender = "Female",
-      status = "ACTIVE IN",
-      prisonId = moorlandPrisonCode,
-      confirmedReleaseDate = null,
-    )
-
-    activeInPrisoner.isAtDifferentLocationTo(pentonvillePrisonCode) isBool true
-    activeInPrisoner.copy(prisonId = null).isAtDifferentLocationTo(pentonvillePrisonCode) isBool true
-    activeInPrisoner.isAtDifferentLocationTo(moorlandPrisonCode) isBool false
+    activeInMoorlandPrisoner.isAtDifferentLocationTo(pentonvillePrisonCode) isBool true
+    activeInMoorlandPrisoner.isAtDifferentLocationTo(pentonvillePrisonCode) isBool true
+    activeInMoorlandPrisoner.isAtDifferentLocationTo(moorlandPrisonCode) isBool false
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
 
-import net.javacrumbs.jsonunit.assertj.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.argumentCaptor
@@ -18,24 +17,17 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isClose
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.startsWith
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandOne
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandTwo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Slot
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.AuditEventType
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.AuditType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AllocationUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.WaitingListApplicationRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AuditRepository
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.WaitingListRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.CASELOAD_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_ACTIVITY_ADMIN
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_ACTIVITY_HUB
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_PRISON
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.HmppsAuditApiClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.HmppsAuditEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsPublisher
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundHMPPSDomainEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.PrisonerAllocatedInformation
@@ -45,8 +37,6 @@ import java.time.LocalDateTime
 
 @TestPropertySource(
   properties = [
-    "feature.audit.service.local.enabled=true",
-    "feature.audit.service.hmpps.enabled=true",
     "feature.event.activities.prisoner.allocation-amended=true",
   ],
 )
@@ -59,17 +49,6 @@ class AllocationIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var allocationRepository: AllocationRepository
-
-  @Autowired
-  private lateinit var waitingListRepository: WaitingListRepository
-
-  @Autowired
-  private lateinit var auditRepository: AuditRepository
-
-  @MockBean
-  private lateinit var hmppsAuditApiClient: HmppsAuditApiClient
-
-  private val hmppsAuditEventCaptor = argumentCaptor<HmppsAuditEvent>()
 
   @Sql("classpath:test_data/seed-activity-id-1.sql")
   @Test
@@ -153,58 +132,6 @@ class AllocationIntegrationTest : IntegrationTestBase() {
       .headers(setAuthorisation(isClientToken = true, roles = listOf(ROLE_ACTIVITY_ADMIN)))
       .exchange()
       .expectStatus().isOk
-  }
-
-  @Sql("classpath:test_data/seed-activity-id-20.sql")
-  @Test
-  fun `add prisoner to a waiting list for an activity`() {
-    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", fullInfo = true)
-
-    val request = WaitingListApplicationRequest(
-      prisonerNumber = "G4793VF",
-      activityScheduleId = 1L,
-      applicationDate = TimeSource.today(),
-      requestedBy = "Bob",
-      comments = "Some comments from Bob",
-      status = WaitingListStatus.PENDING,
-    )
-
-    assertThat(waitingListRepository.findAll()).isEmpty()
-    assertThat(auditRepository.findAll()).isEmpty()
-
-    webTestClient.waitingListApplication(moorlandPrisonCode, request, moorlandPrisonCode).expectStatus().isNoContent
-
-    val persisted = waitingListRepository.findAll().also { assertThat(it).hasSize(1) }.first()
-
-    with(persisted) {
-      assertThat(prisonerNumber).isEqualTo("G4793VF")
-      assertThat(activitySchedule.activityScheduleId).isEqualTo(1L)
-      assertThat(applicationDate).isToday()
-      assertThat(requestedBy).isEqualTo("Bob")
-      assertThat(comments).isEqualTo("Some comments from Bob")
-      assertThat(status).isEqualTo(WaitingListStatus.PENDING)
-    }
-
-    val localAuditRecord = auditRepository.findAll().also { assertThat(it).hasSize(1) }.first()
-
-    with(localAuditRecord) {
-      auditType isEqualTo AuditType.PRISONER
-      detailType isEqualTo AuditEventType.PRISONER_ADDED_TO_WAITING_LIST
-      activityId isEqualTo 1L
-      prisonCode isEqualTo moorlandPrisonCode
-      prisonerNumber isEqualTo "G4793VF"
-      recordedTime isCloseTo TimeSource.now()
-      message startsWith "Prisoner G4793VF was added to the waiting list for activity 'Maths'(1) with a status of PENDING. Event created on ${TimeSource.today()}"
-    }
-
-    verify(hmppsAuditApiClient).createEvent(hmppsAuditEventCaptor.capture())
-
-    with(hmppsAuditEventCaptor.firstValue) {
-      println(details)
-      assertThat(what).isEqualTo("PRISONER_ADDED_TO_WAITING_LIST")
-      assertThat(who).isEqualTo("test-client")
-      assertThatJson(details).isEqualTo("{\"activityId\":1,\"activityName\":\"Maths\",\"prisonCode\":\"MDI\",\"prisonerNumber\":\"G4793VF\",\"scheduleId\":1,\"createdAt\":\"\${json-unit.ignore}\",\"createdBy\":\"test-client\"}")
-    }
   }
 
   @Sql("classpath:test_data/seed-activity-id-20.sql")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/WaitingListApplicationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/WaitingListApplicationIntegrationTest.kt
@@ -1,31 +1,56 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
 
+import net.javacrumbs.jsonunit.assertj.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.MediaType
+import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.typeReference
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.asListOfType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingListStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.startsWith
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.WaitingListApplication
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.WaitingListApplicationRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.WaitingListApplicationUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.WaitingListSearchRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AuditRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.WaitingListRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.findOrThrowNotFound
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.CASELOAD_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_ACTIVITY_HUB
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_PRISON
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.HmppsAuditApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.HmppsAuditEvent
 import java.time.LocalDate
 
+@TestPropertySource(
+  properties = [
+    "feature.audit.service.local.enabled=true",
+    "feature.audit.service.hmpps.enabled=true",
+  ],
+)
 class WaitingListApplicationIntegrationTest : IntegrationTestBase() {
 
   @Autowired
   private lateinit var waitingListRepository: WaitingListRepository
+
+  @Autowired
+  private lateinit var auditRepository: AuditRepository
+
+  @MockBean
+  private lateinit var hmppsAuditApiClient: HmppsAuditApiClient
+
+  private val hmppsAuditEventCaptor = argumentCaptor<HmppsAuditEvent>()
 
   @Sql("classpath:test_data/seed-activity-id-22.sql")
   @Test
@@ -57,7 +82,7 @@ class WaitingListApplicationIntegrationTest : IntegrationTestBase() {
       status isEqualTo WaitingListStatus.PENDING
     }
 
-    val response = webTestClient.update(
+    val response = update(
       1,
       WaitingListApplicationUpdateRequest(
         applicationDate = TimeSource.yesterday(),
@@ -82,7 +107,7 @@ class WaitingListApplicationIntegrationTest : IntegrationTestBase() {
     }
   }
 
-  private fun WebTestClient.update(id: Long, request: WaitingListApplicationUpdateRequest) =
+  private fun update(id: Long, request: WaitingListApplicationUpdateRequest) =
     webTestClient.patch()
       .uri("/waiting-list-applications/$id")
       .accept(MediaType.APPLICATION_JSON)
@@ -167,6 +192,71 @@ class WaitingListApplicationIntegrationTest : IntegrationTestBase() {
       this["id"] isEqualTo 5
     }
   }
+
+  @Sql("classpath:test_data/seed-activity-id-20.sql")
+  @Test
+  fun `add prisoner to a waiting list for an activity`() {
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumber("G4793VF")
+
+    val request = WaitingListApplicationRequest(
+      prisonerNumber = "G4793VF",
+      activityScheduleId = 1L,
+      applicationDate = TimeSource.today(),
+      requestedBy = "Bob",
+      comments = "Some comments from Bob",
+      status = WaitingListStatus.PENDING,
+    )
+
+    assertThat(waitingListRepository.findAll()).isEmpty()
+    assertThat(auditRepository.findAll()).isEmpty()
+
+    webTestClient.waitingListApplication(moorlandPrisonCode, request, moorlandPrisonCode).expectStatus().isNoContent
+
+    val persisted = waitingListRepository.findAll().also { assertThat(it).hasSize(1) }.first()
+
+    with(persisted) {
+      assertThat(prisonerNumber).isEqualTo("G4793VF")
+      assertThat(activitySchedule.activityScheduleId).isEqualTo(1L)
+      assertThat(applicationDate).isToday()
+      assertThat(requestedBy).isEqualTo("Bob")
+      assertThat(comments).isEqualTo("Some comments from Bob")
+      assertThat(status).isEqualTo(WaitingListStatus.PENDING)
+    }
+
+    val localAuditRecord = auditRepository.findAll().also { assertThat(it).hasSize(1) }.first()
+
+    with(localAuditRecord) {
+      auditType isEqualTo uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.AuditType.PRISONER
+      detailType isEqualTo uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.AuditEventType.PRISONER_ADDED_TO_WAITING_LIST
+      activityId isEqualTo 1L
+      prisonCode isEqualTo moorlandPrisonCode
+      prisonerNumber isEqualTo "G4793VF"
+      recordedTime isCloseTo TimeSource.now()
+      message startsWith "Prisoner G4793VF was added to the waiting list for activity 'Maths'(1) with a status of PENDING. Event created on ${TimeSource.today()}"
+    }
+
+    verify(hmppsAuditApiClient).createEvent(hmppsAuditEventCaptor.capture())
+
+    with(hmppsAuditEventCaptor.firstValue) {
+      println(details)
+      assertThat(what).isEqualTo("PRISONER_ADDED_TO_WAITING_LIST")
+      assertThat(who).isEqualTo("test-client")
+      assertThatJson(details).isEqualTo("{\"activityId\":1,\"activityName\":\"Maths\",\"prisonCode\":\"MDI\",\"prisonerNumber\":\"G4793VF\",\"scheduleId\":1,\"createdAt\":\"\${json-unit.ignore}\",\"createdBy\":\"test-client\"}")
+    }
+  }
+
+  private fun WebTestClient.waitingListApplication(
+    prisonCode: String,
+    application: WaitingListApplicationRequest,
+    caseloadId: String? = CASELOAD_ID,
+  ) =
+    post()
+      .uri("/allocations/$prisonCode/waiting-list-application")
+      .bodyValue(application)
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(isClientToken = false, roles = listOf(ROLE_ACTIVITY_HUB)))
+      .header(CASELOAD_ID, caseloadId)
+      .exchange()
 
   private fun WebTestClient.searchWaitingLists(
     prisonCode: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentAttendeeServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentAttendeeServiceTest.kt
@@ -18,8 +18,6 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiApplicationClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiApplicationClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.MovementType
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Appointment
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentAttendee
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentInstance
@@ -164,41 +162,13 @@ class AppointmentAttendeeServiceTest {
   inner class ManageAppointmentAttendees {
     private val prisonNumber = "A1234BC"
 
-    private val activeInPrisoner = PrisonerSearchPrisonerFixture.instance(
-      prisonerNumber = prisonNumber,
-      inOutStatus = Prisoner.InOutStatus.IN,
-      status = "ACTIVE IN",
-      prisonId = moorlandPrisonCode,
-      lastMovementType = null,
-      confirmedReleaseDate = null,
-    )
+    private val activeInPrisoner = activeInMoorlandPrisoner.copy(prisonerNumber = prisonNumber)
 
-    private val activeInDifferentPrison = PrisonerSearchPrisonerFixture.instance(
-      prisonerNumber = prisonNumber,
-      inOutStatus = Prisoner.InOutStatus.IN,
-      status = "ACTIVE IN",
-      prisonId = pentonvillePrisonCode,
-      lastMovementType = null,
-      confirmedReleaseDate = null,
-    )
+    private val activeInDifferentPrison = activeInPentonvillePrisoner.copy(prisonerNumber = prisonNumber)
 
-    private val activeOutPrisoner = PrisonerSearchPrisonerFixture.instance(
-      prisonerNumber = prisonNumber,
-      inOutStatus = Prisoner.InOutStatus.OUT,
-      status = "ACTIVE OUT",
-      prisonId = moorlandPrisonCode,
-      lastMovementType = null,
-      confirmedReleaseDate = null,
-    )
+    private val activeOutPrisoner = activeOutMoorlandPrisoner.copy(prisonerNumber = prisonNumber)
 
-    private val prisonerReleasedToday = PrisonerSearchPrisonerFixture.instance(
-      prisonerNumber = prisonNumber,
-      inOutStatus = Prisoner.InOutStatus.OUT,
-      status = "INACTIVE OUT",
-      prisonId = null,
-      lastMovementType = MovementType.RELEASE,
-      confirmedReleaseDate = LocalDate.now(),
-    )
+    private val prisonerReleasedToday = permanentlyReleasedPrisonerToday.copy(prisonerNumber = prisonNumber)
 
     private val expiredMovement = movement(prisonerNumber = prisonNumber, fromPrisonCode = moorlandPrisonCode, movementDate = TimeSource.yesterday())
     private val nonExpiredMovement = movement(prisonerNumber = prisonNumber, fromPrisonCode = moorlandPrisonCode, movementDate = TimeSource.today())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSearchPrisonerFixture.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSearchPrisonerFixture.kt
@@ -6,7 +6,17 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.PagedPrisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.PrisonerAlert
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import java.time.LocalDate
+
+val activeInMoorlandPrisoner = PrisonerSearchPrisonerFixture.instance(prisonId = moorlandPrisonCode, status = "ACTIVE IN")
+val activeInPentonvillePrisoner = activeInMoorlandPrisoner.copy(prisonId = pentonvillePrisonCode)
+val activeOutMoorlandPrisoner = PrisonerSearchPrisonerFixture.instance(prisonId = moorlandPrisonCode, status = "ACTIVE OUT", inOutStatus = Prisoner.InOutStatus.OUT)
+val activeOutPentonvillePrisoner = activeOutMoorlandPrisoner.copy(prisonId = pentonvillePrisonCode)
+val temporarilyReleasedFromMoorland = PrisonerSearchPrisonerFixture.instance(prisonId = moorlandPrisonCode, status = "ACTIVE OUT", inOutStatus = Prisoner.InOutStatus.OUT)
+val permanentlyReleasedPrisonerToday = PrisonerSearchPrisonerFixture.instance(prisonId = null, status = "INACTIVE OUT", inOutStatus = Prisoner.InOutStatus.OUT, lastMovementType = MovementType.RELEASE, confirmedReleaseDate = TimeSource.today())
 
 object PrisonerSearchPrisonerFixture {
   fun instance(


### PR DESCRIPTION
Changes the WaitingListService to use the prisoner search API instead of prison API as this is the recommended API for prisoner lookups, we should avoid using prison API where possible.

It also includes a little bit of refactoring around prisoner fixture set up in the the tests.