### PR TITLE
SAA-1510: Add time window to deallocate by ending job

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ActivityScheduleRepositoryCustom.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ActivityScheduleRepositoryCustom.kt
@@ -16,8 +16,6 @@ interface ActivityScheduleRepositoryCustom {
     earliestSessionDate: LocalDate? = null,
     allocationsActiveOnDate: LocalDate? = null,
   ): ActivitySchedule?
-
-  fun getActivitySchedulesWithFilteredInstances(prisonCode: String, earliestSessionDate: LocalDate): List<ActivitySchedule>
 }
 
 class ActivityScheduleRepositoryCustomImpl : ActivityScheduleRepositoryCustom {
@@ -57,26 +55,5 @@ class ActivityScheduleRepositoryCustomImpl : ActivityScheduleRepositoryCustom {
       query.singleResult
     }.onFailure { log.error("ActivitySchedule by ID with filters ${it.message}") }
       .getOrNull()
-  }
-
-  @Override
-  override fun getActivitySchedulesWithFilteredInstances(
-    prisonCode: String,
-    earliestSessionDate: LocalDate,
-  ): List<ActivitySchedule> {
-    val session = entityManager.unwrap(Session::class.java)
-
-    val hql = "SELECT s from ActivitySchedule s where s.activity.prisonCode = :prisonCode"
-    val query: TypedQuery<ActivitySchedule> = entityManager.createQuery(hql, ActivitySchedule::class.java)
-    query.setParameter("prisonCode", prisonCode)
-
-    session
-      .enableFilter(SESSION_DATE_FILTER)
-      .setParameter("earliestSessionDate", earliestSessionDate)
-
-    return runCatching {
-      query.resultList.toList()
-    }.onFailure { log.error("ActivitySchedule by ID with filters ${it.message}") }
-      .getOrDefault(emptyList())
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -66,7 +66,7 @@ class ManageAllocationsService(
     }
 
     transactionHandler.newSpringTransaction {
-      activityScheduleRepository.getActivitySchedulesWithFilteredInstances(prisonCode, date).flatMap { schedule ->
+      activityScheduleRepository.findAllByActivityPrisonCode(prisonCode).flatMap { schedule ->
         if (schedule.endsOn(date)) {
           declineWaitingListsFor(schedule)
           schedule.deallocateActiveAllocationsNow()

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -123,6 +123,8 @@ prison:
 jobs:
   create-scheduled-instances:
     days-in-advance: ${SCHEDULE_AHEAD_DAYS}
+  deallocate-allocations-ending:
+    days-start: 3
 
 online:
   create-scheduled-instances:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJobTest.kt
@@ -25,8 +25,9 @@ class ManageAllocationsJobTest {
   private val deallocationService: ManageAllocationsService = mock()
   private val jobRepository: JobRepository = mock()
   private val safeJobRunner = spy(SafeJobRunner(jobRepository, mock<MonitoringService>()))
-  private val job = ManageAllocationsJob(rolloutPrisonRepository, deallocationService, safeJobRunner)
+  private val job = ManageAllocationsJob(rolloutPrisonRepository, deallocationService, safeJobRunner, 2)
   private val yesterday = 1.daysAgo()
+  private val twoDaysAgo = 2.daysAgo()
 
   @Test
   fun `activate allocation operation triggered`() {
@@ -42,6 +43,8 @@ class ManageAllocationsJobTest {
   fun `deallocate allocation due to end operation triggered`() {
     job.execute(withDeallocateEnding = true)
 
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, twoDaysAgo)
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, twoDaysAgo)
     verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, yesterday)
     verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, yesterday)
     verifyNoMoreInteractions(deallocationService)
@@ -64,6 +67,8 @@ class ManageAllocationsJobTest {
     job.execute(withActivate = true, withDeallocateEnding = true)
 
     verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, twoDaysAgo)
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, twoDaysAgo)
     verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, yesterday)
     verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, yesterday)
     verifyNoMoreInteractions(deallocationService)
@@ -86,6 +91,8 @@ class ManageAllocationsJobTest {
   fun `deallocate allocation due to end and deallocate allocation due to expire operations triggered`() {
     job.execute(withDeallocateEnding = true, withDeallocateExpiring = true)
 
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, twoDaysAgo)
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, twoDaysAgo)
     verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, yesterday)
     verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, yesterday)
     verify(deallocationService).allocations(AllocationOperation.EXPIRING_TODAY)
@@ -98,6 +105,8 @@ class ManageAllocationsJobTest {
   fun `activate, deallocate allocation due to end and deallocate allocation due to expire operations triggered`() {
     job.execute(withActivate = true, withDeallocateEnding = true, withDeallocateExpiring = true)
 
+    verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, twoDaysAgo)
+    verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, twoDaysAgo)
     verify(deallocationService).allocations(AllocationOperation.STARTING_TODAY)
     verify(deallocationService).endAllocationsDueToEnd(PENTONVILLE_PRISON_CODE, yesterday)
     verify(deallocationService).endAllocationsDueToEnd(MOORLAND_PRISON_CODE, yesterday)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
@@ -73,7 +73,7 @@ class ManageAllocationsServiceTest {
     val allocation = schedule.allocations().first().also { it.verifyIsActive() }
 
     whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
-    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
+    whenever(activityScheduleRepo.findAllByActivityPrisonCode(prison.code)) doReturn listOf(schedule)
 
     service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 
@@ -88,7 +88,7 @@ class ManageAllocationsServiceTest {
     val schedule = activitySchedule(activityEntity(startDate = yesterday, endDate = today))
 
     whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
-    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
+    whenever(activityScheduleRepo.findAllByActivityPrisonCode(prison.code)) doReturn listOf(schedule)
 
     service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 
@@ -107,7 +107,7 @@ class ManageAllocationsServiceTest {
     allocation.deallocateOn(today, DeallocationReason.OTHER, "by test")
 
     whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
-    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
+    whenever(activityScheduleRepo.findAllByActivityPrisonCode(prison.code)) doReturn listOf(schedule)
 
     service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 
@@ -123,7 +123,7 @@ class ManageAllocationsServiceTest {
     val allocation = schedule.allocations().first().apply { endDate = today }.also { it.verifyIsActive() }
 
     whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
-    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
+    whenever(activityScheduleRepo.findAllByActivityPrisonCode(prison.code)) doReturn listOf(schedule)
 
     service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 
@@ -140,7 +140,7 @@ class ManageAllocationsServiceTest {
     val allocation = schedule.allocations().first().also { it.verifyIsActive() }
 
     whenever(rolloutPrisonRepo.findByCode(prison.code)) doReturn prison
-    whenever(activityScheduleRepo.getActivitySchedulesWithFilteredInstances(prison.code, LocalDate.now())) doReturn listOf(schedule)
+    whenever(activityScheduleRepo.findAllByActivityPrisonCode(prison.code)) doReturn listOf(schedule)
 
     service.endAllocationsDueToEnd(prison.code, LocalDate.now())
 

--- a/src/test/resources/test_data/seed-activity-id-28.sql
+++ b/src/test/resources/test_data/seed-activity-id-28.sql
@@ -1,0 +1,26 @@
+--
+-- Test data to ensure that deallocation for an activity does ot happen if the allocation ended before the job window
+--
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 1, null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
+
+insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
+values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date - 1, null);
+
+-- Should deallocate
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (1, 1, 'A11111A', 10001, 1, current_date - 1, null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+-- Should deallocate
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (2, 1, 'A22222A', 10002, 2, current_date - 3, current_date - 2, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+-- Should not deallocate
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (3, 1, 'A33333A', 10003, 2, current_date - 4, current_date - 3, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');


### PR DESCRIPTION
- Add time window to deallocate ending job to cover that failed for previous runs within the window, e.g. 3 days.
- Remove use of session filter