### PR TITLE
SAA-1561 removing index originally introduced to help prevent duplication submission of allocations as this is impacting deallocations.

### DIFF
--- a/src/main/resources/migrations/common/V2024.02.16__remove_unique_index_from_allocations.sql
+++ b/src/main/resources/migrations/common/V2024.02.16__remove_unique_index_from_allocations.sql
@@ -1,0 +1,6 @@
+--
+-- This index was added to prevent duplicate allocations to the same activity, however this has had a knock on effect with deallocation.
+-- We have found that an offender can be allocated to the same activity on the same date provided earlier one is already ended, however if you then try
+-- to end the later allocation a duplicate key violation is incurred.  This is causing issues the deallocate expiring allocations job.
+--
+DROP INDEX IF EXISTS idx_schedule_id_prisoner_number_start_date_prisoner_status;


### PR DESCRIPTION
This index was added to prevent duplicate allocations to the same activity, however this has had a knock on effect with deallocation

We have since found that an offender can be allocated to the same activity on the same date provided the earlier one is already ended, however if you then try to end the later allocation a duplicate key violation is incurred.

This is causing issues the deallocate expiring allocations job.
