### PR TITLE
SAA-1495 should be able to allocate prisoners to an activity when they are active in or out of the prison in question.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/WebClientConfiguration.kt
@@ -36,7 +36,7 @@ class WebClientConfiguration(
   @Value("\${case-notes.api.url}") private val caseNotesApiUrl: String,
   @Value("\${non-associations.api.url}") private val nonAssociationsApiUrl: String,
   @Value("\${api.health-timeout:2s}") private val healthTimeout: Duration,
-  @Value("\${api.timeout:90s}") private val apiTimeout: Duration,
+  @Value("\${api.timeout:30s}") private val apiTimeout: Duration,
   private val webClientBuilder: WebClient.Builder,
 ) {
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -11,7 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.casenote
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.casenotesapi.api.CaseNoteType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.casenotesapi.api.CaseNotesApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.isActiveIn
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.isActiveAtPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toPrisonerNumber
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.trackEvent
@@ -163,8 +163,8 @@ class ActivityScheduleService(
 
       val activePrisoner = prisonerSearchApiClient.findByPrisonerNumber(request.prisonerNumber)
         ?.also { prisoner ->
-          require(prisoner.isActiveIn(schedule.activity.prisonCode)) {
-            "Unable to allocate prisoner with prisoner number $prisonerNumber, prisoner is not active in prison ${schedule.activity.prisonCode}."
+          require(prisoner.isActiveAtPrison(schedule.activity.prisonCode)) {
+            "Unable to allocate prisoner with prisoner number $prisonerNumber, prisoner is not active at prison ${schedule.activity.prisonCode}."
           }
 
           requireNotNull(prisoner.bookingId) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/casenotesapi/api/CaseNotesApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/casenotesapi/api/CaseNotesApiClientTest.kt
@@ -42,7 +42,7 @@ class CaseNotesApiClientTest {
   fun `getCaseNote - success`() {
     caseNotesApiMockServer.stubGetCaseNote("A1234AA", 1)
     val caseNote = caseNotesApiClient.getCaseNote("A1234AA", 1)
-    assertThat(caseNote?.text).isEqualTo("Case Note Text")
+    assertThat(caseNote.text).isEqualTo("Case Note Text")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -40,16 +40,16 @@ const val moorlandPrisonCode = "MDI"
 const val pentonvillePrisonCode = "PVI"
 const val risleyPrisonCode = "RSI"
 
-val eligibilityRuleOver21 = EligibilityRule(eligibilityRuleId = 1, code = "OVER_21", "The prisoner must be over 21 to attend")
-val eligibilityRuleFemale = EligibilityRule(eligibilityRuleId = 2, code = "FEMALE_ONLY", "The prisoner must be female to attend")
+internal val eligibilityRuleOver21 = EligibilityRule(eligibilityRuleId = 1, code = "OVER_21", "The prisoner must be over 21 to attend")
+internal val eligibilityRuleFemale = EligibilityRule(eligibilityRuleId = 2, code = "FEMALE_ONLY", "The prisoner must be female to attend")
 
-val lowPayBand = prisonPayBandsLowMediumHigh()[0]
-val mediumPayBand = prisonPayBandsLowMediumHigh()[1]
+internal val lowPayBand = prisonPayBandsLowMediumHigh()[0]
+internal val mediumPayBand = prisonPayBandsLowMediumHigh()[1]
 
-val activeAllocation = activityEntity().schedule().allocations().first()
+internal val activeAllocation = activityEntity().schedule().allocations().first()
 
-val pentonvilleActivity = activityEntity(prisonCode = pentonvillePrisonCode)
-val moorlandActivity = activityEntity(prisonCode = moorlandPrisonCode)
+internal val pentonvilleActivity = activityEntity(prisonCode = pentonvillePrisonCode)
+internal val moorlandActivity = activityEntity(prisonCode = moorlandPrisonCode)
 
 internal fun Activity.schedule() = this.schedules().single()
 
@@ -155,7 +155,7 @@ internal fun activityCategory2(code: String = "category code 2") =
     description = "category description 2",
   )
 
-val notInWorkCategory = activityCategory("SAA_NOT_IN_WORK")
+internal val notInWorkCategory = activityCategory("SAA_NOT_IN_WORK")
 
 internal fun schedule(prisonCode: String = moorlandPrisonCode) = activityEntity(prisonCode = prisonCode).schedules().first()
 
@@ -310,7 +310,7 @@ internal fun deallocation(endDate: LocalDate? = null) =
     ?.let { activitySchedule(activityEntity(endDate = it)).allocations().first() }
     ?: activitySchedule(activityEntity()).allocations().first()
 
-fun rolloutPrison() = RolloutPrison(
+internal fun rolloutPrison() = RolloutPrison(
   1,
   pentonvillePrisonCode,
   "HMP Pentonville",
@@ -320,7 +320,7 @@ fun rolloutPrison() = RolloutPrison(
   LocalDate.of(2022, 12, 23),
 )
 
-fun prisonRegime(
+internal fun prisonRegime(
   prisonCode: String = pentonvillePrisonCode,
 ) = PrisonRegime(
   1,
@@ -334,7 +334,7 @@ fun prisonRegime(
   1,
 )
 
-fun prisonPayBandsLowMediumHigh(prisonCode: String = moorlandPrisonCode) = listOf(
+internal fun prisonPayBandsLowMediumHigh(prisonCode: String = moorlandPrisonCode) = listOf(
   PrisonPayBand(
     prisonPayBandId = 1,
     prisonCode = prisonCode,
@@ -432,7 +432,7 @@ internal fun ActivityScheduleSlot.runEveryDayOfWeek() {
   sundayFlag = true
 }
 
-fun waitingList(
+internal fun waitingList(
   waitingListId: Long = 1,
   prisonCode: String = pentonvillePrisonCode,
   prisonerNumber: String = "123456",


### PR DESCRIPTION
Fixes a bug I introduced whereby we used to be able to allocate a prisoner when they are either active in or out of a given prison.