### PR TITLE
SAA-1510: Allow allocations due to end job to de-allocate from yesterday

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -57,6 +57,7 @@ dependencies {
   testImplementation("net.javacrumbs.json-unit:json-unit-json-path:3.2.2")
   testImplementation("org.springframework.security:spring-security-test")
   testImplementation("org.springframework.boot:spring-boot-starter-test")
+  testImplementation("org.awaitility:awaitility-kotlin")
 }
 
 kotlin {

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-ending-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-ending-cronjob.yaml
@@ -1,9 +1,9 @@
 apiVersion: batch/v1
 kind: CronJob
 metadata:
-  name: deallocate-allocations
+  name: deallocate-allocations-ending
 spec:
-  schedule:  "{{ .Values.cron.allocationsDeallocate }}"
+  schedule:  "{{ .Values.cron.allocationsDeallocateEnding }}"
   concurrencyPolicy: Replace
   failedJobsHistoryLimit: 5
   startingDeadlineSeconds: 43200
@@ -17,9 +17,9 @@ spec:
           restartPolicy: Never
           activeDeadlineSeconds: 3600
           containers:
-            - name: deallocate-allocations-job
+            - name: deallocate-allocations-ending-job
               image: ghcr.io/ministryofjustice/hmpps-devops-tools
               args:
                 - /bin/sh
                 - -c
-                - curl --fail --retry 2 -XPOST http://hmpps-activities-management-api/job/manage-allocations?withDeallocate=true
+                - curl --fail --retry 2 -XPOST http://hmpps-activities-management-api/job/manage-allocations?withDeallocateEnding=true

--- a/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-expiring-cronjob.yaml
+++ b/helm_deploy/hmpps-activities-management-api/templates/manage-allocations-deallocate-expiring-cronjob.yaml
@@ -1,0 +1,25 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: deallocate-allocations-expiring
+spec:
+  schedule:  "{{ .Values.cron.allocationsDeallocateExpiring }}"
+  concurrencyPolicy: Replace
+  failedJobsHistoryLimit: 5
+  startingDeadlineSeconds: 43200
+  successfulJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      ttlSecondsAfterFinished: 345600 # 4 days
+      backoffLimit: 2
+      template:
+        spec:
+          restartPolicy: Never
+          activeDeadlineSeconds: 3600
+          containers:
+            - name: deallocate-allocations-expiring-job
+              image: ghcr.io/ministryofjustice/hmpps-devops-tools
+              args:
+                - /bin/sh
+                - -c
+                - curl --fail --retry 2 -XPOST http://hmpps-activities-management-api/job/manage-allocations?withDeallocateExpiring=true

--- a/helm_deploy/hmpps-activities-management-api/values.yaml
+++ b/helm_deploy/hmpps-activities-management-api/values.yaml
@@ -115,7 +115,8 @@ generic-prometheus-alerts:
   targetApplication: hmpps-activities-management-api
 
 cron:
-  allocationsDeallocate: "0 22 * * *"
+  allocationsDeallocateEnding: "0 1 * * *"
+  allocationsDeallocateExpiring: "0 22 * * *"
   allocationsActivate: "0 2 * * *"
   appointmentAttendees: "30 2 * * *"
   createScheduledInstances: "0 3 * * *"

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -37,8 +37,9 @@ generic-prometheus-alerts:
 
 # We are overriding the times in development due to core service dependencies being switched off overnight e.g. prisoner search API.
 cron:
-  allocationsDeallocate: "30 21 * * *"
-  allocationsActivate: "30 6 * * *"
-  appointmentAttendees: "30 6 * * *"
-  createScheduledInstances: "45 6 * * *"
-  attendanceRecords: "0 7 * * *"
+  allocationsDeallocateEnding: "30 6 * * *"
+  allocationsDeallocateExpiring: "30 21 * * *"
+  allocationsActivate: "45 6 * * *"
+  appointmentAttendees: "45 6 * * *"
+  createScheduledInstances: "0 7 * * *"
+  attendanceRecords: "15 7 * * *"

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExt.kt
@@ -7,7 +7,7 @@ operator fun LocalDate.rangeTo(other: LocalDate) = LocalDateRange(this, other)
 
 fun LocalDate.between(from: LocalDate, to: LocalDate?) = this >= from && (to == null || this <= to)
 
-fun LocalDate.onOrBefore(date: LocalDate) = this <= date
+fun LocalDate?.onOrBefore(date: LocalDate) = this != null && this <= date
 
 fun LocalDate.toIsoDate(): String = this.format(DateTimeFormatter.ISO_DATE)
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalTimeExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalTimeExt.kt
@@ -4,3 +4,5 @@ import java.time.LocalTime
 import java.time.format.DateTimeFormatter
 
 fun LocalTime.toIsoTime(): String = this.format(DateTimeFormatter.ISO_TIME)
+
+fun LocalTime.onOrAfter(that: LocalTime) = this >= that

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/WebMvcConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/WebMvcConfiguration.kt
@@ -1,13 +1,23 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config
 
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.format.FormatterRegistry
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.converter.StringToTimeSlotConverter
+import java.time.Clock
+import java.time.LocalDateTime
 
 @Configuration
 class WebMvcConfiguration : WebMvcConfigurer {
   override fun addFormatters(registry: FormatterRegistry) {
     registry.addConverter(StringToTimeSlotConverter())
   }
+
+  @Bean
+  fun systemTimeSource() = SystemTimeSource { LocalDateTime.now(Clock.systemDefaultZone()) }
+}
+
+fun interface SystemTimeSource {
+  fun now(): LocalDateTime
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -366,6 +366,8 @@ data class ActivitySchedule(
       .filterNot { key -> slots.map { Pair(it.weekNumber, it.slotTimes()) }.contains(key) }
       .forEach { addSlot(it.first, it.second, updates[it]!!) }
   }
+
+  fun endsOn(date: LocalDate) = date == endDate
 }
 
 fun List<ActivitySchedule>.toModelLite() = map { it.toModelLite() }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -146,7 +146,7 @@ data class Allocation(
   /**
    * This will also check the planned end date should the end date be different or null.
    */
-  fun ends(date: LocalDate) = date == endDate || date == plannedDeallocation?.plannedDate
+  fun endsOn(date: LocalDate) = date == endDate || date == plannedDeallocation?.plannedDate
 
   fun deallocateOn(date: LocalDate, reason: DeallocationReason, deallocatedBy: String, caseNoteId: Long? = null) =
     this.apply {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJob.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.onOrBefore
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RolloutPrisonPlan
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAttendancesService
@@ -48,5 +49,5 @@ class ManageAttendanceRecordsJob(
     (
       mayBePrisonCode?.let { listOf(roleOutPrisonService.getByPrisonCode(it)) }
         ?: roleOutPrisonService.getRolloutPrisons()
-      ).filter(RolloutPrisonPlan::activitiesRolledOut).map(RolloutPrisonPlan::prisonCode)
+      ).filter { it.activitiesRolledOut && it.activitiesRolloutDate.onOrBefore(LocalDate.now()) }.map(RolloutPrisonPlan::prisonCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJob.kt
@@ -17,7 +17,7 @@ import java.time.LocalDate
  */
 @Component
 class ManageAttendanceRecordsJob(
-  private val roleOutPrisonService: RolloutPrisonService,
+  private val rolloutPrisonService: RolloutPrisonService,
   private val manageAttendancesService: ManageAttendancesService,
   private val jobRunner: SafeJobRunner,
 ) {
@@ -47,7 +47,7 @@ class ManageAttendanceRecordsJob(
 
   private fun getRolledOutPrisonsForActivities(mayBePrisonCode: String?) =
     (
-      mayBePrisonCode?.let { listOf(roleOutPrisonService.getByPrisonCode(it)) }
-        ?: roleOutPrisonService.getRolloutPrisons()
+      mayBePrisonCode?.let { listOf(rolloutPrisonService.getByPrisonCode(it)) }
+        ?: rolloutPrisonService.getRolloutPrisons()
       ).filter { it.activitiesRolledOut && it.activitiesRolloutDate.onOrBefore(LocalDate.now()) }.map(RolloutPrisonPlan::prisonCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJob.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
 import org.springframework.scheduling.annotation.Async
 import org.springframework.stereotype.Component
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.onOrBefore
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RolloutPrisonPlan
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAttendancesService
@@ -49,5 +48,5 @@ class ManageAttendanceRecordsJob(
     (
       mayBePrisonCode?.let { listOf(rolloutPrisonService.getByPrisonCode(it)) }
         ?: rolloutPrisonService.getRolloutPrisons()
-      ).filter { it.activitiesRolledOut && it.activitiesRolloutDate.onOrBefore(LocalDate.now()) }.map(RolloutPrisonPlan::prisonCode)
+      ).filter { it.activitiesRolledOut }.map(RolloutPrisonPlan::prisonCode)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ActivityScheduleRepositoryCustom.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ActivityScheduleRepositoryCustom.kt
@@ -16,6 +16,8 @@ interface ActivityScheduleRepositoryCustom {
     earliestSessionDate: LocalDate? = null,
     allocationsActiveOnDate: LocalDate? = null,
   ): ActivitySchedule?
+
+  fun getActivitySchedulesWithFilteredInstances(prisonCode: String, earliestSessionDate: LocalDate): List<ActivitySchedule>
 }
 
 class ActivityScheduleRepositoryCustomImpl : ActivityScheduleRepositoryCustom {
@@ -55,5 +57,26 @@ class ActivityScheduleRepositoryCustomImpl : ActivityScheduleRepositoryCustom {
       query.singleResult
     }.onFailure { log.error("ActivitySchedule by ID with filters ${it.message}") }
       .getOrNull()
+  }
+
+  @Override
+  override fun getActivitySchedulesWithFilteredInstances(
+    prisonCode: String,
+    earliestSessionDate: LocalDate,
+  ): List<ActivitySchedule> {
+    val session = entityManager.unwrap(Session::class.java)
+
+    val hql = "SELECT s from ActivitySchedule s where s.activity.prisonCode = :prisonCode"
+    val query: TypedQuery<ActivitySchedule> = entityManager.createQuery(hql, ActivitySchedule::class.java)
+    query.setParameter("prisonCode", prisonCode)
+
+    session
+      .enableFilter(SESSION_DATE_FILTER)
+      .setParameter("earliestSessionDate", earliestSessionDate)
+
+    return runCatching {
+      query.resultList.toList()
+    }.onFailure { log.error("ActivitySchedule by ID with filters ${it.message}") }
+      .getOrDefault(emptyList())
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/JobTriggerController.kt
@@ -80,11 +80,14 @@ class JobTriggerController(
     @RequestParam(value = "withActivate", required = false)
     @Parameter(description = "If true will run the activate pending allocations process. Defaults to false.")
     withActivate: Boolean = false,
-    @RequestParam(value = "withDeallocate", required = false)
-    @Parameter(description = "If true will run the deallocate allocations process. Defaults to false.")
-    withDeallocate: Boolean = false,
+    @RequestParam(value = "withDeallocateEnding", required = false)
+    @Parameter(description = "If true will run the deallocate allocations that are ending process. Defaults to false.")
+    withDeallocateEnding: Boolean = false,
+    @RequestParam(value = "withDeallocateExpiring", required = false)
+    @Parameter(description = "If true will run the deallocate allocations that are expiring process. Defaults to false.")
+    withDeallocateExpiring: Boolean = false,
   ): String {
-    manageAllocationsJob.execute(withActivate = withActivate, withDeallocate = withDeallocate)
+    manageAllocationsJob.execute(withActivate = withActivate, withDeallocateEnding = withDeallocateEnding, withDeallocateExpiring = withDeallocateExpiring)
 
     return "Manage allocations triggered operations"
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -9,9 +9,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.isAtDifferentLocationTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.extensions.isOutOfPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.ifNotEmpty
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.onOrAfter
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.onOrBefore
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.SystemTimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
@@ -28,7 +25,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.time.LocalTime
 
 @Service
 class ManageAllocationsService(
@@ -41,7 +37,6 @@ class ManageAllocationsService(
   private val transactionHandler: TransactionHandler,
   private val outboundEventsService: OutboundEventsService,
   private val prisonApi: PrisonApiApplicationClient,
-  private val timeSource: SystemTimeSource,
 ) {
 
   companion object {
@@ -66,18 +61,6 @@ class ManageAllocationsService(
    * Caution to be used when using the current date. Allocations should be ended at the end of the day.
    */
   fun endAllocationsDueToEnd(prisonCode: String, date: LocalDate) {
-    val now = timeSource.now()
-
-    require(date.onOrBefore(now.toLocalDate())) {
-      "You cannot end allocations in the future."
-    }
-
-    if (date == now.toLocalDate()) {
-      require(now.toLocalTime().onOrAfter(LocalTime.of(20, 0))) {
-        "You can only end today's allocations from 8pm onwards."
-      }
-    }
-
     require(rolloutPrisonRepository.isActivitiesRolledOutAt(prisonCode)) {
       "Supplied prison $prisonCode is not rolled out."
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -73,8 +73,8 @@ class ManageAllocationsService(
     }
 
     if (date == now.toLocalDate()) {
-      require(now.toLocalTime().onOrAfter(LocalTime.of(22, 0))) {
-        "You can only end today's allocations from 10pm onwards."
+      require(now.toLocalTime().onOrAfter(LocalTime.of(20, 0))) {
+        "You can only end today's allocations from 8pm onwards."
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExtTest.kt
@@ -2,6 +2,8 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common
 
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import java.time.LocalDate
 
@@ -35,5 +37,24 @@ class LocalDateExtTest {
       }.isInstanceOf(IllegalArgumentException::class.java)
         .hasMessage("Weeks ago must be positive")
     }
+  }
+
+  @Test
+  fun `on or before`() {
+    TimeSource.yesterday().onOrBefore(TimeSource.yesterday()) isBool true
+    TimeSource.yesterday().onOrBefore(TimeSource.today()) isBool true
+    TimeSource.yesterday().onOrBefore(TimeSource.tomorrow()) isBool true
+
+    TimeSource.today().onOrBefore(TimeSource.today()) isBool true
+    TimeSource.today().onOrBefore(TimeSource.tomorrow()) isBool true
+    TimeSource.today().onOrBefore(TimeSource.yesterday()) isBool false
+
+    TimeSource.tomorrow().onOrBefore(TimeSource.tomorrow()) isBool true
+    TimeSource.tomorrow().onOrBefore(TimeSource.yesterday()) isBool false
+
+    val nullDate: LocalDate? = null
+    nullDate.onOrBefore(TimeSource.yesterday()) isBool false
+    nullDate.onOrBefore(TimeSource.today()) isBool false
+    nullDate.onOrBefore(TimeSource.tomorrow()) isBool false
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -10,6 +10,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSou
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.lowPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityLite
@@ -1196,12 +1197,39 @@ class ActivityScheduleTest {
       activity = activityEntity(),
       noSlots = true,
     ).apply {
-      this.addSlot(1, LocalTime.of(8, 0) to LocalTime.of(12, 0), DayOfWeek.values().toSet())
+      this.addSlot(1, LocalTime.of(8, 0) to LocalTime.of(12, 0), DayOfWeek.entries.toSet())
     }
 
     assertThatThrownBy {
       schedule.updateSlots(emptyMap())
     }.isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Must have at least 1 active slot across the schedule")
+  }
+
+  @Test
+  fun `check schedule ends`() {
+    with(activitySchedule(activityEntity(startDate = yesterday, endDate = yesterday))) {
+      endsOn(yesterday) isBool true
+      endsOn(today) isBool false
+      endsOn(tomorrow) isBool false
+    }
+
+    with(activitySchedule(activityEntity(endDate = today))) {
+      endsOn(yesterday) isBool false
+      endsOn(today) isBool true
+      endsOn(tomorrow) isBool false
+    }
+
+    with(activitySchedule(activityEntity(endDate = tomorrow))) {
+      endsOn(yesterday) isBool false
+      endsOn(today) isBool false
+      endsOn(tomorrow) isBool true
+    }
+
+    with(activitySchedule(activityEntity(endDate = null))) {
+      endsOn(yesterday) isBool false
+      endsOn(today) isBool false
+      endsOn(tomorrow) isBool false
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -38,15 +38,15 @@ class AllocationTest {
   @Test
   fun `check allocation ends`() {
     with(allocation().apply { endDate = tomorrow }) {
-      assertThat(ends(yesterday)).isFalse
-      assertThat(ends(today)).isFalse
-      assertThat(ends(tomorrow)).isTrue
+      assertThat(endsOn(yesterday)).isFalse
+      assertThat(endsOn(today)).isFalse
+      assertThat(endsOn(tomorrow)).isTrue
     }
 
     with(allocation().apply { endDate = null }) {
-      assertThat(ends(yesterday)).isFalse
-      assertThat(ends(today)).isFalse
-      assertThat(ends(tomorrow)).isFalse
+      assertThat(endsOn(yesterday)).isFalse
+      assertThat(endsOn(today)).isFalse
+      assertThat(endsOn(tomorrow)).isFalse
     }
   }
 
@@ -248,7 +248,7 @@ class AllocationTest {
       assertThat(plannedAt).isCloseTo(LocalDateTime.now(), within(2, ChronoUnit.SECONDS))
     }
 
-    assertThat(allocation.ends(tomorrow))
+    assertThat(allocation.endsOn(tomorrow))
   }
 
   @Test
@@ -271,7 +271,7 @@ class AllocationTest {
       assertThat(plannedAt).isCloseTo(LocalDateTime.now(), within(5, ChronoUnit.SECONDS))
     }
 
-    assertThat(allocation.ends(tomorrow.plusDays(1)))
+    assertThat(allocation.endsOn(tomorrow.plusDays(1)))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -48,8 +48,8 @@ internal val mediumPayBand = prisonPayBandsLowMediumHigh()[1]
 
 internal val activeAllocation = activityEntity().schedule().allocations().first()
 
-internal val pentonvilleActivity = activityEntity(prisonCode = PENTONVILLE_PRISON_CODE)
-internal val moorlandActivity = activityEntity(prisonCode = MOORLAND_PRISON_CODE)
+internal val pentonvilleActivity = activityEntity(activityId = 1, prisonCode = PENTONVILLE_PRISON_CODE)
+internal val moorlandActivity = activityEntity(activityId = 2, prisonCode = MOORLAND_PRISON_CODE)
 
 internal fun Activity.schedule() = this.schedules().single()
 
@@ -310,9 +310,9 @@ internal fun deallocation(endDate: LocalDate? = null) =
     ?.let { activitySchedule(activityEntity(endDate = it)).allocations().first() }
     ?: activitySchedule(activityEntity()).allocations().first()
 
-internal fun rolloutPrison() = RolloutPrison(
+internal fun rolloutPrison(prisonCode: String = PENTONVILLE_PRISON_CODE) = RolloutPrison(
   1,
-  PENTONVILLE_PRISON_CODE,
+  prisonCode,
   "HMP Pentonville",
   true,
   LocalDate.of(2022, 12, 22),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/DailyActivityMetricsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/DailyActivityMetricsJobIntegrationTest.kt
@@ -1,6 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
 
 import com.microsoft.applicationinsights.TelemetryClient
+import org.awaitility.kotlin.await
+import org.awaitility.kotlin.untilAsserted
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -26,8 +28,8 @@ class DailyActivityMetricsJobIntegrationTest : IntegrationTestBase() {
       .exchange()
       .expectStatus().isCreated
 
-    Thread.sleep(5000)
-
-    verify(telemetryClient, times(81)).trackEvent(eq(TelemetryEvent.ACTIVITIES_DAILY_STATS.value), any(), any())
+    await untilAsserted {
+      verify(telemetryClient, times(81)).trackEvent(eq(TelemetryEvent.ACTIVITIES_DAILY_STATS.value), any(), any())
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -3,21 +3,30 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.PENTONVILLE_PRISON_CODE
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rolloutPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAllocationsService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
+import java.time.LocalDate
 
 class ManageAllocationsJobTest {
+  private val rolloutPrisonRepository: RolloutPrisonRepository = mock {
+    on { findAll() } doReturn listOf(rolloutPrison(PENTONVILLE_PRISON_CODE), rolloutPrison(MOORLAND_PRISON_CODE))
+  }
   private val deallocationService: ManageAllocationsService = mock()
   private val jobRepository: JobRepository = mock()
   private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
-  private val job = ManageAllocationsJob(deallocationService, safeJobRunner)
+  private val job = ManageAllocationsJob(rolloutPrisonRepository, deallocationService, safeJobRunner)
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 
   @Test
@@ -34,7 +43,8 @@ class ManageAllocationsJobTest {
   fun `deallocate allocation operation triggered`() {
     job.execute(withDeallocate = true)
 
-    verify(deallocationService).allocations(AllocationOperation.ENDING_TODAY)
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, LocalDate.now())
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, LocalDate.now())
     verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
     verify(safeJobRunner, times(2)).runJob(jobDefinitionCaptor.capture())
 
@@ -47,7 +57,8 @@ class ManageAllocationsJobTest {
     job.execute(withActivate = true, withDeallocate = true)
 
     verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
-    verify(deallocationService).allocations(AllocationOperation.ENDING_TODAY)
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, LocalDate.now())
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, LocalDate.now())
     verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
     verify(safeJobRunner, times(3)).runJob(jobDefinitionCaptor.capture())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -1,13 +1,13 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job
 
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoMoreInteractions
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.daysAgo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.PENTONVILLE_PRISON_CODE
@@ -17,7 +17,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Roll
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationOperation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ManageAllocationsService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.MonitoringService
-import java.time.LocalDate
 
 class ManageAllocationsJobTest {
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock {
@@ -27,43 +26,89 @@ class ManageAllocationsJobTest {
   private val jobRepository: JobRepository = mock()
   private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
   private val job = ManageAllocationsJob(rolloutPrisonRepository, deallocationService, safeJobRunner)
-  private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
+  private val yesterday = 1.daysAgo()
 
   @Test
   fun `activate allocation operation triggered`() {
     job.execute(withActivate = true)
 
     verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
-    verify(safeJobRunner).runJob(jobDefinitionCaptor.capture())
+    verifyNoMoreInteractions(deallocationService)
 
-    assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.ALLOCATE)
+    verifyJobsCalled(JobType.ALLOCATE)
   }
 
   @Test
-  fun `deallocate allocation operation triggered`() {
-    job.execute(withDeallocate = true)
+  fun `deallocate allocation due to end operation triggered`() {
+    job.execute(withDeallocateEnding = true)
 
-    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, LocalDate.now())
-    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, LocalDate.now())
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, yesterday)
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, yesterday)
+    verifyNoMoreInteractions(deallocationService)
+
+    verifyJobsCalled(JobType.DEALLOCATE_ENDING)
+  }
+
+  @Test
+  fun `deallocate allocation due to expire operation triggered`() {
+    job.execute(withDeallocateExpiring = true)
+
     verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
-    verify(safeJobRunner, times(2)).runJob(jobDefinitionCaptor.capture())
+    verifyNoMoreInteractions(deallocationService)
 
-    assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.DEALLOCATE_ENDING)
-    assertThat(jobDefinitionCaptor.secondValue.jobType).isEqualTo(JobType.DEALLOCATE_EXPIRING)
+    verifyJobsCalled(JobType.DEALLOCATE_EXPIRING)
   }
 
   @Test
-  fun `activate and deallocate allocation operations triggered`() {
-    job.execute(withActivate = true, withDeallocate = true)
+  fun `activate and deallocate allocation due to end operations triggered`() {
+    job.execute(withActivate = true, withDeallocateEnding = true)
 
     verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
-    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, LocalDate.now())
-    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, LocalDate.now())
-    verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
-    verify(safeJobRunner, times(3)).runJob(jobDefinitionCaptor.capture())
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, yesterday)
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, yesterday)
+    verifyNoMoreInteractions(deallocationService)
 
-    assertThat(jobDefinitionCaptor.firstValue.jobType).isEqualTo(JobType.ALLOCATE)
-    assertThat(jobDefinitionCaptor.secondValue.jobType).isEqualTo(JobType.DEALLOCATE_ENDING)
-    assertThat(jobDefinitionCaptor.thirdValue.jobType).isEqualTo(JobType.DEALLOCATE_EXPIRING)
+    verifyJobsCalled(JobType.ALLOCATE, JobType.DEALLOCATE_ENDING)
+  }
+
+  @Test
+  fun `activate and deallocate allocation due to expire operations triggered`() {
+    job.execute(withActivate = true, withDeallocateExpiring = true)
+
+    verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
+    verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
+    verifyNoMoreInteractions(deallocationService)
+
+    verifyJobsCalled(JobType.ALLOCATE, JobType.DEALLOCATE_EXPIRING)
+  }
+
+  @Test
+  fun `deallocate allocation due to end and deallocate allocation due to expire operations triggered`() {
+    job.execute(withDeallocateEnding = true, withDeallocateExpiring = true)
+
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, yesterday)
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, yesterday)
+    verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
+    verifyNoMoreInteractions(deallocationService)
+
+    verifyJobsCalled(JobType.DEALLOCATE_ENDING, JobType.DEALLOCATE_EXPIRING)
+  }
+
+  @Test
+  fun `activate, deallocate allocation due to end and deallocate allocation due to expire operations triggered`() {
+    job.execute(withActivate = true, withDeallocateEnding = true, withDeallocateExpiring = true)
+
+    verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, yesterday)
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, yesterday)
+    verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
+    verifyNoMoreInteractions(deallocationService)
+
+    verifyJobsCalled(JobType.ALLOCATE, JobType.DEALLOCATE_ENDING, JobType.DEALLOCATE_EXPIRING)
+  }
+
+  private fun verifyJobsCalled(vararg jobTypes: JobType) {
+    jobTypes.forEach { verify(safeJobRunner).runJob(argThat { this.jobType == it }) }
+    verifyNoMoreInteractions(safeJobRunner)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
@@ -22,19 +22,19 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.Rollout
 import java.time.LocalDate
 
 class ManageAttendanceRecordsJobTest {
-  private val roleOutPrisonService: RolloutPrisonService = mock {
+  private val rollOutPrisonService: RolloutPrisonService = mock {
     on { getRolloutPrisons() } doReturn listOf(
       RolloutPrisonPlan(
         MOORLAND_PRISON_CODE,
         activitiesRolledOut = true,
-        activitiesRolloutDate = null,
+        activitiesRolloutDate = TimeSource.today(),
         appointmentsRolledOut = false,
         appointmentsRolloutDate = null,
       ),
       RolloutPrisonPlan(
         PENTONVILLE_PRISON_CODE,
         activitiesRolledOut = true,
-        activitiesRolloutDate = null,
+        activitiesRolloutDate = TimeSource.today(),
         appointmentsRolledOut = false,
         appointmentsRolloutDate = null,
       ),
@@ -43,7 +43,7 @@ class ManageAttendanceRecordsJobTest {
       RolloutPrisonPlan(
         PENTONVILLE_PRISON_CODE,
         activitiesRolledOut = true,
-        activitiesRolloutDate = null,
+        activitiesRolloutDate = TimeSource.today(),
         appointmentsRolledOut = false,
         appointmentsRolloutDate = null,
       )
@@ -52,7 +52,7 @@ class ManageAttendanceRecordsJobTest {
   private val attendancesService: ManageAttendancesService = mock()
   private val jobRepository: JobRepository = mock()
   private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
-  private val job = ManageAttendanceRecordsJob(roleOutPrisonService, attendancesService, safeJobRunner)
+  private val job = ManageAttendanceRecordsJob(rollOutPrisonService, attendancesService, safeJobRunner)
   private val jobDefinitionCaptor = argumentCaptor<JobDefinition>()
 
   @Test
@@ -96,7 +96,7 @@ class ManageAttendanceRecordsJobTest {
     job.execute(date = TimeSource.tomorrow(), withExpiry = false)
 
     verifyNoInteractions(attendancesService)
-    verifyNoInteractions(roleOutPrisonService)
+    verifyNoInteractions(rollOutPrisonService)
     verifyNoInteractions(safeJobRunner)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
@@ -47,7 +47,7 @@ class ManageAllocationsServiceTest {
   private val waitingListService: WaitingListService = mock()
   private val outboundEventsService: OutboundEventsService = mock()
   private val prisonApi: PrisonApiApplicationClient = mock()
-  private val fixedTimeSource = SystemTimeSource { LocalDate.now().atTime(22, 0) }
+  private val fixedTimeSource = SystemTimeSource { LocalDate.now().atTime(20, 0) }
 
   private val service =
     ManageAllocationsService(
@@ -118,7 +118,7 @@ class ManageAllocationsServiceTest {
   }
 
   @Test
-  fun `should fail to deallocate offenders when before 10pm today`() {
+  fun `should fail to deallocate offenders when before 8pm today`() {
     val prison = rolloutPrison()
     val schedule = activitySchedule(activityEntity(startDate = yesterday, endDate = today))
 
@@ -136,9 +136,9 @@ class ManageAllocationsServiceTest {
         TransactionHandler(),
         outboundEventsService,
         prisonApi,
-      ) { TimeSource.today().atTime(21, 59) }.endAllocationsDueToEnd(prison.code, TimeSource.today())
+      ) { TimeSource.today().atTime(19, 59) }.endAllocationsDueToEnd(prison.code, TimeSource.today())
     }.isInstanceOf(IllegalArgumentException::class.java)
-      .hasMessage("You can only end today's allocations from 10pm onwards.")
+      .hasMessage("You can only end today's allocations from 8pm onwards.")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
@@ -1,6 +1,6 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
-import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
@@ -13,6 +13,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiApplicationClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiApplicationClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.SystemTimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
@@ -20,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.enumeration.Ser
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
@@ -27,7 +29,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.movemen
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.prisonRegime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rolloutPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.waitingList
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.PrisonRegimeRepository
@@ -39,7 +40,6 @@ import java.time.LocalDateTime
 class ManageAllocationsServiceTest {
 
   private val rolloutPrisonRepo: RolloutPrisonRepository = mock()
-  private val activityRepo: ActivityRepository = mock()
   private val activityScheduleRepo: ActivityScheduleRepository = mock()
   private val allocationRepository: AllocationRepository = mock()
   private val prisonRegimeRepository: PrisonRegimeRepository = mock()
@@ -47,11 +47,11 @@ class ManageAllocationsServiceTest {
   private val waitingListService: WaitingListService = mock()
   private val outboundEventsService: OutboundEventsService = mock()
   private val prisonApi: PrisonApiApplicationClient = mock()
+  private val fixedTimeSource = SystemTimeSource { LocalDate.now().atTime(22, 0) }
 
   private val service =
     ManageAllocationsService(
       rolloutPrisonRepo,
-      activityRepo,
       activityScheduleRepo,
       allocationRepository,
       prisonRegimeRepository,
@@ -60,6 +60,7 @@ class ManageAllocationsServiceTest {
       TransactionHandler(),
       outboundEventsService,
       prisonApi,
+      fixedTimeSource,
     )
   private val yesterday = LocalDate.now().minusDays(1)
   private val today = yesterday.plusDays(1)
@@ -72,14 +73,13 @@ class ManageAllocationsServiceTest {
   @Test
   fun `deallocate offenders from activity ending today without pending deallocation`() {
     val prison = rolloutPrison()
-    val activity = activityEntity(startDate = yesterday, endDate = today)
-    val schedule = activity.schedules().first()
+    val schedule = activitySchedule(activityEntity(startDate = yesterday, endDate = today))
     val allocation = schedule.allocations().first().also { it.verifyIsActive() }
 
-    whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
-    whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
+    whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
+    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
 
-    service.allocations(AllocationOperation.ENDING_TODAY)
+    service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 
     allocation.verifyIsEnded()
 
@@ -89,32 +89,69 @@ class ManageAllocationsServiceTest {
   @Test
   fun `deallocate offenders from activity ending today declines pending or approved waiting lists`() {
     val prison = rolloutPrison()
-    val activity = activityEntity(startDate = yesterday, endDate = today)
+    val schedule = activitySchedule(activityEntity(startDate = yesterday, endDate = today))
 
-    whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
-    whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
+    whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
+    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
 
-    service.allocations(AllocationOperation.ENDING_TODAY)
+    service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 
     verify(waitingListService).declinePendingOrApprovedApplications(
-      activity.activityId,
+      schedule.activity.activityId,
       "Activity ended",
       "Activities Management Service",
     )
   }
 
   @Test
+  fun `should fail to deallocate offenders when future date supplied`() {
+    val prison = rolloutPrison()
+    val schedule = activitySchedule(activityEntity(startDate = yesterday, endDate = today))
+
+    whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
+    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
+
+    assertThatThrownBy {
+      service.endAllocationsDueToEnd(prison.code, TimeSource.tomorrow())
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("You cannot end allocations in the future.")
+  }
+
+  @Test
+  fun `should fail to deallocate offenders when before 10pm today`() {
+    val prison = rolloutPrison()
+    val schedule = activitySchedule(activityEntity(startDate = yesterday, endDate = today))
+
+    whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
+    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
+
+    assertThatThrownBy {
+      ManageAllocationsService(
+        rolloutPrisonRepo,
+        activityScheduleRepo,
+        allocationRepository,
+        prisonRegimeRepository,
+        searchApiClient,
+        waitingListService,
+        TransactionHandler(),
+        outboundEventsService,
+        prisonApi,
+      ) { TimeSource.today().atTime(21, 59) }.endAllocationsDueToEnd(prison.code, TimeSource.today())
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("You can only end today's allocations from 10pm onwards.")
+  }
+
+  @Test
   fun `deallocate offenders from activity ending today with pending deallocation`() {
     val prison = rolloutPrison()
-    val activity = activityEntity(startDate = yesterday, endDate = today)
-    val schedule = activity.schedules().first()
+    val schedule = activitySchedule(activityEntity(startDate = yesterday, endDate = today))
     val allocation = schedule.allocations().first().also { it.verifyIsActive() }
     allocation.deallocateOn(today, DeallocationReason.OTHER, "by test")
 
-    whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
-    whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
+    whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
+    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
 
-    service.allocations(AllocationOperation.ENDING_TODAY)
+    service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 
     allocation.verifyIsEnded(DeallocationReason.OTHER, "by test")
 
@@ -124,14 +161,13 @@ class ManageAllocationsServiceTest {
   @Test
   fun `deallocate offenders from activity with no end date and allocation ends today`() {
     val prison = rolloutPrison()
-    val activity = activityEntity(startDate = yesterday, endDate = null)
-    val schedule = activity.schedules().first()
+    val schedule = activitySchedule(activityEntity(startDate = yesterday, endDate = null))
     val allocation = schedule.allocations().first().apply { endDate = today }.also { it.verifyIsActive() }
 
-    whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
-    whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
+    whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
+    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
 
-    service.allocations(AllocationOperation.ENDING_TODAY)
+    service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 
     allocation.verifyIsEnded()
 
@@ -142,65 +178,18 @@ class ManageAllocationsServiceTest {
   @Test
   fun `offenders not deallocated from activity with no end date and allocation does not end today`() {
     val prison = rolloutPrison()
-    val activity = activityEntity(startDate = yesterday, endDate = null)
-    val schedule = activity.schedules().first()
+    val schedule = activitySchedule(activityEntity(startDate = yesterday, endDate = null))
     val allocation = schedule.allocations().first().also { it.verifyIsActive() }
 
-    whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(prison))
-    whenever(activityRepo.getAllForPrisonAndDate(prison.code, LocalDate.now())).thenReturn(listOf(activity))
+    whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
+    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
 
-    service.allocations(AllocationOperation.ENDING_TODAY)
+    service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 
     allocation.verifyIsActive()
 
     verify(activityScheduleRepo, never()).saveAndFlush(any())
     verifyNoInteractions(waitingListService)
-  }
-
-  @Test
-  fun `deallocate offenders from activities across multiple prisons`() {
-    val moorland = rolloutPrison().copy(code = MOORLAND_PRISON_CODE)
-    val pentonville = rolloutPrison()
-    whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(pentonville, moorland))
-
-    val pentonvilleActivity = activityEntity(activityId = 1, startDate = yesterday, endDate = today)
-    val moorlandActivity = activityEntity(activityId = 2, startDate = yesterday, endDate = today)
-    whenever(activityRepo.getAllForPrisonAndDate(pentonville.code, today)).thenReturn(listOf(pentonvilleActivity))
-    whenever(activityRepo.getAllForPrisonAndDate(moorland.code, today)).thenReturn(listOf(moorlandActivity))
-
-    service.allocations(AllocationOperation.ENDING_TODAY)
-
-    listOf(pentonvilleActivity, moorlandActivity).onEach { activity ->
-      with(activity) {
-        this.schedules().first().allocations().forEach { assertThat(it.status(PrisonerStatus.ENDED)).isTrue() }
-        verify(activityScheduleRepo).saveAndFlush(this.schedules().first())
-      }
-    }
-  }
-
-  @Test
-  fun `deallocate offenders from activities ending today declines pending or approved waiting lists`() {
-    val moorland = rolloutPrison().copy(code = MOORLAND_PRISON_CODE)
-    val pentonville = rolloutPrison()
-    whenever(rolloutPrisonRepo.findAll()).thenReturn(listOf(pentonville, moorland))
-
-    val pentonvilleActivity = activityEntity(activityId = 1, startDate = yesterday, endDate = today)
-    val moorlandActivity = activityEntity(activityId = 2, startDate = yesterday, endDate = today)
-    whenever(activityRepo.getAllForPrisonAndDate(pentonville.code, today)).thenReturn(listOf(pentonvilleActivity))
-    whenever(activityRepo.getAllForPrisonAndDate(moorland.code, today)).thenReturn(listOf(moorlandActivity))
-
-    service.allocations(AllocationOperation.ENDING_TODAY)
-
-    verify(waitingListService).declinePendingOrApprovedApplications(
-      pentonvilleActivity.activityId,
-      "Activity ended",
-      "Activities Management Service",
-    )
-    verify(waitingListService).declinePendingOrApprovedApplications(
-      moorlandActivity.activityId,
-      "Activity ended",
-      "Activities Management Service",
-    )
   }
 
   @Test

--- a/src/test/resources/test_data/seed-activity-id-11.sql
+++ b/src/test/resources/test_data/seed-activity-id-11.sql
@@ -2,7 +2,7 @@
 -- Test data for activity offender deallocation for an activity ending today.  Note one allocation is already ended, 3 are not.  This is to ensure it does not try end it again.
 --
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date -1, current_date, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 2, current_date - 1, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
@@ -11,19 +11,19 @@ insert into activity_minimum_education_level(activity_minimum_education_level_id
 values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date)
-values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date - 1, current_date);
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date - 2, current_date - 1);
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (1, 1, 'A11111A', 10001, 1, current_date - 1, null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (1, 1, 'A11111A', 10001, 1, current_date - 2, null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (2, 1, 'A22222A', 10002, 2, current_date - 1, current_date, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (2, 1, 'A22222A', 10002, 2, current_date - 2, current_date - 1, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (3, 1, 'A33333A', 10003, 2, current_date, current_date + 1, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (3, 1, 'A33333A', 10003, 2, current_date - 1, current_date, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (4, 1, 'A33333A', 10004, 2, current_date - 1, current_date - 1, '2022-10-10 09:00:00', 'MRS BLOGS', current_timestamp - 1, 'Activities Management Service', 'ENDED', null, null, null, 'ENDED');
+values (4, 1, 'A33333A', 10004, 2, current_date - 2, current_date - 2, '2022-10-10 09:00:00', 'MRS BLOGS', current_timestamp - 1, 'Activities Management Service', 'ENDED', null, null, null, 'ENDED');
 
 insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
 values (1, 'PVI', 'A11111A', 111111, '2023-06-23', 1, 1, 'Fred Bloggs', 'PENDING', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);

--- a/src/test/resources/test_data/seed-activity-id-12.sql
+++ b/src/test/resources/test_data/seed-activity-id-12.sql
@@ -2,7 +2,7 @@
 -- Test data for activity offender deallocation for an activity with no end date. Only one of the 3 allocations should be deallocated
 --
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date -1, null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 1, null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
@@ -17,7 +17,7 @@ insert into allocation(allocation_id, activity_schedule_id, prisoner_number, boo
 values (1, 1, 'A11111A', 10001, 1, current_date - 1, null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (2, 1, 'A22222A', 10002, 2, current_date - 1, current_date, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (2, 1, 'A22222A', 10002, 2, current_date - 2, current_date - 1, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (3, 1, 'A33333A', 10003, 2, '2022-10-10', current_date + 1, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');


### PR DESCRIPTION
This reverts this [revert](https://github.com/ministryofjustice/hmpps-activities-management-api/pull/767) with the addition of a small change to the time restrictions for deallocation of offenders 