### PR TITLE
SAA-1464 tidy up calls to prisoner API when getting prisoner information to restrict to minimal view of prisoner only, we don't need anymore than that.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/extensions/InmateDetailExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/extensions/InmateDetailExt.kt
@@ -1,7 +1,0 @@
-package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.extensions
-
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.InmateDetail
-
-fun InmateDetail.isActiveInPrison(prisonCode: String): Boolean = status == "ACTIVE IN" && agencyId == prisonCode
-
-fun InmateDetail.isActiveOutPrison(prisonCode: String): Boolean = status == "ACTIVE OUT" && agencyId == prisonCode

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/InterestingEventHandler.kt
@@ -46,7 +46,7 @@ class InterestingEventHandler(
     if (event is InboundReleaseEvent) return recordRelease(event)
     if (event is OffenderMergedEvent) return recordMerge(event)
 
-    getPrisonerDetailsFor(event.prisonerNumber())?.let { prisoner ->
+    getPrisonerDetailsFor(event.prisonerNumber()).let { prisoner ->
       if (rolloutPrisonRepository.isActivitiesRolledOutAt(prisoner.agencyId!!)) {
         if (allocationRepository.findByPrisonCodePrisonerNumberPrisonerStatus(
             prisonCode = prisoner.agencyId,
@@ -78,7 +78,7 @@ class InterestingEventHandler(
 
   private fun recordRelease(releaseEvent: InboundReleaseEvent): Outcome {
     if (rolloutPrisonRepository.isActivitiesRolledOutAt(releaseEvent.prisonCode())) {
-      getPrisonerDetailsFor(releaseEvent.prisonerNumber())?.let { prisoner ->
+      getPrisonerDetailsFor(releaseEvent.prisonerNumber()).let { prisoner ->
         val saved = eventReviewRepository.saveAndFlush(
           EventReview(
             eventTime = LocalDateTime.now(),
@@ -102,7 +102,7 @@ class InterestingEventHandler(
 
   private fun recordMerge(mergedEvent: OffenderMergedEvent): Outcome {
     // Use the new prisoner number - the merged will have been actioned in prison API
-    getPrisonerDetailsFor(mergedEvent.prisonerNumber())?.let { prisoner ->
+    getPrisonerDetailsFor(mergedEvent.prisonerNumber()).let { prisoner ->
       if (rolloutPrisonRepository.isActivitiesRolledOutAt(prisoner.agencyId!!)) {
         val saved = eventReviewRepository.saveAndFlush(
           EventReview(
@@ -115,7 +115,6 @@ class InterestingEventHandler(
           ),
         )
         log.debug("Saved interesting event ID ${saved.eventReviewId} - ${mergedEvent.eventType()} - replaced ${mergedEvent.removedPrisonerNumber()} with ${mergedEvent.prisonerNumber()}")
-        return Outcome.success()
       } else {
         log.debug("Ignoring offender merged event for ${mergedEvent.removedPrisonerNumber()} - prison ${prisoner.agencyId} is not rolled out.")
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderMergedEventHandler.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderMergedEventHandler.kt
@@ -50,7 +50,7 @@ class OffenderMergedEventHandler(
     val newNumber = event.prisonerNumber()
     val oldNumber = event.removedPrisonerNumber()
 
-    prisonApi.getPrisonerDetailsLite(newNumber)?.let { prisoner ->
+    prisonApi.getPrisonerDetailsLite(newNumber).let { prisoner ->
       prisoner.agencyId?.let { prisonCode ->
         if (rolloutPrisonRepository.isActivitiesRolledOutAt(prisonCode)) {
           transactionHandler.newSpringTransaction {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClientTest.kt
@@ -67,7 +67,7 @@ class PrisonApiClientTest {
 
     prisonApiMockServer.stubGetPrisonerDetails(prisonerNumber)
 
-    val prisonerDetails = prisonApiClient.getPrisonerDetails(prisonerNumber).block()!!
+    val prisonerDetails = prisonApiClient.getPrisonerDetailsLite(prisonerNumber)
     assertThat(prisonerDetails.bookingId).isEqualTo(1200993)
   }
 
@@ -77,9 +77,9 @@ class PrisonApiClientTest {
 
     prisonApiMockServer.stubGetPrisonerDetailsNotFound(prisonerNumber)
 
-    assertThatThrownBy { prisonApiClient.getPrisonerDetails(prisonerNumber).block() }
+    assertThatThrownBy { prisonApiClient.getPrisonerDetailsLite(prisonerNumber) }
       .isInstanceOf(WebClientResponseException::class.java)
-      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/offenderNo/AAAAA?fullInfo=true")
+      .hasMessage("404 Not Found from GET http://localhost:8999/api/bookings/offenderNo/AAAAA")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -347,7 +347,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/seed-activity-id-7.sql",
   )
   fun `403 (forbidden) response when user doesnt have correct role to allocate prisoner`() {
-    prisonApiMockServer.stubGetPrisonerDetails("G4793VF", fullInfo = false)
+    prisonApiMockServer.stubGetPrisonerDetails("G4793VF")
 
     repository.findById(1).orElseThrow().also { assertThat(it.allocations()).isEmpty() }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -689,7 +689,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
   fun `offender merged event replaces old prisoner number with new prisoner number`() {
     val (oldNumber, newNumber) = "A11111A" to "B11111B"
 
-    prisonApiMockServer.stubGetPrisonerDetails(activeInPentonvilleInmate.copy(offenderNo = newNumber), fullInfo = false)
+    prisonApiMockServer.stubGetPrisonerDetails(activeInPentonvilleInmate.copy(offenderNo = newNumber))
 
     // Check all set to the old prisoner number before event is processed
     allocationRepository.findAll().single().prisonerNumber isEqualTo oldNumber

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationTestBase.kt
@@ -100,10 +100,10 @@ abstract class IntegrationTestBase {
     this.queryParamIfPresent(name, Optional.ofNullable(type))
 
   internal fun stubPrisonerForInterestingEvent(prisoner: InmateDetail) {
-    prisonApiMockServer.stubGetPrisonerDetails(prisoner, fullInfo = false)
+    prisonApiMockServer.stubGetPrisonerDetails(prisoner)
   }
 
   internal fun stubPrisonerForInterestingEvent(prisonerNumber: String) {
-    prisonApiMockServer.stubGetPrisonerDetails(prisonerNumber = prisonerNumber, fullInfo = false)
+    prisonApiMockServer.stubGetPrisonerDetails(prisonerNumber = prisonerNumber)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -186,14 +186,9 @@ class PrisonApiMockServer : WireMockServer(8999) {
     )
   }
 
-  fun stubGetPrisonerDetails(
-    prisonerNumber: String,
-    fullInfo: Boolean = true,
-    extraInfo: Boolean? = null,
-    jsonFileSuffix: String = "",
-  ) {
+  fun stubGetPrisonerDetails(prisonerNumber: String, jsonFileSuffix: String = "") {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/offenderNo/$prisonerNumber?fullInfo=$fullInfo${extraInfo?.let { "&extraInfo=$it" } ?: ""}"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/offenderNo/$prisonerNumber"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")
@@ -203,13 +198,9 @@ class PrisonApiMockServer : WireMockServer(8999) {
     )
   }
 
-  fun stubGetPrisonerDetails(
-    prisoner: InmateDetail,
-    fullInfo: Boolean = true,
-    extraInfo: Boolean? = null,
-  ) {
+  fun stubGetPrisonerDetails(prisoner: InmateDetail) {
     stubFor(
-      WireMock.get(WireMock.urlEqualTo("/api/bookings/offenderNo/${prisoner.offenderNo}?fullInfo=$fullInfo${extraInfo?.let { "&extraInfo=$it" } ?: ""}"))
+      WireMock.get(WireMock.urlEqualTo("/api/bookings/offenderNo/${prisoner.offenderNo}"))
         .willReturn(
           WireMock.aResponse()
             .withHeader("Content-Type", "application/json")


### PR DESCRIPTION
This PR tidy's up a loose end with regards to one of the prison API calls.

It warranted some documentation as well to explain why it is the way it is.