### PR TITLE
SAA-1528 new endpoint to surface prisoner data for subject access requests.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/SarAllocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/SarAllocation.kt
@@ -19,4 +19,5 @@ data class SarAllocation(
   val endDate: LocalDate?,
   val activityId: Long,
   val activitySummary: String,
+  val payBand: String?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/SarAllocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/SarAllocation.kt
@@ -1,0 +1,22 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import org.hibernate.annotations.Immutable
+import java.time.LocalDate
+
+@Entity
+@Immutable
+@Table(name = "v_sar_allocation")
+data class SarAllocation(
+  @Id
+  val allocationId: Long,
+  val prisonCode: String,
+  val prisonerNumber: String,
+  val prisonerStatus: String,
+  val startDate: LocalDate,
+  val endDate: LocalDate?,
+  val activityId: Long,
+  val activitySummary: String,
+)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestContent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestContent.kt
@@ -1,3 +1,57 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
 
-data class SubjectAccessRequestContent(val content: String)
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.SarAllocation as EntitySarAllocation
+
+data class SubjectAccessRequestContent(
+  @Schema(description = "The prisoner number (Nomis ID)", example = "A1234AA")
+  val prisonerNumber: String,
+
+  @Schema(description = "The from date for the request", example = "2022-01-01")
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val fromDate: LocalDate,
+
+  @Schema(description = "The to date for the request", example = "2024-01-01")
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val toDate: LocalDate,
+
+  @Schema(description = "All of the allocations for the prisoner for the period")
+  val allocations: List<SarAllocation>,
+)
+
+data class SarAllocation(
+  @Schema(description = "The internally-generated ID for this allocation", example = "123456")
+  val allocationId: Long,
+
+  @Schema(description = "The prison code where this activity takes place", example = "PVI")
+  val prisonCode: String,
+
+  @Schema(description = "The status of the allocation", example = "ACTIVE")
+  val prisonerStatus: String,
+
+  @Schema(description = "The start date of the allocation", example = "2022-01-01")
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val startDate: LocalDate,
+
+  @Schema(description = "The end date of the allocation, can be null", example = "2024-01-01")
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val endDate: LocalDate?,
+
+  @Schema(description = "The internally-generated ID for this activity", example = "123456")
+  val activityId: Long,
+
+  @Schema(description = "A brief summary description of this activity", example = "Maths level 1")
+  val activitySummary: String,
+) {
+  constructor(allocation: EntitySarAllocation) : this(
+    allocation.allocationId,
+    allocation.prisonCode,
+    allocation.prisonerStatus,
+    allocation.startDate,
+    allocation.endDate,
+    allocation.activityId,
+    allocation.activitySummary,
+  )
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestContent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestContent.kt
@@ -44,6 +44,9 @@ data class SarAllocation(
 
   @Schema(description = "A brief summary description of this activity", example = "Maths level 1")
   val activitySummary: String,
+
+  @Schema(description = "The pay band for the allocation, can be null e.g. unpaid activity", example = "Pay band 1 (lowest)")
+  val payBand: String?,
 ) {
   constructor(allocation: EntitySarAllocation) : this(
     allocation.allocationId,
@@ -53,5 +56,6 @@ data class SarAllocation(
     allocation.endDate,
     allocation.activityId,
     allocation.activitySummary,
+    allocation.payBand,
   )
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestContent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestContent.kt
@@ -1,0 +1,3 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+data class SubjectAccessRequestContent(val content: String)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/SarRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/SarRepository.kt
@@ -1,0 +1,28 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
+
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Component
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.SarAllocation
+import java.time.LocalDate
+
+@Repository
+interface SarAllocationRepository : ReadOnlyRepository<SarAllocation, Long> {
+  @Query(
+    """
+    SELECT sa FROM SarAllocation sa
+     WHERE sa.prisonerNumber = :prisonerNumber
+       AND sa.startDate >= :startDate
+       AND (sa.endDate is null or sa.endDate <= :endDate)
+    """,
+  )
+  fun findBy(@Param("prisonerNumber") prisonerNumber: String, @Param("startDate") startDate: LocalDate, @Param("endDate") endDate: LocalDate): List<SarAllocation>
+}
+
+@Component
+class SarRepository(
+  private val allocation: SarAllocationRepository,
+) {
+  fun findAllocationsBy(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate) = allocation.findBy(prisonerNumber, fromDate, toDate)
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/SarRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/SarRepository.kt
@@ -13,11 +13,10 @@ interface SarAllocationRepository : ReadOnlyRepository<SarAllocation, Long> {
     """
     SELECT sa FROM SarAllocation sa
      WHERE sa.prisonerNumber = :prisonerNumber
-       AND sa.startDate >= :startDate
-       AND (sa.endDate is null or sa.endDate <= :endDate)
+       AND sa.startDate >= :fromDate AND sa.startDate <= :toDate
     """,
   )
-  fun findBy(@Param("prisonerNumber") prisonerNumber: String, @Param("startDate") startDate: LocalDate, @Param("endDate") endDate: LocalDate): List<SarAllocation>
+  fun findBy(@Param("prisonerNumber") prisonerNumber: String, @Param("fromDate") fromDat: LocalDate, @Param("toDate") toDate: LocalDate): List<SarAllocation>
 }
 
 @Component

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/Roles.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/Roles.kt
@@ -3,3 +3,9 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 const val ROLE_ACTIVITY_ADMIN = "ROLE_ACTIVITY_ADMIN"
 const val ROLE_PRISON = "ROLE_PRISON"
 const val ROLE_ACTIVITY_HUB = "ROLE_ACTIVITY_HUB"
+
+object Role {
+  // TODO move other roles above into this object.  Avoiding for now as will impact many files ...
+
+  const val SUBJECT_ACCESS_REQUEST = "ROLE_SAR_DATA_ACCESS"
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/SubjectAccessRequestController.kt
@@ -100,8 +100,8 @@ class SubjectAccessRequestController(private val service: SubjectAccessRequestSe
         .body(
           ErrorResponse(
             status = HttpStatus.NO_CONTENT,
-            userMessage = "No content found for the prisoner number.",
-            developerMessage = "No content found for the prisoner number.",
+            userMessage = "Request successfully processed - no content found",
+            developerMessage = "Request successfully processed - no content found",
           ),
         )
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/SubjectAccessRequestController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/SubjectAccessRequestController.kt
@@ -1,0 +1,108 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
+
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.Content
+import io.swagger.v3.oas.annotations.media.Schema
+import io.swagger.v3.oas.annotations.responses.ApiResponse
+import io.swagger.v3.oas.annotations.responses.ApiResponses
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestContent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.SubjectAccessRequestService
+import java.time.LocalDate
+
+/**
+ * Prisoners have the right to access and receive a copy of their personal data and other supplementary information.
+ *
+ * This is commonly referred to as a subject access request or ‘SAR’.
+ */
+@RestController
+@Tag(name = "Subject Access Request")
+@PreAuthorize(" hasRole('SAR_DATA_ACCESS')")
+@RequestMapping("/subject-access-request", produces = [MediaType.APPLICATION_JSON_VALUE])
+class SubjectAccessRequestController(private val service: SubjectAccessRequestService) {
+
+  @GetMapping
+  @Operation(
+    summary = "Provides content for a prisoner to satisfy the needs of a subject access request on their behalf",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Request successfully processed - content found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = SubjectAccessRequestContent::class))],
+      ),
+      ApiResponse(
+        responseCode = "204",
+        description = "Request successfully processed - no content found",
+      ),
+      ApiResponse(
+        responseCode = "209",
+        description = "Subject Identifier is not recognised by this service",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "The client does not have authorisation to make this request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "500",
+        description = "Unexpected error occurred",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  fun getSarContentByReference(
+    @RequestParam(name = "prn", required = false)
+    @Parameter(description = "NOMIS Prison Reference Number")
+    prn: String?,
+    @RequestParam(name = "crn", required = false)
+    @Parameter(description = "nDelius Case Reference Number")
+    crn: String?,
+    @RequestParam(value = "fromDate", required = false)
+    @Parameter(description = "Optional parameter denoting minimum date of event occurrence which should be returned in the response")
+    fromDate: LocalDate?,
+    @RequestParam(value = "toDate", required = false)
+    @Parameter(description = "Optional parameter denoting maximum date of event occurrence which should be returned in the response")
+    toDate: LocalDate?,
+  ): ResponseEntity<Any> {
+    if (crn != null) {
+      return ResponseEntity.status(209).body(
+        ErrorResponse(
+          status = 209,
+          userMessage = "Search by case reference number is not supported.",
+          developerMessage = "Search by case reference number is not supported.",
+        ),
+      )
+    }
+
+    return prn
+      ?.takeIf(String::isNotBlank)
+      ?.let { service.getContentFor(prn, fromDate, toDate) }
+      ?.let { content -> ResponseEntity.ok(content) }
+      ?: ResponseEntity.status(HttpStatus.NO_CONTENT)
+        .body(
+          ErrorResponse(
+            status = HttpStatus.NO_CONTENT,
+            userMessage = "No content found for the prisoner number.",
+            developerMessage = "No content found for the prisoner number.",
+          ),
+        )
+  }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
@@ -8,6 +8,13 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.SarR
 import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SarAllocation as ModelSarAllocation
 
+/**
+ * Prisoners have the right to access and receive a copy of their personal data and other supplementary information.
+ *
+ * This is commonly referred to as a subject access request or ‘SAR’.
+ *
+ * The purpose of this service is to surface all relevant prisoner specific information for a subject access request.
+ */
 @Service
 class SubjectAccessRequestService(private val repository: SarRepository) {
   companion object {
@@ -15,16 +22,20 @@ class SubjectAccessRequestService(private val repository: SarRepository) {
   }
 
   fun getContentFor(prisonerNumber: String, fromDate: LocalDate?, toDate: LocalDate?): SubjectAccessRequestContent? {
+    log.info("SAR: processing subject access request for prisoner $prisonerNumber")
+
     val from = fromDate ?: LocalDate.now()
     val to = toDate ?: LocalDate.now()
 
-    log.info("before")
-    val allocations = repository.findAllocationsBy(prisonerNumber, from, to).also { log.info(it.joinToString(",")) }
-    log.info("after")
+    val allocations = repository.findAllocationsBy(prisonerNumber, from, to)
+
+    // TODO we also need to surface prisoner attendance, waiting list and appointment data here.
 
     return if (allocations.isEmpty()) {
+      log.info("SAR: no data found for subject access request for prisoner $prisonerNumber for dates $from to date $to")
       null
     } else {
+      log.info("SAR: data found for subject access request for prisoner $prisonerNumber for dates $from to date $to")
       SubjectAccessRequestContent(
         prisonerNumber = prisonerNumber,
         fromDate = from,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
@@ -1,10 +1,36 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestContent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.SarRepository
 import java.time.LocalDate
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SarAllocation as ModelSarAllocation
 
 @Service
-class SubjectAccessRequestService {
-  fun getContentFor(prisonerNumber: String, fromDate: LocalDate?, toDate: LocalDate?): SubjectAccessRequestContent? = TODO("SAA-1528 - work in progress")
+class SubjectAccessRequestService(private val repository: SarRepository) {
+  companion object {
+    private val log: Logger = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getContentFor(prisonerNumber: String, fromDate: LocalDate?, toDate: LocalDate?): SubjectAccessRequestContent? {
+    val from = fromDate ?: LocalDate.now()
+    val to = toDate ?: LocalDate.now()
+
+    log.info("before")
+    val allocations = repository.findAllocationsBy(prisonerNumber, from, to).also { log.info(it.joinToString(",")) }
+    log.info("after")
+
+    return if (allocations.isEmpty()) {
+      null
+    } else {
+      SubjectAccessRequestContent(
+        prisonerNumber = prisonerNumber,
+        fromDate = from,
+        toDate = to,
+        allocations = allocations.map(::ModelSarAllocation),
+      )
+    }
+  }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
@@ -1,0 +1,10 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import org.springframework.stereotype.Service
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestContent
+import java.time.LocalDate
+
+@Service
+class SubjectAccessRequestService {
+  fun getContentFor(prisonerNumber: String, fromDate: LocalDate?, toDate: LocalDate?): SubjectAccessRequestContent? = TODO("SAA-1528 - work in progress")
+}

--- a/src/main/resources/migrations/common/V2024.02.07__create_subject_access_request_allocations_view.sql
+++ b/src/main/resources/migrations/common/V2024.02.07__create_subject_access_request_allocations_view.sql
@@ -1,0 +1,18 @@
+-- =================================================================================================
+-- Creates the allocations view necessary to support subject access requests on behalf of a prisoner
+-- =================================================================================================
+
+CREATE OR REPLACE VIEW v_sar_allocation AS
+SELECT act.prison_code AS prison_code,
+       allo.allocation_id AS allocation_id,
+       allo.prisoner_number AS prisoner_number,
+       allo.prisoner_status AS prisoner_status,
+       allo.start_date AS start_date,
+       allo.end_date AS end_date,
+       act.activity_id AS activity_id,
+       act.summary AS activity_summary,
+       ppb.pay_band_description AS pay_band
+  FROM allocation allo
+  JOIN activity_schedule act_sch ON act_sch.activity_schedule_id = allo.activity_schedule_id
+  JOIN activity act ON act.activity_id = act_sch.activity_id
+  LEFT OUTER JOIN prison_pay_band ppb ON ppb.prison_pay_band_id = allo.prison_pay_band_id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
@@ -312,5 +312,5 @@ class MigrateAppointmentIntegrationTest : IntegrationTestBase() {
       .expectStatus().isOk
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectBody(Appointment::class.java)
-      .returnResult().responseBody
+      .returnResult().responseBody!!
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/SubjectAccessRequestIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/SubjectAccessRequestIntegrationTest.kt
@@ -1,0 +1,73 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.MediaType
+import org.springframework.test.context.jdbc.Sql
+import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.PENTONVILLE_PRISON_CODE
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.containsExactly
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.containsExactlyInAnyOrder
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SarAllocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestContent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.Role
+import java.time.LocalDate
+
+class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
+
+  @Sql("classpath:test_data/seed-subject-access-request.sql")
+  @Test
+  fun `should return single allocation for subject access request`() {
+    val response = webTestClient.getSarContent("111111", LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 1))
+
+    response.allocations containsExactly listOf(
+      SarAllocation(
+        allocationId = 1,
+        prisonCode = PENTONVILLE_PRISON_CODE,
+        prisonerStatus = "ENDED",
+        startDate = LocalDate.of(2020, 1, 1),
+        endDate = LocalDate.of(2020, 12, 1),
+        activityId = 1,
+        activitySummary = "Maths Level 1",
+      ),
+    )
+  }
+
+  @Sql("classpath:test_data/seed-subject-access-request.sql")
+  @Test
+  fun `should return two allocations for subject access request`() {
+    val response = webTestClient.getSarContent("111111", LocalDate.of(2020, 1, 1), TimeSource.today())
+
+    response.allocations containsExactlyInAnyOrder listOf(
+      SarAllocation(
+        allocationId = 1,
+        prisonCode = PENTONVILLE_PRISON_CODE,
+        prisonerStatus = "ENDED",
+        startDate = LocalDate.of(2020, 1, 1),
+        endDate = LocalDate.of(2020, 12, 1),
+        activityId = 1,
+        activitySummary = "Maths Level 1",
+      ),
+      SarAllocation(
+        allocationId = 2,
+        prisonCode = PENTONVILLE_PRISON_CODE,
+        prisonerStatus = "ACTIVE",
+        startDate = TimeSource.today(),
+        endDate = null,
+        activityId = 1,
+        activitySummary = "Maths Level 1",
+      ),
+    )
+  }
+
+  private fun WebTestClient.getSarContent(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate) =
+    get()
+      .uri("/subject-access-request?prn=$prisonerNumber&fromDate=$fromDate&toDate=$toDate")
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisation(roles = listOf(Role.SUBJECT_ACCESS_REQUEST)))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBody(SubjectAccessRequestContent::class.java)
+      .returnResult().responseBody!!
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/SubjectAccessRequestIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/SubjectAccessRequestIntegrationTest.kt
@@ -29,6 +29,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
         endDate = LocalDate.of(2020, 12, 1),
         activityId = 1,
         activitySummary = "Maths Level 1",
+        payBand = "Pay band 1 (lowest)",
       ),
     )
   }
@@ -47,6 +48,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
         endDate = LocalDate.of(2020, 12, 1),
         activityId = 1,
         activitySummary = "Maths Level 1",
+        payBand = "Pay band 1 (lowest)",
       ),
       SarAllocation(
         allocationId = 2,
@@ -56,6 +58,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
         endDate = null,
         activityId = 1,
         activitySummary = "Maths Level 1",
+        payBand = "Pay band 1 (lowest)",
       ),
     )
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/SubjectAccessRequestControllerTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -24,11 +25,13 @@ class SubjectAccessRequestControllerTest : ControllerTestBase<SubjectAccessReque
   @MockBean
   private lateinit var service: SubjectAccessRequestService
 
+  private val content: SubjectAccessRequestContent = mock()
+
   override fun controller() = SubjectAccessRequestController(service)
 
   @Test
   fun `should return 200 response when prisoner found and no dates provided`() {
-    whenever(service.getContentFor("123456", null, null)) doReturn SubjectAccessRequestContent("SAR content")
+    whenever(service.getContentFor("123456", null, null)) doReturn content
 
     mockMvcWithSecurity.get("/subject-access-request?prn=123456")
       .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
@@ -39,7 +42,7 @@ class SubjectAccessRequestControllerTest : ControllerTestBase<SubjectAccessReque
 
   @Test
   fun `should return 200 response when prisoner found and from date provided`() {
-    whenever(service.getContentFor("123456", TimeSource.today(), null)) doReturn SubjectAccessRequestContent("SAR content")
+    whenever(service.getContentFor("123456", TimeSource.today(), null)) doReturn content
 
     mockMvcWithSecurity.get("/subject-access-request?prn=123456&fromDate=${TimeSource.today()}")
       .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
@@ -50,7 +53,7 @@ class SubjectAccessRequestControllerTest : ControllerTestBase<SubjectAccessReque
 
   @Test
   fun `should return 200 response when prisoner found and to date provided`() {
-    whenever(service.getContentFor("123456", null, TimeSource.today())) doReturn SubjectAccessRequestContent("SAR content")
+    whenever(service.getContentFor("123456", null, TimeSource.today())) doReturn content
 
     mockMvcWithSecurity.get("/subject-access-request?prn=123456&toDate=${TimeSource.today()}")
       .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/SubjectAccessRequestControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/SubjectAccessRequestControllerTest.kt
@@ -1,0 +1,117 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.http.MediaType
+import org.springframework.security.test.context.support.WithAnonymousUser
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.ContextConfiguration
+import org.springframework.test.web.servlet.get
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestContent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.SubjectAccessRequestService
+
+@WebMvcTest(controllers = [SubjectAccessRequestController::class])
+@ContextConfiguration(classes = [SubjectAccessRequestController::class])
+@WithMockUser(roles = ["SAR_DATA_ACCESS"])
+class SubjectAccessRequestControllerTest : ControllerTestBase<SubjectAccessRequestController>() {
+
+  @MockBean
+  private lateinit var service: SubjectAccessRequestService
+
+  override fun controller() = SubjectAccessRequestController(service)
+
+  @Test
+  fun `should return 200 response when prisoner found and no dates provided`() {
+    whenever(service.getContentFor("123456", null, null)) doReturn SubjectAccessRequestContent("SAR content")
+
+    mockMvcWithSecurity.get("/subject-access-request?prn=123456")
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isOk() } }
+
+    verify(service).getContentFor("123456", null, null)
+  }
+
+  @Test
+  fun `should return 200 response when prisoner found and from date provided`() {
+    whenever(service.getContentFor("123456", TimeSource.today(), null)) doReturn SubjectAccessRequestContent("SAR content")
+
+    mockMvcWithSecurity.get("/subject-access-request?prn=123456&fromDate=${TimeSource.today()}")
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isOk() } }
+
+    verify(service).getContentFor("123456", TimeSource.today(), null)
+  }
+
+  @Test
+  fun `should return 200 response when prisoner found and to date provided`() {
+    whenever(service.getContentFor("123456", null, TimeSource.today())) doReturn SubjectAccessRequestContent("SAR content")
+
+    mockMvcWithSecurity.get("/subject-access-request?prn=123456&toDate=${TimeSource.today()}")
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isOk() } }
+
+    verify(service).getContentFor("123456", null, TimeSource.today())
+  }
+
+  @Test
+  fun `should return 204 response when prisoner not found`() {
+    whenever(service.getContentFor("UNKNOWN", null, null)) doReturn null
+
+    mockMvcWithSecurity.get("/subject-access-request?prn=UNKNOWN")
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isNoContent() } }
+
+    verify(service).getContentFor("UNKNOWN", null, null)
+  }
+
+  @Test
+  fun `should return 204 response when prisoner number empty`() {
+    mockMvcWithSecurity.get("/subject-access-request?prn= ")
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isNoContent() } }
+
+    verifyNoInteractions(service)
+  }
+
+  @Test
+  fun `should return 204 response when prisoner number null`() {
+    mockMvcWithSecurity.get("/subject-access-request")
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isNoContent() } }
+
+    verifyNoInteractions(service)
+  }
+
+  @Test
+  fun `should return 209 response for unsupported search type`() {
+    mockMvcWithSecurity.get("/subject-access-request?crn=123456")
+      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+      .andExpect { status { isEqualTo(209) } }
+
+    verifyNoInteractions(service)
+  }
+
+  @Test
+  @WithAnonymousUser
+  fun `should return 401 response for unauthorised`() {
+    mockMvcWithSecurity.get("/subject-access-request?prn=123456")
+      .andExpect { status { isUnauthorized() } }
+
+    verifyNoInteractions(service)
+  }
+
+  @Test
+  @WithMockUser(roles = ["PRISON"])
+  fun `should return 403 response for missing SAR_DATA_ACCESS role`() {
+    mockMvcWithSecurity.get("/subject-access-request?prn=123456")
+      .andExpect { status { isForbidden() } }
+
+    verifyNoInteractions(service)
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
@@ -8,8 +8,6 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.junit.jupiter.api.extension.ExtendWith
-import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
@@ -44,7 +42,6 @@ import java.time.LocalDateTime
 import java.time.LocalTime
 import java.util.Optional
 
-@ExtendWith(MockitoExtension::class)
 class ScheduledInstanceServiceTest {
   private val repository: ScheduledInstanceRepository = mock()
   private val attendanceSummaryRepository: ScheduledInstanceAttendanceSummaryRepository = mock()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
@@ -29,6 +29,7 @@ class SubjectAccessRequestServiceTest {
     endDate = null,
     activityId = 2,
     activitySummary = "Activity Summary",
+    payBand = "Pay band 1",
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
@@ -1,0 +1,56 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.SarAllocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestContent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.SarRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SarAllocation as ModelSarAllocation
+
+class SubjectAccessRequestServiceTest {
+
+  private val repository: SarRepository = mock()
+
+  private val service = SubjectAccessRequestService(repository)
+
+  private val sarAllocation = SarAllocation(
+    allocationId = 1,
+    prisonerNumber = "12345",
+    prisonCode = MOORLAND_PRISON_CODE,
+    prisonerStatus = PrisonerStatus.ACTIVE.name,
+    startDate = TimeSource.yesterday(),
+    endDate = null,
+    activityId = 2,
+    activitySummary = "Activity Summary",
+  )
+
+  @Test
+  fun `should return null when no content found`() {
+    whenever(repository.findAllocationsBy("12345", TimeSource.today(), TimeSource.today())) doReturn emptyList()
+
+    service.getContentFor("12345", null, null) isEqualTo null
+
+    verify(repository).findAllocationsBy("12345", TimeSource.today(), TimeSource.today())
+  }
+
+  @Test
+  fun `should return content when allocations found`() {
+    whenever(repository.findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn listOf(sarAllocation)
+
+    service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
+      prisonerNumber = sarAllocation.prisonerNumber,
+      fromDate = TimeSource.yesterday(),
+      toDate = TimeSource.tomorrow(),
+      allocations = listOf(sarAllocation).map(::ModelSarAllocation),
+    )
+
+    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
+  }
+}

--- a/src/test/resources/test_data/seed-subject-access-request.sql
+++ b/src/test/resources/test_data/seed-subject-access-request.sql
@@ -1,0 +1,23 @@
+--
+-- Test data for activity pending allocation activation.
+--
+INSERT INTO prison_regime (prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
+VALUES('PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths Level 1', 'Maths Level 1', '2020-01-01', null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
+
+insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
+values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2020-01-01', null);
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (1, 1, '111111', 10001, 1, '2020-01-01', '2020-12-01', '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ENDED');
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (2, 1, '111111', 10001, 1, current_date, null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');


### PR DESCRIPTION
The is the first attempt and introducing an endpoint for subject access requests in the service.

The first cut only provides allocations data. We still need attendances, waiting lists and appointments to be included.

This does however provide the bulk of the framework needed to add in the other required data.

The use of SQL views is intentional to avoid potential costly JPA queries.  It also helps keep the SARs code completely separate.

Note if you want to run/test this locally you will need the appropriate SAR role in your personal dev client credentials (if you have them).  The activities client does not and should not have this role.