### PR TITLE
SAA-1536 deprecated heavy hitting endpoint with the plan to remove when given all clear.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
@@ -43,6 +43,7 @@ class ActivityController(
   @Operation(
     summary = "Get an activity by its id",
     description = "Returns a single activity and its details by its unique identifier.",
+    deprecated = true,
   )
   @ApiResponses(
     value = [


### PR DESCRIPTION
This flags the GET activities/{ID} as deprecated with the plan to remove it in the near future once we are happy it is no longer used.

![image](https://github.com/ministryofjustice/hmpps-activities-management-api/assets/60104344/76e9c01a-3ab9-48aa-a030-3fdf36c860bf)
