### PR TITLE
SAA-1497: Fix check for expired movements at a given prison

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/client/prisonapi/api/PrisonApiClient.kt
@@ -421,7 +421,12 @@ class PrisonApiClient(private val prisonApiWebClient: WebClient) {
     prisonerNumbers.ifNotEmpty {
       prisonApiWebClient
         .post()
-        .uri("/api/movements/offenders")
+        .uri { uriBuilder: UriBuilder ->
+          uriBuilder
+            .path("/api/movements/offenders")
+            .queryParam("latestOnly", false)
+            .build()
+        }
         .bodyValue(prisonerNumbers)
         .retrieve()
         .bodyToMono(typeReference<List<Movement>>())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/wiremock/PrisonApiMockServer.kt
@@ -538,7 +538,7 @@ class PrisonApiMockServer : WireMockServer(8999) {
 
   fun stubPrisonerMovements(prisonerNumbers: List<String>, movements: List<Movement>) {
     stubFor(
-      WireMock.post(WireMock.urlEqualTo("/api/movements/offenders"))
+      WireMock.post(WireMock.urlEqualTo("/api/movements/offenders?latestOnly=false"))
         .withRequestBody(equalToJson(mapper.writeValueAsString(prisonerNumbers)))
         .willReturn(
           WireMock.aResponse()


### PR DESCRIPTION
Our deallocation job currently identifies expired prisoners by checking that the latest movement from the from the prison is more than 5 days ago. However, the endpoint to fetch these is missing the `latestOnly = false` query parameter. This means that if someone has multiple transfers within the 5 days, then only the movement out of the latest prison will be returned, and the movement from the prison in question will not be returned.

We have a case in production where someone had movements from Risley -> Peterborough -> Norwich, and only the movement from Peterborough -> Norwich was returned from the movements endpoint, and the person was not correctly identified as an expired prisoner from Risley

Adding this query parameter means that the movement out of Risley is returned, and the service layer will identify this movement as expired.