### PR TITLE
SAA-1504: Show deleted appointments with `isDeleted` flag

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Appointment.kt
@@ -11,7 +11,6 @@ import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import jakarta.persistence.Table
-import org.hibernate.annotations.SQLRestriction
 import org.springframework.data.domain.AbstractAggregateRoot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
@@ -32,7 +31,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointme
 
 @Entity
 @Table(name = "appointment")
-@SQLRestriction("NOT is_deleted")
 data class Appointment(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -216,6 +214,7 @@ data class Appointment(
     cancelledTime = cancelledTime,
     cancellationReasonId = cancellationReason?.appointmentCancellationReasonId,
     cancelledBy = cancelledBy,
+    isDeleted = isDeleted,
     attendees = attendees().toModel(),
   )
 
@@ -228,6 +227,7 @@ data class Appointment(
       endTime,
       isEdited = isEdited(),
       isCancelled = isCancelled(),
+      isDeleted = isDeleted,
     )
 
   fun toDetails(
@@ -270,6 +270,7 @@ data class Appointment(
         userMap[updatedBy].toSummary(updatedBy!!)
       },
       isCancelled(),
+      isDeleted,
       cancelledTime,
       if (cancelledBy == null) {
         null

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSeries.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSeries.kt
@@ -114,7 +114,7 @@ data class AppointmentSeries(
   @OrderBy("sequenceNumber ASC")
   private val appointments: MutableList<Appointment> = mutableListOf()
 
-  fun appointments() = appointments.filterNot { it.isDeleted }.toList()
+  fun appointments(includeDeleted: Boolean = false) = appointments.filter { !it.isDeleted || includeDeleted }.toList()
 
   fun scheduledAppointments() = appointments().filter { it.isScheduled() }.toList()
 
@@ -147,7 +147,7 @@ data class AppointmentSeries(
     referenceCodeMap: Map<String, ReferenceCode>,
     locationMap: Map<Long, Location>,
     userMap: Map<String, UserDetail>,
-  ) = appointments().toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)
+  ) = appointments(true).toDetails(prisonerMap, referenceCodeMap, locationMap, userMap)
 
   fun addAppointment(appointment: Appointment) = appointments.add(appointment)
 
@@ -174,13 +174,13 @@ data class AppointmentSeries(
     createdBy = createdBy,
     updatedTime = updatedTime,
     updatedBy = updatedBy,
-    appointments = appointments().toModel(),
+    appointments = appointments(true).toModel(),
   )
 
   fun toSummary() = AppointmentSeriesSummary(
     id = appointmentSeriesId,
     schedule = schedule?.toModel(),
-    appointmentCount = appointments().size,
+    appointmentCount = appointments(true).size,
     scheduledAppointmentCount = scheduledAppointments().size,
   )
 
@@ -217,7 +217,7 @@ data class AppointmentSeries(
       } else {
         userMap[updatedBy].toSummary(updatedBy!!)
       },
-      appointments().toSummary(),
+      appointments(true).toSummary(),
     )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSet.kt
@@ -83,7 +83,7 @@ data class AppointmentSet(
 
   fun appointmentSeries() = appointmentSeries.toList()
 
-  fun appointments(includeDeleted: Boolean = false) = appointmentSeries().map { series -> series.appointments(includeDeleted) }.flatten().sortedWith(compareBy<Appointment> { it.startDate }.thenBy { it.startTime })
+  fun appointments(includeDeleted: Boolean = false) = appointmentSeries().flatMap { series -> series.appointments(includeDeleted) }.sortedWith(compareBy<Appointment> { it.startDate }.thenBy { it.startTime })
 
   fun addAppointmentSeries(appointmentSeries: AppointmentSeries) = this.appointmentSeries.add(appointmentSeries)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSet.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSet.kt
@@ -83,13 +83,13 @@ data class AppointmentSet(
 
   fun appointmentSeries() = appointmentSeries.toList()
 
-  fun appointments() = appointmentSeries().map { series -> series.appointments() }.flatten().sortedWith(compareBy<Appointment> { it.startDate }.thenBy { it.startTime })
+  fun appointments(includeDeleted: Boolean = false) = appointmentSeries().map { series -> series.appointments(includeDeleted) }.flatten().sortedWith(compareBy<Appointment> { it.startDate }.thenBy { it.startTime })
 
   fun addAppointmentSeries(appointmentSeries: AppointmentSeries) = this.appointmentSeries.add(appointmentSeries)
 
-  fun prisonerNumbers() = appointmentSeries().flatMap { appointmentSeries -> appointmentSeries.appointments().flatMap { it.prisonerNumbers() } }.distinct()
+  fun prisonerNumbers() = appointmentSeries().flatMap { appointmentSeries -> appointmentSeries.appointments(true).flatMap { it.prisonerNumbers() } }.distinct()
 
-  fun usernames() = listOfNotNull(createdBy, updatedBy).union(appointments().flatMap { appointment -> appointment.usernames() }).distinct()
+  fun usernames() = listOfNotNull(createdBy, updatedBy).union(appointments(true).flatMap { appointment -> appointment.usernames() }).distinct()
 
   fun toModel() = AppointmentSetModel(
     id = this.appointmentSetId,
@@ -108,7 +108,7 @@ data class AppointmentSet(
 
   fun toSummary() = AppointmentSetSummary(
     id = this.appointmentSetId,
-    appointmentCount = this.appointmentSeries().flatMap { it.appointments() }.size,
+    appointmentCount = this.appointmentSeries().flatMap { it.appointments(true) }.size,
     scheduledAppointmentCount = this.appointmentSeries().flatMap { it.scheduledAppointments() }.size,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentUpdateDomainService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentUpdateDomainService.kt
@@ -81,6 +81,7 @@ class AppointmentUpdateDomainService(
       }
       if (request.isPropertyUpdate()) {
         updatedAppointmentSeries.appointments
+          .filterNot { it.isDeleted }
           .filter { appointmentIdsToUpdate.contains(it.id) }.toSet()
           .flatMap { it.attendees.map { attendee -> attendee.id } }
           .filter { !removedAttendeeIds.contains(it) && !addedAttendeesIds.contains(it) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Appointment.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Appointment.kt
@@ -174,6 +174,15 @@ data class Appointment(
   @Schema(
     description =
     """
+    Indicates that this appointment has been deleted and removed from scheduled events.
+    """,
+    example = "false",
+  )
+  val isDeleted: Boolean,
+
+  @Schema(
+    description =
+    """
     The prisoner or prisoners attending this appointment. Single appointments such as medical will have one
     attendee. A group appointment e.g. gym or chaplaincy sessions will have more than one attendee.
     Attendees are at the appointment level supporting alteration of attendees in any future appointment.

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentDetails.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentDetails.kt
@@ -218,6 +218,15 @@ data class AppointmentDetails(
   @Schema(
     description =
     """
+    Indicates that this appointment has been deleted and removed from scheduled events.
+    """,
+    example = "false",
+  )
+  val isDeleted: Boolean,
+
+  @Schema(
+    description =
+    """
     The date and time this appointment was cancelled.
     Will be null if this appointment has not been cancelled
     """,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentSummary.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentSummary.kt
@@ -65,4 +65,13 @@ data class AppointmentSummary(
     example = "false",
   )
   val isCancelled: Boolean,
+
+  @Schema(
+    description =
+    """
+    Indicates that this appointment has been deleted and removed from scheduled events.
+    """,
+    example = "false",
+  )
+  val isDeleted: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/DailyAppointmentMetricsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/DailyAppointmentMetricsService.kt
@@ -67,7 +67,7 @@ class DailyAppointmentMetricsService(
   private fun List<Appointment>.countUniqueAppointmentSets() =
     this.mapNotNull { it.appointmentSeries.appointmentSet }.map { it.appointmentSetId }.distinct().size.toDouble()
 
-  private fun List<Appointment>.countCancelledAppointments() = this.filter { it.isCancelled() }.size.toDouble()
+  private fun List<Appointment>.countCancelledAppointments() = this.filter { it.isCancelled() && !it.isDeleted }.size.toDouble()
 
   private fun List<Appointment>.countDeletedAppointments() = this.filter { it.isDeleted }.size.toDouble()
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentCancelDomainServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentCancelDomainServiceTest.kt
@@ -171,8 +171,8 @@ class AppointmentCancelDomainServiceTest {
         startTimeInMs,
       )
 
-      response.appointments.filter { ids.contains(it.id) } hasSize 0
-      response.appointments.filterNot { ids.contains(it.id) } hasSize 1
+      response.appointments.filter { ids.contains(it.id) && it.isDeleted } hasSize 3
+      response.appointments.filterNot { ids.contains(it.id) && it.isDeleted } hasSize 1
 
       verify(service).cancelAppointments(
         appointmentSeries,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSeriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSeriesTest.kt
@@ -42,6 +42,7 @@ class AppointmentSeriesTest {
     with(entity.appointments()) {
       assertThat(size).isEqualTo(2)
       assertThat(this.map { it.appointmentId }).isEqualTo(listOf(2L, 3L))
+      assertThat(this.map { it.isDeleted }).isEqualTo(listOf(false, false))
     }
   }
 
@@ -52,6 +53,7 @@ class AppointmentSeriesTest {
     with(entity.appointments(true)) {
       assertThat(size).isEqualTo(3)
       assertThat(this.map { it.appointmentId }).isEqualTo(listOf(1L, 2L, 3L))
+      assertThat(this.map { it.isDeleted }).isEqualTo(listOf(true, false, false))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSeriesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSeriesTest.kt
@@ -46,6 +46,16 @@ class AppointmentSeriesTest {
   }
 
   @Test
+  fun `appointments includes soft deleted appointments when "includeDeleted=true"`() {
+    val entity = appointmentSeriesEntity(frequency = AppointmentFrequency.WEEKLY, numberOfAppointments = 3)
+    entity.appointments().first().isDeleted = true
+    with(entity.appointments(true)) {
+      assertThat(size).isEqualTo(3)
+      assertThat(this.map { it.appointmentId }).isEqualTo(listOf(1L, 2L, 3L))
+    }
+  }
+
+  @Test
   fun `scheduled appointments filters out past appointments`() {
     val entity = appointmentSeriesEntity(
       startDate = LocalDate.now().minusDays(3),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSetTest.kt
@@ -229,6 +229,32 @@ class AppointmentSetTest {
     entity.toDetails(prisonerMap, referenceCodeMap, locationMap, userMap).appointments hasSize 2
   }
 
+  @Test
+  fun `appointments filters out soft deleted appointments`() {
+    val entity = appointmentSetEntity(
+      prisonerNumberToBookingIdMap = mapOf("A1234BC" to 456, "B2345CD" to 457, "C3456DE" to 458),
+    )
+    entity.appointments().first().isDeleted = true
+
+    with(entity.appointments()) {
+      assertThat(size).isEqualTo(2)
+      assertThat(this.map { it.appointmentId }).isEqualTo(listOf(2L, 3L))
+    }
+  }
+
+  @Test
+  fun `appointments includes soft deleted appointments when "includeDeleted=true"`() {
+    val entity = appointmentSetEntity(
+      prisonerNumberToBookingIdMap = mapOf("A1234BC" to 456, "B2345CD" to 457, "C3456DE" to 458),
+    )
+    entity.appointments().first().isDeleted = true
+
+    with(entity.appointments(true)) {
+      assertThat(size).isEqualTo(3)
+      assertThat(this.map { it.appointmentId }).isEqualTo(listOf(1L, 2L, 3L))
+    }
+  }
+
   private fun getPrisonerMap() = mapOf(
     "A1234BC" to PrisonerSearchPrisonerFixture.instance(
       prisonerNumber = "A1234BC",

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSetTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentSetTest.kt
@@ -239,6 +239,7 @@ class AppointmentSetTest {
     with(entity.appointments()) {
       assertThat(size).isEqualTo(2)
       assertThat(this.map { it.appointmentId }).isEqualTo(listOf(2L, 3L))
+      assertThat(this.map { it.isDeleted }).isEqualTo(listOf(false, false))
     }
   }
 
@@ -252,6 +253,7 @@ class AppointmentSetTest {
     with(entity.appointments(true)) {
       assertThat(size).isEqualTo(3)
       assertThat(this.map { it.appointmentId }).isEqualTo(listOf(1L, 2L, 3L))
+      assertThat(this.map { it.isDeleted }).isEqualTo(listOf(true, false, false))
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentTest.kt
@@ -220,6 +220,7 @@ class AppointmentTest {
         LocalTime.of(10, 30),
         isEdited = true,
         isCancelled = false,
+        isDeleted = false,
       ),
     )
   }
@@ -237,6 +238,7 @@ class AppointmentTest {
           entity.endTime,
           isEdited = true,
           isCancelled = false,
+          isDeleted = false,
         ),
       ),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
@@ -88,6 +88,7 @@ fun appointmentModel(createdTime: LocalDateTime = LocalDateTime.now(), updatedTi
     null,
     null,
     null,
+    false,
     attendees = listOf(appointmentAttendeeModel()),
   )
 
@@ -251,6 +252,7 @@ fun appointmentSeriesDetails(
       LocalTime.of(10, 30),
       isEdited = updatedTime != null,
       isCancelled = false,
+      isDeleted = false,
     ),
   ),
 )
@@ -298,6 +300,7 @@ fun appointmentDetails(
   updatedTime != null,
   updatedTime,
   updatedBy,
+  false,
   false,
   null,
   null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentDetailsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentDetailsIntegrationTest.kt
@@ -51,26 +51,6 @@ class AppointmentDetailsIntegrationTest : IntegrationTestBase() {
   }
 
   @Sql(
-    "classpath:test_data/seed-appointment-deleted-id-2.sql",
-  )
-  @Test
-  fun `get deleted appointment details returns 404 not found`() {
-    prisonApiMockServer.stubGetAppointmentCategoryReferenceCodes()
-    prisonApiMockServer.stubGetLocationsForAppointments("TPR", 123)
-    prisonApiMockServer.stubGetUserDetailsList(listOf("TEST.USER"))
-    prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
-      listOf("A1234BC"),
-      listOf(PrisonerSearchPrisonerFixture.instance(prisonerNumber = "A1234BC", bookingId = 456, prisonId = "TPR")),
-    )
-
-    webTestClient.get()
-      .uri("/appointments/3/details")
-      .headers(setAuthorisation(roles = listOf(ROLE_PRISON)))
-      .exchange()
-      .expectStatus().isNotFound
-  }
-
-  @Sql(
     "classpath:test_data/seed-appointment-attendance.sql",
   )
   @Test
@@ -175,6 +155,7 @@ class AppointmentDetailsIntegrationTest : IntegrationTestBase() {
         null,
         null,
         false,
+        false,
         null,
         null,
       ),
@@ -232,6 +213,7 @@ class AppointmentDetailsIntegrationTest : IntegrationTestBase() {
         false,
         null,
         null,
+        false,
         false,
         null,
         null,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentJobIntegrationTest.kt
@@ -97,12 +97,12 @@ class AppointmentJobIntegrationTest : IntegrationTestBase() {
 
     webTestClient.manageAppointmentAttendees(0)
 
-    with(webTestClient.getAppointmentSeriesById(1)!!) {
-      appointments.flatMap { it.attendees } hasSize 10
+    with(webTestClient.getAppointmentSeriesById(1)!!.appointments.filterNot { it.isDeleted }) {
+      flatMap { it.attendees } hasSize 10
     }
 
-    with(webTestClient.getAppointmentSetById(1)!!) {
-      appointments.flatMap { it.attendees } hasSize 3
+    with(webTestClient.getAppointmentSetById(1)!!.appointments.filterNot { it.isDeleted }) {
+      flatMap { it.attendees } hasSize 3
     }
 
     verifyNoInteractions(eventsPublisher)
@@ -116,15 +116,15 @@ class AppointmentJobIntegrationTest : IntegrationTestBase() {
 
     webTestClient.manageAppointmentAttendees(1)
 
-    with(webTestClient.getAppointmentSeriesById(1)!!) {
-      appointments.flatMap { it.attendees } hasSize 7
-      appointments.single { it.id == 1L }.attendees.map { it.prisonerNumber } isEqualTo listOf(prisonNumber, "B2345CD")
-      appointments.filterNot { it.id == 1L }.flatMap { it.attendees }.map { it.prisonerNumber }.toSet() isEqualTo setOf("B2345CD")
+    with(webTestClient.getAppointmentSeriesById(1)!!.appointments.filterNot { it.isDeleted }) {
+      flatMap { it.attendees } hasSize 7
+      single { it.id == 1L }.attendees.map { it.prisonerNumber } isEqualTo listOf(prisonNumber, "B2345CD")
+      filterNot { it.id == 1L }.flatMap { it.attendees }.map { it.prisonerNumber }.toSet() isEqualTo setOf("B2345CD")
     }
 
-    with(webTestClient.getAppointmentSetById(1)!!) {
-      appointments.flatMap { it.attendees } hasSize 2
-      appointments.flatMap { it.attendees }.map { it.prisonerNumber }.toSet() isEqualTo setOf("B2345CD", "C3456DE")
+    with(webTestClient.getAppointmentSetById(1)!!.appointments.filterNot { it.isDeleted }) {
+      flatMap { it.attendees } hasSize 2
+      flatMap { it.attendees }.map { it.prisonerNumber }.toSet() isEqualTo setOf("B2345CD", "C3456DE")
     }
 
     verify(eventsPublisher, times(4)).send(eventCaptor.capture())
@@ -149,12 +149,12 @@ class AppointmentJobIntegrationTest : IntegrationTestBase() {
 
     webTestClient.manageAppointmentAttendees(1)
 
-    with(webTestClient.getAppointmentSeriesById(1)!!) {
-      appointments.flatMap { it.attendees } hasSize 10
+    with(webTestClient.getAppointmentSeriesById(1)!!.appointments.filterNot { it.isDeleted }) {
+      flatMap { it.attendees } hasSize 10
     }
 
-    with(webTestClient.getAppointmentSetById(1)!!) {
-      appointments.flatMap { it.attendees } hasSize 3
+    with(webTestClient.getAppointmentSetById(1)!!.appointments.filterNot { it.isDeleted }) {
+      flatMap { it.attendees } hasSize 3
     }
 
     verifyNoInteractions(eventsPublisher)
@@ -169,15 +169,15 @@ class AppointmentJobIntegrationTest : IntegrationTestBase() {
 
     webTestClient.manageAppointmentAttendees(1)
 
-    with(webTestClient.getAppointmentSeriesById(1)!!) {
-      appointments.flatMap { it.attendees } hasSize 7
-      appointments.single { it.id == 1L }.attendees.map { it.prisonerNumber } isEqualTo listOf(prisonNumber, "B2345CD")
-      appointments.filterNot { it.id == 1L }.flatMap { it.attendees }.map { it.prisonerNumber }.toSet() isEqualTo setOf("B2345CD")
+    with(webTestClient.getAppointmentSeriesById(1)!!.appointments.filterNot { it.isDeleted }) {
+      flatMap { it.attendees } hasSize 7
+      single { it.id == 1L }.attendees.map { it.prisonerNumber } isEqualTo listOf(prisonNumber, "B2345CD")
+      filterNot { it.id == 1L }.flatMap { it.attendees }.map { it.prisonerNumber }.toSet() isEqualTo setOf("B2345CD")
     }
 
-    with(webTestClient.getAppointmentSetById(1)!!) {
-      appointments.flatMap { it.attendees } hasSize 2
-      appointments.flatMap { it.attendees }.map { it.prisonerNumber }.toSet() isEqualTo setOf("B2345CD", "C3456DE")
+    with(webTestClient.getAppointmentSetById(1)!!.appointments.filterNot { it.isDeleted }) {
+      flatMap { it.attendees } hasSize 2
+      flatMap { it.attendees }.map { it.prisonerNumber }.toSet() isEqualTo setOf("B2345CD", "C3456DE")
     }
 
     verify(eventsPublisher, times(4)).send(eventCaptor.capture())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSeriesIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSeriesIntegrationTest.kt
@@ -137,6 +137,7 @@ class AppointmentSeriesIntegrationTest : IntegrationTestBase() {
             null,
             null,
             null,
+            isDeleted = false,
             attendees = listOf(
               AppointmentAttendee(
                 3,
@@ -226,6 +227,7 @@ class AppointmentSeriesIntegrationTest : IntegrationTestBase() {
             LocalTime.of(10, 30),
             isEdited = false,
             isCancelled = false,
+            isDeleted = false,
           ),
         ),
       ),
@@ -519,6 +521,7 @@ class AppointmentSeriesIntegrationTest : IntegrationTestBase() {
             null,
             null,
             null,
+            isDeleted = false,
             attendees = listOf(
               AppointmentAttendee(
                 appointmentSeries.appointments.first().attendees.first().id,
@@ -604,6 +607,7 @@ class AppointmentSeriesIntegrationTest : IntegrationTestBase() {
             null,
             null,
             null,
+            isDeleted = false,
             attendees = listOf(
               AppointmentAttendee(id = 1, prisonerNumber = "A12345BC", bookingId = 1, null, null, null, null, null, null, null, null),
               AppointmentAttendee(id = 2, prisonerNumber = "B23456CE", bookingId = 2, null, null, null, null, null, null, null, null),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSetIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSetIntegrationTest.kt
@@ -132,6 +132,7 @@ class AppointmentSetIntegrationTest : IntegrationTestBase() {
             null,
             null,
             null,
+            isDeleted = false,
             attendees = listOf(
               AppointmentAttendee(
                 6,
@@ -177,6 +178,7 @@ class AppointmentSetIntegrationTest : IntegrationTestBase() {
             null,
             null,
             null,
+            isDeleted = false,
             attendees = listOf(
               AppointmentAttendee(
                 7,
@@ -222,6 +224,7 @@ class AppointmentSetIntegrationTest : IntegrationTestBase() {
             null,
             null,
             null,
+            isDeleted = false,
             attendees = listOf(
               AppointmentAttendee(
                 8,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
@@ -17,10 +17,10 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentMigrateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointment
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentInstance
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentSeries
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.AppointmentDeletedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentMigrateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_PRISON
@@ -181,17 +181,17 @@ class MigrateAppointmentIntegrationTest : IntegrationTestBase() {
 
     // Appointments starting earlier than supplied date should not have been deleted
     setOf(10L, 11L, 12L, 13L).forEach {
-      webTestClient.getAppointmentById(it).isDeleted isEqualTo false
+      webTestClient.getAppointmentById(it).isDeleted isBool false
     }
 
     // Not migrated
-    webTestClient.getAppointmentById(14).isDeleted isEqualTo false
+    webTestClient.getAppointmentById(14).isDeleted isBool false
     // On start date
-    webTestClient.getAppointmentById(15).isDeleted isEqualTo true
+    webTestClient.getAppointmentById(15).isDeleted isBool true
     // Different prison
-    webTestClient.getAppointmentById(16).isDeleted isEqualTo false
+    webTestClient.getAppointmentById(16).isDeleted isBool false
     // On start date
-    webTestClient.getAppointmentById(17).isDeleted isEqualTo true
+    webTestClient.getAppointmentById(17).isDeleted isBool true
 
     verify(eventsPublisher, times(2)).send(eventCaptor.capture())
 
@@ -219,17 +219,17 @@ class MigrateAppointmentIntegrationTest : IntegrationTestBase() {
 
     // Appointments starting earlier than supplied date should not have been deleted
     setOf(10L, 11L, 12L, 13L).forEach {
-      webTestClient.getAppointmentById(it).isDeleted isEqualTo false
+      webTestClient.getAppointmentById(it).isDeleted isBool false
     }
 
     // Not migrated
-    webTestClient.getAppointmentById(14).isDeleted isEqualTo false
+    webTestClient.getAppointmentById(14).isDeleted isBool false
     // On start date with matching category code
-    webTestClient.getAppointmentById(15).isDeleted isEqualTo true
+    webTestClient.getAppointmentById(15).isDeleted isBool true
     // Different prison
-    webTestClient.getAppointmentById(16).isDeleted isEqualTo false
+    webTestClient.getAppointmentById(16).isDeleted isBool false
     // On start date with different category code
-    webTestClient.getAppointmentById(17).isDeleted isEqualTo false
+    webTestClient.getAppointmentById(17).isDeleted isBool false
 
     verify(eventsPublisher).send(eventCaptor.capture())
 
@@ -303,23 +303,6 @@ class MigrateAppointmentIntegrationTest : IntegrationTestBase() {
 
     Thread.sleep(1000)
   }
-
-  private fun WebTestClient.getAppointmentSeriesById(id: Long) =
-    get()
-      .uri("/appointment-series/$id")
-      .headers(setAuthorisation(roles = listOf(ROLE_PRISON)))
-      .exchange()
-      .expectStatus().isOk
-      .expectHeader().contentType(MediaType.APPLICATION_JSON)
-      .expectBody(AppointmentSeries::class.java)
-      .returnResult().responseBody
-
-  private fun WebTestClient.expectGetAppointmentByIdNotFound(id: Long) =
-    get()
-      .uri("/appointments/$id")
-      .headers(setAuthorisation(roles = listOf(ROLE_PRISON)))
-      .exchange()
-      .expectStatus().isNotFound
 
   private fun WebTestClient.getAppointmentById(id: Long) =
     get()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
@@ -17,6 +17,7 @@ import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentMigrateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Appointment
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentSeries
@@ -180,17 +181,17 @@ class MigrateAppointmentIntegrationTest : IntegrationTestBase() {
 
     // Appointments starting earlier than supplied date should not have been deleted
     setOf(10L, 11L, 12L, 13L).forEach {
-      assertThat(webTestClient.getAppointmentById(it)).isNotNull
+      webTestClient.getAppointmentById(it).isDeleted isEqualTo false
     }
 
     // Not migrated
-    assertThat(webTestClient.getAppointmentById(14)).isNotNull
+    webTestClient.getAppointmentById(14).isDeleted isEqualTo false
     // On start date
-    webTestClient.expectGetAppointmentByIdNotFound(15)
+    webTestClient.getAppointmentById(15).isDeleted isEqualTo true
     // Different prison
-    assertThat(webTestClient.getAppointmentById(16)).isNotNull
+    webTestClient.getAppointmentById(16).isDeleted isEqualTo false
     // On start date
-    webTestClient.expectGetAppointmentByIdNotFound(17)
+    webTestClient.getAppointmentById(17).isDeleted isEqualTo true
 
     verify(eventsPublisher, times(2)).send(eventCaptor.capture())
 
@@ -218,17 +219,17 @@ class MigrateAppointmentIntegrationTest : IntegrationTestBase() {
 
     // Appointments starting earlier than supplied date should not have been deleted
     setOf(10L, 11L, 12L, 13L).forEach {
-      assertThat(webTestClient.getAppointmentById(it)).isNotNull
+      webTestClient.getAppointmentById(it).isDeleted isEqualTo false
     }
 
     // Not migrated
-    assertThat(webTestClient.getAppointmentById(14)).isNotNull
+    webTestClient.getAppointmentById(14).isDeleted isEqualTo false
     // On start date with matching category code
-    webTestClient.expectGetAppointmentByIdNotFound(15)
+    webTestClient.getAppointmentById(15).isDeleted isEqualTo true
     // Different prison
-    assertThat(webTestClient.getAppointmentById(16)).isNotNull
+    webTestClient.getAppointmentById(16).isDeleted isEqualTo false
     // On start date with different category code
-    assertThat(webTestClient.getAppointmentById(17)).isNotNull
+    webTestClient.getAppointmentById(17).isDeleted isEqualTo false
 
     verify(eventsPublisher).send(eventCaptor.capture())
 
@@ -255,7 +256,7 @@ class MigrateAppointmentIntegrationTest : IntegrationTestBase() {
 
     // All appointments in the seed data should have been deleted
     setOf(10L, 11L, 12L, 13L).forEach {
-      webTestClient.expectGetAppointmentByIdNotFound(it)
+      webTestClient.getAppointmentById(it).isDeleted isEqualTo true
     }
 
     verify(eventsPublisher, times(2)).send(eventCaptor.capture())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/AppointmentTest.kt
@@ -46,6 +46,7 @@ class AppointmentTest : ModelTest() {
       cancelledTime = null,
       cancellationReasonId = null,
       cancelledBy = null,
+      isDeleted = false,
     )
 
     val json = objectMapper.writeValueAsString(appointment)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesServiceTest.kt
@@ -228,6 +228,7 @@ class AppointmentSeriesServiceTest {
             appointmentEntity.endTime,
             isEdited = true,
             isCancelled = false,
+            isDeleted = false,
           ),
         ),
       ),


### PR DESCRIPTION
## Overview

This will make deleted appointments retrievable through our service while flagged as deleted. This allows us to show where appointments have been deleted from an appointment series/set and allows the user to view the archived details of the appointment such as who deleted it and when.

This has no impact on NOMIS sync where deleted appointments will remain deleted. Similarly, deleted appointments will continue to be hidden from unlock lists and the appointment search dashboard.