### PR TITLE
SAA-1577 fixing issue whereby event was being published before being committed to DB when deallocating offenders due to end on activities.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -87,8 +87,8 @@ class ManageAllocationsService(
         } else {
           schedule.deallocateAllocationsEndingOn(date)
         }.also { allocationIds -> allocationIds.ifNotEmpty { activityScheduleRepository.saveAndFlush(schedule) } }
-      }.let(::sendAllocationsAmendedEvents)
-    }
+      }
+    }.let(::sendAllocationsAmendedEvents)
   }
 
   private fun declineWaitingListsFor(schedule: ActivitySchedule) {


### PR DESCRIPTION
This bug was introduced by me when reworking the job.

The change fixes the issue where the allocation amended event was being published before the allocation end had been committed to the DB.

This now publishes the allocation amended event after the change has been saved to the database.

Not sure how to test this other than manually looking at commits in log output at the moment, it not easy to cover in a unit test.