### PR TITLE
SAA-1536 remove unused deprecated endpoint GET /activities/{ID}, this is no longer used.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExt.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExt.kt
@@ -13,3 +13,5 @@ fun LocalDate.toIsoDate(): String = this.format(DateTimeFormatter.ISO_DATE)
 
 fun Int.daysAgo(): LocalDate = require(this > 0) { "Days ago must be positive" }.let { LocalDate.now().minusDays(this.toLong()) }
 fun Int.weeksAgo(): LocalDate = require(this > 0) { "Weeks ago must be positive" }.let { LocalDate.now().minusWeeks(this.toLong()) }
+
+fun Int.monthsAgo(): LocalDate = require(this > 0) { "Months ago must be positive" }.let { LocalDate.now().minusMonths(this.toLong()) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
@@ -37,63 +37,6 @@ import java.time.LocalDate
 class ActivityController(
   private val activityService: ActivityService,
 ) {
-
-  @GetMapping(value = ["/{activityId}"])
-  @ResponseBody
-  @Operation(
-    summary = "Get an activity by its id",
-    description = "Returns a single activity and its details by its unique identifier.",
-    deprecated = true,
-  )
-  @ApiResponses(
-    value = [
-      ApiResponse(
-        responseCode = "200",
-        description = "Activity found",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = Activity::class),
-          ),
-        ],
-      ),
-      ApiResponse(
-        responseCode = "401",
-        description = "Unauthorised, requires a valid Oauth2 token",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ErrorResponse::class),
-          ),
-        ],
-      ),
-      ApiResponse(
-        responseCode = "403",
-        description = "Forbidden, requires an appropriate role",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ErrorResponse::class),
-          ),
-        ],
-      ),
-      ApiResponse(
-        responseCode = "404",
-        description = "The activity for this ID was not found.",
-        content = [
-          Content(
-            mediaType = "application/json",
-            schema = Schema(implementation = ErrorResponse::class),
-          ),
-        ],
-      ),
-    ],
-  )
-  @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN', 'NOMIS_ACTIVITIES')")
-  @CaseloadHeader
-  fun getActivityById(@PathVariable("activityId") activityId: Long): Activity =
-    activityService.getActivityById(activityId)
-
   @GetMapping(value = ["/{activityId}/filtered"])
   @ResponseBody
   @Operation(
@@ -145,6 +88,7 @@ class ActivityController(
     ],
   )
   @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN', 'NOMIS_ACTIVITIES')")
+  @CaseloadHeader
   fun getActivityByIdWithFilters(
     @PathVariable("activityId") activityId: Long,
     @RequestParam(value = "earliestSessionDate", required = false)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -11,6 +11,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonap
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.monthsAgo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityState
@@ -79,18 +80,13 @@ class ActivityService(
     val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  fun getActivityByIdWithFilters(activityId: Long, earliestSessionDate: LocalDate?): ModelActivity {
-    // TODO: Caseload check
-    val earliestSession = earliestSessionDate ?: LocalDate.now().minusMonths(1)
+  fun getActivityByIdWithFilters(activityId: Long, earliestSessionDate: LocalDate? = null): ModelActivity {
+    val earliestSession = earliestSessionDate ?: 1.monthsAgo()
     val activity = activityRepository.getActivityByIdWithFilters(activityId, earliestSession)
-      ?: throw (EntityNotFoundException("Activity $activityId not found"))
-    return transform(activity)
-  }
+      ?: throw EntityNotFoundException("Activity $activityId not found")
 
-  fun getActivityById(activityId: Long): ModelActivity {
-    val activity = activityRepository.findById(activityId)
-      .orElseThrow { EntityNotFoundException("Activity $activityId not found") }
     checkCaseloadAccess(activity.prisonCode)
+
     return transform(activity)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExtTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/common/LocalDateExtTest.kt
@@ -36,4 +36,19 @@ class LocalDateExtTest {
         .hasMessage("Weeks ago must be positive")
     }
   }
+
+  @Test
+  fun `months ago`() {
+    (1..10).forEach { it.monthsAgo() isEqualTo LocalDate.now().minusMonths(it.toLong()) }
+  }
+
+  @Test
+  fun `months ago fails if not a positive number`() {
+    (0 downTo -10).forEach {
+      assertThatThrownBy {
+        (it).monthsAgo()
+      }.isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessage("Months ago must be positive")
+    }
+  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -691,7 +691,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
   @Test
   fun `attempting to get an activity from a different caseload returns a 403`() {
     webTestClient.get()
-      .uri("/activities/2")
+      .uri("/activities/2/filtered")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(isClientToken = false, roles = listOf(ROLE_PRISON)))
       .header(CASELOAD_ID, "MDI")
@@ -705,7 +705,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
   @Test
   fun `attempting to get an activity without specifying a caseload succeeds if using a client token`() {
     webTestClient.get()
-      .uri("/activities/2")
+      .uri("/activities/2/filtered")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(isClientToken = true, roles = listOf(ROLE_ACTIVITY_ADMIN)))
       .exchange()
@@ -718,7 +718,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
   @Test
   fun `attempting to get an activity without specifying a caseload succeeds if admin role present`() {
     webTestClient.get()
-      .uri("/activities/2")
+      .uri("/activities/2/filtered")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(isClientToken = true, roles = listOf(ROLE_ACTIVITY_ADMIN)))
       .exchange()
@@ -812,7 +812,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
 
   private fun WebTestClient.getActivityById(id: Long, caseLoadId: String = "PVI") =
     get()
-      .uri("/activities/$id")
+      .uri("/activities/$id/filtered")
       .accept(MediaType.APPLICATION_JSON)
       .headers(setAuthorisation(roles = listOf(ROLE_PRISON)))
       .header(CASELOAD_ID, caseLoadId)


### PR DESCRIPTION
This removes the unused deprecated endpoint `GET /activities/{ID}`.

All calls that require to get the activity by its ID should go through the filtered endpoint `GET /activities/{ID}/filtered`.

I have checked Application Insights and cannot see this endpoint used anymore.

Goes with this PR [here](https://github.com/ministryofjustice/hmpps-activities-management/pull/748).