### PR TITLE
SAA-1520 applies (missing) tier 1 to two archived Risley activities in production.

### DIFF
--- a/src/main/resources/migrations/prod/V2024.02.12__apply_missing_tiers_to_risley_activities.sql
+++ b/src/main/resources/migrations/prod/V2024.02.12__apply_missing_tiers_to_risley_activities.sql
@@ -1,0 +1,5 @@
+-- The Risley activities affected here are both archived so cannot be updated via the UI. These activities were created
+-- before the Tier work was released. Both activities are Tier 1 activities
+
+UPDATE activity SET activity_tier_id = (SELECT et.event_tier_id from event_tier et WHERE et.code = 'TIER_1')
+ WHERE prison_code = 'RSI' AND activity_tier_id is null and activity_id in (187, 189);


### PR DESCRIPTION
Whilst this could be easily be done direct this keeps a record of the change should there be any questions or issued raised. 