### PR TITLE
SAA-1528 - subject-access-request base allocation searches on allocation time for the from and to date

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/SarAllocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/SarAllocation.kt
@@ -20,4 +20,5 @@ data class SarAllocation(
   val activityId: Long,
   val activitySummary: String,
   val payBand: String?,
+  val createdDate: LocalDate,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestContent.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestContent.kt
@@ -51,6 +51,10 @@ data class SarAllocation(
 
   @Schema(description = "The pay band for the allocation, can be null e.g. unpaid activity", example = "Pay band 1 (lowest)")
   val payBand: String?,
+
+  @Schema(description = "The date the allocation entry was created", example = "2022-01-01")
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val createdDate: LocalDate,
 ) {
   constructor(allocation: EntitySarAllocation) : this(
     allocation.allocationId,
@@ -61,6 +65,7 @@ data class SarAllocation(
     allocation.activityId,
     allocation.activitySummary,
     allocation.payBand,
+    allocation.createdDate,
   )
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/SarRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/SarRepository.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
 
-import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Repository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.SarAllocation
@@ -9,12 +8,12 @@ import java.time.LocalDate
 
 @Repository
 interface SarAllocationRepository : ReadOnlyRepository<SarAllocation, Long> {
-  fun findByPrisonerNumberAndCreatedDateBetween(@Param("prisonerNumber") prisonerNumber: String, @Param("fromDate") fromDat: LocalDate, @Param("toDate") toDate: LocalDate): List<SarAllocation>
+  fun findByPrisonerNumberAndCreatedDateBetween(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate): List<SarAllocation>
 }
 
 @Repository
 interface SarWaitingListRepository : ReadOnlyRepository<SarWaitingList, Long> {
-  fun findByPrisonerNumberAndCreatedDateBetween(@Param("prisonerNumber") prisonerNumber: String, @Param("fromDate") fromDat: LocalDate, @Param("toDate") toDate: LocalDate): List<SarWaitingList>
+  fun findByPrisonerNumberAndCreatedDateBetween(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate): List<SarWaitingList>
 }
 
 @Component
@@ -22,7 +21,7 @@ class SarRepository(
   private val allocation: SarAllocationRepository,
   private val waitingList: SarWaitingListRepository,
 ) {
-  fun findAllocationsBy(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate) = allocation.findByPrisonerNumberAndCreatedDateBetween(prisonerNumber, fromDate, toDate)
+  fun findAllocationsBy(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate) = allocation.findByPrisonerNumberAndCreatedDateBetween(prisonerNumber, fromDate, toDate.plusDays(1))
 
-  fun findWaitingListsBy(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate) = waitingList.findByPrisonerNumberAndCreatedDateBetween(prisonerNumber, fromDate, toDate)
+  fun findWaitingListsBy(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate) = waitingList.findByPrisonerNumberAndCreatedDateBetween(prisonerNumber, fromDate, toDate.plusDays(1))
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/SarRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/SarRepository.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
 
-import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Component
 import org.springframework.stereotype.Repository
@@ -10,14 +9,7 @@ import java.time.LocalDate
 
 @Repository
 interface SarAllocationRepository : ReadOnlyRepository<SarAllocation, Long> {
-  @Query(
-    """
-    SELECT sa FROM SarAllocation sa
-     WHERE sa.prisonerNumber = :prisonerNumber
-       AND sa.startDate >= :fromDate AND sa.startDate <= :toDate
-    """,
-  )
-  fun findBy(@Param("prisonerNumber") prisonerNumber: String, @Param("fromDate") fromDat: LocalDate, @Param("toDate") toDate: LocalDate): List<SarAllocation>
+  fun findByPrisonerNumberAndCreatedDateBetween(@Param("prisonerNumber") prisonerNumber: String, @Param("fromDate") fromDat: LocalDate, @Param("toDate") toDate: LocalDate): List<SarAllocation>
 }
 
 @Repository
@@ -30,7 +22,7 @@ class SarRepository(
   private val allocation: SarAllocationRepository,
   private val waitingList: SarWaitingListRepository,
 ) {
-  fun findAllocationsBy(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate) = allocation.findBy(prisonerNumber, fromDate, toDate)
+  fun findAllocationsBy(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate) = allocation.findByPrisonerNumberAndCreatedDateBetween(prisonerNumber, fromDate, toDate)
 
   fun findWaitingListsBy(prisonerNumber: String, fromDate: LocalDate, toDate: LocalDate) = waitingList.findByPrisonerNumberAndCreatedDateBetween(prisonerNumber, fromDate, toDate)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
@@ -28,8 +28,8 @@ class SubjectAccessRequestService(private val repository: SarRepository) {
     val from = fromDate ?: LocalDate.now()
     val to = toDate ?: LocalDate.now()
 
-    val allocations = repository.findAllocationsBy(prisonerNumber, from, to.plusDays(1))
-    val waitingLists = repository.findWaitingListsBy(prisonerNumber, from, to.plusDays(1))
+    val allocations = repository.findAllocationsBy(prisonerNumber, from, to)
+    val waitingLists = repository.findWaitingListsBy(prisonerNumber, from, to)
 
     // TODO we also need to surface prisoner attendance, waiting list and appointment data here.
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
@@ -28,7 +28,7 @@ class SubjectAccessRequestService(private val repository: SarRepository) {
     val from = fromDate ?: LocalDate.now()
     val to = toDate ?: LocalDate.now()
 
-    val allocations = repository.findAllocationsBy(prisonerNumber, from, to)
+    val allocations = repository.findAllocationsBy(prisonerNumber, from, to.plusDays(1))
     val waitingLists = repository.findWaitingListsBy(prisonerNumber, from, to.plusDays(1))
 
     // TODO we also need to surface prisoner attendance, waiting list and appointment data here.

--- a/src/main/resources/migrations/common/V2024.02.13__add_allocation_date_subject_access_request_allocations_view.sql
+++ b/src/main/resources/migrations/common/V2024.02.13__add_allocation_date_subject_access_request_allocations_view.sql
@@ -1,0 +1,19 @@
+-- =================================================================================================
+-- Creates the allocations view necessary to support subject access requests on behalf of a prisoner
+-- =================================================================================================
+
+CREATE OR REPLACE VIEW v_sar_allocation AS
+SELECT act.prison_code AS prison_code,
+       allo.allocation_id AS allocation_id,
+       allo.prisoner_number AS prisoner_number,
+       allo.prisoner_status AS prisoner_status,
+       allo.start_date AS start_date,
+       allo.end_date AS end_date,
+       act.activity_id AS activity_id,
+       act.summary AS activity_summary,
+       ppb.pay_band_description AS pay_band,
+       allo.allocated_time AS created_date
+  FROM allocation allo
+  JOIN activity_schedule act_sch ON act_sch.activity_schedule_id = allo.activity_schedule_id
+  JOIN activity act ON act.activity_id = act_sch.activity_id
+  LEFT OUTER JOIN prison_pay_band ppb ON ppb.prison_pay_band_id = allo.prison_pay_band_id

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/SubjectAccessRequestIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/SubjectAccessRequestIntegrationTest.kt
@@ -18,7 +18,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
 
   @Sql("classpath:test_data/seed-subject-access-request.sql")
   @Test
-  fun `should return single allocation for subject access request`() {
+  fun `should return single allocation for a same day date boundary subject access request`() {
     val response = webTestClient.getSarContent("111111", LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 1))
 
     response.allocations containsExactly listOf(
@@ -26,11 +26,12 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
         allocationId = 1,
         prisonCode = PENTONVILLE_PRISON_CODE,
         prisonerStatus = "ENDED",
-        startDate = LocalDate.of(2020, 1, 1),
+        startDate = LocalDate.of(2020, 1, 2),
         endDate = LocalDate.of(2020, 12, 1),
         activityId = 1,
         activitySummary = "Maths Level 1",
         payBand = "Pay band 1 (lowest)",
+        createdDate = LocalDate.of(2020, 1, 1),
       ),
     )
   }
@@ -38,18 +39,19 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   @Sql("classpath:test_data/seed-subject-access-request.sql")
   @Test
   fun `should return two allocations for subject access request`() {
-    val response = webTestClient.getSarContent("111111", LocalDate.of(2020, 1, 1), TimeSource.today())
+    val response = webTestClient.getSarContent("111111", LocalDate.of(2020, 1, 1), LocalDate.of(2023, 1, 1))
 
     response.allocations containsExactlyInAnyOrder listOf(
       SarAllocation(
         allocationId = 1,
         prisonCode = PENTONVILLE_PRISON_CODE,
         prisonerStatus = "ENDED",
-        startDate = LocalDate.of(2020, 1, 1),
+        startDate = LocalDate.of(2020, 1, 2),
         endDate = LocalDate.of(2020, 12, 1),
         activityId = 1,
         activitySummary = "Maths Level 1",
         payBand = "Pay band 1 (lowest)",
+        createdDate = LocalDate.of(2020, 1, 1),
       ),
       SarAllocation(
         allocationId = 2,
@@ -60,6 +62,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
         activityId = 1,
         activitySummary = "Maths Level 1",
         payBand = "Pay band 1 (lowest)",
+        createdDate = LocalDate.of(2022, 10, 10),
       ),
     )
   }
@@ -150,6 +153,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
         activityId = 2,
         activitySummary = "Activity Summary WL",
         payBand = "Pay band 1 (lowest)",
+        createdDate = LocalDate.of(2022, 10, 10),
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
@@ -51,19 +51,19 @@ class SubjectAccessRequestServiceTest {
 
   @Test
   fun `should return null when no content found`() {
-    whenever(repository.findAllocationsBy("12345", TimeSource.today(), TimeSource.today().plusDays(1))) doReturn emptyList()
-    whenever(repository.findWaitingListsBy("12345", TimeSource.today(), TimeSource.today().plusDays(1))) doReturn emptyList()
+    whenever(repository.findAllocationsBy("12345", TimeSource.today(), TimeSource.today())) doReturn emptyList()
+    whenever(repository.findWaitingListsBy("12345", TimeSource.today(), TimeSource.today())) doReturn emptyList()
 
     service.getContentFor("12345", null, null) isEqualTo null
 
-    verify(repository).findAllocationsBy("12345", TimeSource.today(), TimeSource.today().plusDays(1))
-    verify(repository).findWaitingListsBy("12345", TimeSource.today(), TimeSource.today().plusDays(1))
+    verify(repository).findAllocationsBy("12345", TimeSource.today(), TimeSource.today())
+    verify(repository).findWaitingListsBy("12345", TimeSource.today(), TimeSource.today())
   }
 
   @Test
   fun `should return content when allocations found`() {
-    whenever(repository.findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn listOf(sarAllocation)
-    whenever(repository.findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn emptyList()
+    whenever(repository.findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn listOf(sarAllocation)
+    whenever(repository.findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn emptyList()
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
       prisonerNumber = sarAllocation.prisonerNumber,
@@ -73,14 +73,14 @@ class SubjectAccessRequestServiceTest {
       waitingListApplications = emptyList(),
     )
 
-    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
-    verify(repository).findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
+    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
+    verify(repository).findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
   }
 
   @Test
   fun `should return content when waiting lists found`() {
-    whenever(repository.findAllocationsBy("12345", TimeSource.today(), TimeSource.tomorrow().plusDays(1))) doReturn emptyList()
-    whenever(repository.findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn listOf(sarWaitingList)
+    whenever(repository.findAllocationsBy("12345", TimeSource.today(), TimeSource.tomorrow())) doReturn emptyList()
+    whenever(repository.findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn listOf(sarWaitingList)
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
       prisonerNumber = sarAllocation.prisonerNumber,
@@ -90,14 +90,14 @@ class SubjectAccessRequestServiceTest {
       waitingListApplications = listOf(sarWaitingList).map(::ModelSarWaitingList),
     )
 
-    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
-    verify(repository).findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
+    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
+    verify(repository).findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
   }
 
   @Test
   fun `should return content when allocation and waiting lists found`() {
-    whenever(repository.findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn listOf(sarAllocation)
-    whenever(repository.findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn listOf(sarWaitingList)
+    whenever(repository.findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn listOf(sarAllocation)
+    whenever(repository.findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn listOf(sarWaitingList)
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
       prisonerNumber = sarAllocation.prisonerNumber,
@@ -107,7 +107,7 @@ class SubjectAccessRequestServiceTest {
       waitingListApplications = listOf(sarWaitingList).map(::ModelSarWaitingList),
     )
 
-    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
-    verify(repository).findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
+    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
+    verify(repository).findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
@@ -33,6 +33,7 @@ class SubjectAccessRequestServiceTest {
     activityId = 2,
     activitySummary = "Activity Summary",
     payBand = "Pay band 1",
+    createdDate = TimeSource.yesterday(),
   )
 
   private val sarWaitingList = SarWaitingList(
@@ -50,16 +51,19 @@ class SubjectAccessRequestServiceTest {
 
   @Test
   fun `should return null when no content found`() {
-    whenever(repository.findAllocationsBy("12345", TimeSource.today(), TimeSource.today())) doReturn emptyList()
+    whenever(repository.findAllocationsBy("12345", TimeSource.today(), TimeSource.today().plusDays(1))) doReturn emptyList()
+    whenever(repository.findWaitingListsBy("12345", TimeSource.today(), TimeSource.today().plusDays(1))) doReturn emptyList()
 
     service.getContentFor("12345", null, null) isEqualTo null
 
-    verify(repository).findAllocationsBy("12345", TimeSource.today(), TimeSource.today())
+    verify(repository).findAllocationsBy("12345", TimeSource.today(), TimeSource.today().plusDays(1))
+    verify(repository).findWaitingListsBy("12345", TimeSource.today(), TimeSource.today().plusDays(1))
   }
 
   @Test
   fun `should return content when allocations found`() {
-    whenever(repository.findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn listOf(sarAllocation)
+    whenever(repository.findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn listOf(sarAllocation)
+    whenever(repository.findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn emptyList()
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
       prisonerNumber = sarAllocation.prisonerNumber,
@@ -69,12 +73,13 @@ class SubjectAccessRequestServiceTest {
       waitingListApplications = emptyList(),
     )
 
-    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
+    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
+    verify(repository).findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
   }
 
   @Test
   fun `should return content when waiting lists found`() {
-    whenever(repository.findAllocationsBy("12345", TimeSource.today(), TimeSource.tomorrow())) doReturn emptyList()
+    whenever(repository.findAllocationsBy("12345", TimeSource.today(), TimeSource.tomorrow().plusDays(1))) doReturn emptyList()
     whenever(repository.findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn listOf(sarWaitingList)
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
@@ -85,12 +90,13 @@ class SubjectAccessRequestServiceTest {
       waitingListApplications = listOf(sarWaitingList).map(::ModelSarWaitingList),
     )
 
-    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
+    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
+    verify(repository).findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
   }
 
   @Test
   fun `should return content when allocation and waiting lists found`() {
-    whenever(repository.findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn listOf(sarAllocation)
+    whenever(repository.findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn listOf(sarAllocation)
     whenever(repository.findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))) doReturn listOf(sarWaitingList)
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
@@ -101,6 +107,7 @@ class SubjectAccessRequestServiceTest {
       waitingListApplications = listOf(sarWaitingList).map(::ModelSarWaitingList),
     )
 
-    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
+    verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
+    verify(repository).findWaitingListsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow().plusDays(1))
   }
 }

--- a/src/test/resources/test_data/seed-subject-access-request.sql
+++ b/src/test/resources/test_data/seed-subject-access-request.sql
@@ -23,7 +23,7 @@ insert into activity_schedule(activity_schedule_id, activity_id, description, in
 values (2, 2, 'Maths AM', 1, 'L1', 'Location 1', 10, '2020-01-01', null);
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (1, 1, '111111', 10001, 1, '2020-01-01', '2020-12-01', '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ENDED');
+values (1, 1, '111111', 10001, 1, '2020-01-02', '2020-12-01', '2020-01-01 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ENDED');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (2, 1, '111111', 10001, 1, current_date, null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');


### PR DESCRIPTION
API endpoint GET /subject-access-request/prisoner/{prisonerNumber}

change the from and to date search for allocations to be based on the allocation creation date.