### PR TITLE
SAA-1493 interim solution to prevent overly large schedules being returned when looking up a schedule by its ID.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,7 +4,7 @@ import org.jlleitschuh.gradle.ktlint.tasks.KtLintFormatTask
 import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.12.0"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.13.0"
   kotlin("plugin.spring") version "1.9.22"
   kotlin("plugin.jpa") version "1.9.22"
   jacoco

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExt.kt
@@ -10,3 +10,6 @@ fun LocalDate.between(from: LocalDate, to: LocalDate?) = this >= from && (to == 
 fun LocalDate.onOrBefore(date: LocalDate) = this <= date
 
 fun LocalDate.toIsoDate(): String = this.format(DateTimeFormatter.ISO_DATE)
+
+fun Int.daysAgo(): LocalDate = require(this > 0) { "Days ago must be positive" }.let { LocalDate.now().minusDays(this.toLong()) }
+fun Int.weeksAgo(): LocalDate = require(this > 0) { "Weeks ago must be positive" }.let { LocalDate.now().minusWeeks(this.toLong()) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleController.kt
@@ -28,6 +28,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.weeksAgo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
@@ -168,8 +169,14 @@ class ActivityScheduleController(
   )
   @CaseloadHeader
   @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN', 'NOMIS_ACTIVITIES')")
-  fun getScheduleId(@PathVariable("scheduleId") scheduleId: Long) =
-    scheduleService.getScheduleById(scheduleId)
+  fun getScheduleId(
+    @PathVariable("scheduleId") scheduleId: Long,
+    @RequestParam(value = "earliestSessionDate", required = false)
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    @Parameter(description = "If provided will filter earliest sessions >= the given date. Format YYYY-MM-DD, otherwise defaults to 4 weeks prior to the current date.")
+    earliestSessionDate: LocalDate?,
+  ) =
+    scheduleService.getScheduleById(scheduleId, earliestSessionDate ?: 4.weeksAgo())
 
   @PostMapping(value = ["/{scheduleId}/allocations"])
   @Operation(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -128,8 +128,11 @@ class ActivityScheduleService(
       }
   }
 
-  fun getScheduleById(scheduleId: Long) =
-    repository.findOrThrowNotFound(scheduleId).checkCaseloadAccess().toModelSchedule()
+  fun getScheduleById(scheduleId: Long, earliestSessionDate: LocalDate) =
+    repository.getActivityScheduleByIdWithFilters(
+      activityScheduleId = scheduleId,
+      earliestSessionDate = earliestSessionDate,
+    )?.checkCaseloadAccess()?.toModelSchedule() ?: throw EntityNotFoundException("Activity schedule ID $scheduleId not found")
 
   @Transactional
   fun allocatePrisoner(scheduleId: Long, request: PrisonerAllocationRequest, allocatedBy: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExtTest.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common
+
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import java.time.LocalDate
+
+class LocalDateExtTest {
+
+  @Test
+  fun `days ago`() {
+    (1..10).forEach { it.daysAgo() isEqualTo LocalDate.now().minusDays(it.toLong()) }
+  }
+
+  @Test
+  fun `days ago fails if not a positive number`() {
+    (0 downTo -10).forEach {
+      assertThatThrownBy {
+        (it).daysAgo()
+      }.isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessage("Days ago must be positive")
+    }
+  }
+
+  @Test
+  fun `weeks ago`() {
+    (1..10).forEach { it.weeksAgo() isEqualTo LocalDate.now().minusWeeks(it.toLong()) }
+  }
+
+  @Test
+  fun `weeks ago fails if not a positive number`() {
+    (0 downTo -10).forEach {
+      assertThatThrownBy {
+        (it).weeksAgo()
+      }.isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessage("Weeks ago must be positive")
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -46,7 +46,12 @@ val eligibilityRuleFemale = EligibilityRule(eligibilityRuleId = 2, code = "FEMAL
 val lowPayBand = prisonPayBandsLowMediumHigh()[0]
 val mediumPayBand = prisonPayBandsLowMediumHigh()[1]
 
-val activeAllocation = activityEntity().schedules().first().allocations().first()
+val activeAllocation = activityEntity().schedule().allocations().first()
+
+val pentonvilleActivity = activityEntity(prisonCode = pentonvillePrisonCode)
+val moorlandActivity = activityEntity(prisonCode = moorlandPrisonCode)
+
+internal fun Activity.schedule() = this.schedules().single()
 
 internal fun activityEntity(
   category: ActivityCategory = activityCategory(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/TimeSource.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/TimeSource.kt
@@ -11,6 +11,4 @@ object TimeSource {
   fun yesterday(): LocalDate = today().minusDays(1)
 
   fun tomorrow(): LocalDate = today().plusDays(1)
-
-  fun daysInPast(days: Long): LocalDate = today().minusDays(days)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentJobIntegrationTest.kt
@@ -15,7 +15,7 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.MovementType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.daysAgo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
@@ -87,8 +87,8 @@ class AppointmentJobIntegrationTest : IntegrationTestBase() {
     confirmedReleaseDate = LocalDate.now(),
   )
 
-  private val expiredMovement = movement(prisonerNumber = prisonNumber, fromPrisonCode = risleyPrisonCode, movementDate = TimeSource.daysInPast(5))
-  private val nonExpiredMovement = movement(prisonerNumber = prisonNumber, fromPrisonCode = risleyPrisonCode, movementDate = TimeSource.daysInPast(4))
+  private val expiredMovement = movement(prisonerNumber = prisonNumber, fromPrisonCode = risleyPrisonCode, movementDate = 5.daysAgo())
+  private val nonExpiredMovement = movement(prisonerNumber = prisonNumber, fromPrisonCode = risleyPrisonCode, movementDate = 4.daysAgo())
 
   @Sql("classpath:test_data/seed-manage-appointments-job.sql")
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAllocationsJobIntegrationTest.kt
@@ -14,6 +14,7 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.MovementType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.daysAgo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason.ENDED
@@ -131,7 +132,7 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
     prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(listOf("A11111A"), listOf(prisoner))
     prisonApiMockServer.stubPrisonerMovements(
       listOf("A11111A"),
-      listOf(movement("A11111A", fromPrisonCode = pentonvillePrisonCode, movementDate = TimeSource.daysInPast(10))),
+      listOf(movement("A11111A", fromPrisonCode = pentonvillePrisonCode, movementDate = 10.daysAgo())),
     )
 
     with(allocationRepository.findAll()) {
@@ -170,7 +171,7 @@ class ManageAllocationsJobIntegrationTest : IntegrationTestBase() {
     prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(listOf("A11111A"), listOf(prisoner))
     prisonApiMockServer.stubPrisonerMovements(
       listOf("A11111A"),
-      listOf(movement("A11111A", fromPrisonCode = pentonvillePrisonCode, movementDate = TimeSource.daysInPast(10))),
+      listOf(movement("A11111A", fromPrisonCode = pentonvillePrisonCode, movementDate = 10.daysAgo())),
     )
 
     webTestClient.manageAllocations(withDeallocate = true)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
@@ -29,7 +29,9 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocat
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandActivity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.moorlandPrisonCode
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvilleActivity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.pentonvillePrisonCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.prisonPayBandsLowMediumHigh
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.schedule
@@ -49,9 +51,11 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.PRISO
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.PRISON_CODE_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.TelemetryEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.USER_PROPERTY_KEY
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.CaseloadAccessException
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.FakeCaseLoad
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.FakeSecurityContext
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelAllocations
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelSchedule
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
@@ -713,5 +717,37 @@ class ActivityScheduleServiceTest {
     }
       .isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Prisoner has a PENDING waiting list application. It must be APPROVED before they can be allocated.")
+  }
+
+  @Test
+  fun `should retrieve schedule by id and date`() {
+    val schedule = pentonvilleActivity.schedule()
+
+    whenever(repository.getActivityScheduleByIdWithFilters(schedule.activityScheduleId, TimeSource.today())) doReturn schedule
+
+    service.getScheduleById(schedule.activityScheduleId, TimeSource.today()) isEqualTo schedule.toModelSchedule()
+  }
+
+  @Test
+  fun `should fail to retrieve schedule by id and date when invalid case load`() {
+    val schedule = moorlandActivity.schedule()
+
+    whenever(repository.getActivityScheduleByIdWithFilters(schedule.activityScheduleId, TimeSource.today())) doReturn schedule
+
+    assertThatThrownBy {
+      service.getScheduleById(schedule.activityScheduleId, TimeSource.today()) isEqualTo schedule.toModelSchedule()
+    }.isInstanceOf(CaseloadAccessException::class.java)
+  }
+
+  @Test
+  fun `should fail to retrieve schedule by id and date when schedule not found`() {
+    val schedule = pentonvilleActivity.schedule()
+
+    whenever(repository.getActivityScheduleByIdWithFilters(schedule.activityScheduleId, TimeSource.today())) doReturn null
+
+    assertThatThrownBy {
+      service.getScheduleById(schedule.activityScheduleId, TimeSource.today()) isEqualTo schedule.toModelSchedule()
+    }.isInstanceOf(EntityNotFoundException::class.java)
+      .hasMessage("Activity schedule ID ${schedule.activityScheduleId} not found")
   }
 }

--- a/src/test/resources/test_data/seed-reduced-activity-instances.sql
+++ b/src/test/resources/test_data/seed-reduced-activity-instances.sql
@@ -1,0 +1,32 @@
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag)
+values (1, 1, '09:00:00', '12:00:00', true, true, true, true, true, true, true);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date, '09:00:00', '12:00:00', false, null, null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date - 1, '09:00:00', '12:00:00', false, null, null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date - 2, '09:00:00', '12:00:00', false, null, null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date - 3, '09:00:00', '12:00:00', false, null, null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date - 4, '09:00:00', '12:00:00', false, null, null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date - 5, '09:00:00', '12:00:00', false, null, null, null, null);
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_date - 6, '09:00:00', '12:00:00', false, null, null, null, null);


### PR DESCRIPTION
This should be viewed as a short to medium term (temporary??) solution to limit the overall size of a schedule and its associated instance child entities (which in turn have attendances associated with each instance).

This change adds an optional filter to the existing GET /schedules/{id} for the earliest point at which instances should be included in the response.

Note the potential gotcha here is if there are no recent instances that fit within the current time window (schedule no longer active/running) then they will be empty on the returned schedule.

![image](https://github.com/ministryofjustice/hmpps-activities-management-api/assets/60104344/0584e6aa-5861-4807-a6aa-39a50e61243a)
