### PR TITLE
SAA-1578 adds the missing root node 'content' to the SAR response object.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/SubjectAccessRequestData.kt
@@ -8,7 +8,9 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.SarAlloc
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.SarAppointment as EntitySarAppointment
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.SarWaitingList as EntitySarWaitingList
 
-data class SubjectAccessRequestContent(
+data class SubjectAccessRequestContent(val content: SubjectAccessRequestData)
+
+data class SubjectAccessRequestData(
   @Schema(description = "The prisoner number (Nomis ID)", example = "A1234AA")
   val prisonerNumber: String,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestService.kt
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SarAttendanceSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestContent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestData
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.SarRepository
 import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SarAllocation as ModelSarAllocation
@@ -46,13 +47,15 @@ class SubjectAccessRequestService(private val repository: SarRepository) {
         allAttendance.groupingBy { it.attendanceReasonCode }.eachCount().mapNotNull { it.key?.let { it1 -> ModelSarAttendanceSummary(it1, it.value) } }
 
       SubjectAccessRequestContent(
-        prisonerNumber = prisonerNumber,
-        fromDate = from,
-        toDate = to,
-        allocations = allocations.map(::ModelSarAllocation),
-        attendanceSummary = attendanceSummary,
-        waitingListApplications = waitingLists.map(::ModelSarWaitingList),
-        appointments = appointments.map(::ModelSarAppointment),
+        SubjectAccessRequestData(
+          prisonerNumber = prisonerNumber,
+          fromDate = from,
+          toDate = to,
+          allocations = allocations.map(::ModelSarAllocation),
+          attendanceSummary = attendanceSummary,
+          waitingListApplications = waitingLists.map(::ModelSarWaitingList),
+          appointments = appointments.map(::ModelSarAppointment),
+        ),
       )
     }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/SubjectAccessRequestIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/SubjectAccessRequestIntegrationTest.kt
@@ -24,7 +24,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return single allocation for a same day date boundary subject access request`() {
     val response = webTestClient.getSarContent("111111", LocalDate.of(2020, 1, 1), LocalDate.of(2020, 1, 1))
 
-    response.allocations containsExactly listOf(
+    response.content.allocations containsExactly listOf(
       SarAllocation(
         allocationId = 1,
         prisonCode = PENTONVILLE_PRISON_CODE,
@@ -44,7 +44,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return two allocations for subject access request`() {
     val response = webTestClient.getSarContent("111111", LocalDate.of(2020, 1, 1), LocalDate.of(2023, 1, 1))
 
-    response.allocations containsExactlyInAnyOrder listOf(
+    response.content.allocations containsExactlyInAnyOrder listOf(
       SarAllocation(
         allocationId = 1,
         prisonCode = PENTONVILLE_PRISON_CODE,
@@ -75,7 +75,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return single waiting list application with a 2 day boundary for a subject access request`() {
     val response = webTestClient.getSarContent("111222", LocalDate.of(2022, 10, 9), LocalDate.of(2022, 10, 11))
 
-    response.waitingListApplications containsExactly listOf(
+    response.content.waitingListApplications containsExactly listOf(
       SarWaitingList(
         waitingListId = 2,
         prisonCode = PENTONVILLE_PRISON_CODE,
@@ -95,7 +95,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return single waiting list application for a same day date boundary for a subject access request`() {
     val response = webTestClient.getSarContent("111222", LocalDate.of(2022, 10, 10), LocalDate.of(2022, 10, 10))
 
-    response.waitingListApplications containsExactly listOf(
+    response.content.waitingListApplications containsExactly listOf(
       SarWaitingList(
         waitingListId = 2,
         prisonCode = PENTONVILLE_PRISON_CODE,
@@ -115,7 +115,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return two waiting list applications for a subject access request`() {
     val response = webTestClient.getSarContent("111222", LocalDate.of(2022, 10, 10), LocalDate.of(2022, 10, 12))
 
-    response.waitingListApplications containsExactlyInAnyOrder listOf(
+    response.content.waitingListApplications containsExactlyInAnyOrder listOf(
       SarWaitingList(
         waitingListId = 2,
         prisonCode = PENTONVILLE_PRISON_CODE,
@@ -146,7 +146,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return 3 appointments for a subject access request (Attended, Not attended and Unknown Attendance)`() {
     val response = webTestClient.getSarContent("111222", LocalDate.of(2022, 10, 8), LocalDate.of(2024, 10, 10))
 
-    response.appointments containsExactlyInAnyOrder listOf(
+    response.content.appointments containsExactlyInAnyOrder listOf(
       SarAppointment(
         appointmentId = 1,
         prisonCode = PENTONVILLE_PRISON_CODE,
@@ -188,7 +188,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return one appointment for a same day date boundary for a subject access request`() {
     val response = webTestClient.getSarContent("111222", LocalDate.of(2022, 10, 10), LocalDate.of(2022, 10, 12))
 
-    response.appointments containsExactly listOf(
+    response.content.appointments containsExactly listOf(
       SarAppointment(
         appointmentId = 1,
         prisonCode = PENTONVILLE_PRISON_CODE,
@@ -208,7 +208,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return one attendance summaries for a subject access request`() {
     val response = webTestClient.getSarContent("A4745DZ", LocalDate.of(2023, 7, 21), LocalDate.of(2023, 7, 22))
 
-    response.attendanceSummary containsExactly listOf(
+    response.content.attendanceSummary containsExactly listOf(
       SarAttendanceSummary(
         attendanceReasonCode = "ATTENDED",
         count = 1,
@@ -221,7 +221,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return two attendance summaries for a subject access request`() {
     val response = webTestClient.getSarContent("G9372GQ", LocalDate.of(2023, 7, 20), LocalDate.of(2023, 7, 21))
 
-    response.attendanceSummary containsExactlyInAnyOrder listOf(
+    response.content.attendanceSummary containsExactlyInAnyOrder listOf(
       SarAttendanceSummary(
         attendanceReasonCode = "ATTENDED",
         count = 1,
@@ -238,7 +238,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return one attendance summaries for a single day query for a subject access request`() {
     val response = webTestClient.getSarContent("G9372GQ", LocalDate.of(2023, 7, 21), LocalDate.of(2023, 7, 21))
 
-    response.attendanceSummary containsExactlyInAnyOrder listOf(
+    response.content.attendanceSummary containsExactlyInAnyOrder listOf(
       SarAttendanceSummary(
         attendanceReasonCode = "CANCELLED",
         count = 1,
@@ -251,7 +251,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return one of two attendance summaries (one status is WAITING) for a subject access request`() {
     val response = webTestClient.getSarContent("A4745DZ", LocalDate.of(2023, 7, 21), LocalDate.of(2023, 7, 23))
 
-    response.attendanceSummary containsExactlyInAnyOrder listOf(
+    response.content.attendanceSummary containsExactlyInAnyOrder listOf(
       SarAttendanceSummary(
         attendanceReasonCode = "ATTENDED",
         count = 1,
@@ -264,7 +264,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should two attendance summaries with different counts for a subject access request`() {
     val response = webTestClient.getSarContent("A4743DZ", LocalDate.of(2023, 7, 21), LocalDate.of(2024, 7, 21))
 
-    response.attendanceSummary containsExactlyInAnyOrder listOf(
+    response.content.attendanceSummary containsExactlyInAnyOrder listOf(
       SarAttendanceSummary(
         attendanceReasonCode = "SUSPENDED",
         count = 1,
@@ -281,7 +281,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
   fun `should return one allocation, two waiting list applications and an appointment for a subject access request`() {
     val response = webTestClient.getSarContent("111222", LocalDate.of(2022, 10, 10), LocalDate.of(2022, 10, 12))
 
-    response.allocations containsExactly listOf(
+    response.content.allocations containsExactly listOf(
       SarAllocation(
         allocationId = 3,
         prisonCode = PENTONVILLE_PRISON_CODE,
@@ -295,7 +295,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
       ),
     )
 
-    response.waitingListApplications containsExactlyInAnyOrder listOf(
+    response.content.waitingListApplications containsExactlyInAnyOrder listOf(
       SarWaitingList(
         waitingListId = 2,
         prisonCode = PENTONVILLE_PRISON_CODE,
@@ -320,7 +320,7 @@ class SubjectAccessRequestIntegrationTest : IntegrationTestBase() {
       ),
     )
 
-    response.appointments containsExactly listOf(
+    response.content.appointments containsExactly listOf(
       SarAppointment(
         appointmentId = 1,
         prisonCode = PENTONVILLE_PRISON_CODE,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/SubjectAccessRequestServiceTest.kt
@@ -15,6 +15,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.PENTONV
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestContent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SubjectAccessRequestData
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.SarRepository
 import java.time.LocalTime
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.SarAllocation as ModelSarAllocation
@@ -127,13 +128,15 @@ class SubjectAccessRequestServiceTest {
     whenever(repository.findAttendanceBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn emptyList()
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
-      prisonerNumber = sarAllocation.prisonerNumber,
-      fromDate = TimeSource.yesterday(),
-      toDate = TimeSource.tomorrow(),
-      allocations = listOf(sarAllocation).map(::ModelSarAllocation),
-      attendanceSummary = emptyList(),
-      waitingListApplications = emptyList(),
-      appointments = emptyList(),
+      SubjectAccessRequestData(
+        prisonerNumber = sarAllocation.prisonerNumber,
+        fromDate = TimeSource.yesterday(),
+        toDate = TimeSource.tomorrow(),
+        allocations = listOf(sarAllocation).map(::ModelSarAllocation),
+        attendanceSummary = emptyList(),
+        waitingListApplications = emptyList(),
+        appointments = emptyList(),
+      ),
     )
 
     verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
@@ -150,13 +153,15 @@ class SubjectAccessRequestServiceTest {
     whenever(repository.findAttendanceBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn emptyList()
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
-      prisonerNumber = "12345",
-      fromDate = TimeSource.yesterday(),
-      toDate = TimeSource.tomorrow(),
-      allocations = emptyList(),
-      attendanceSummary = emptyList(),
-      waitingListApplications = listOf(sarWaitingList).map(::ModelSarWaitingList),
-      appointments = emptyList(),
+      SubjectAccessRequestData(
+        prisonerNumber = "12345",
+        fromDate = TimeSource.yesterday(),
+        toDate = TimeSource.tomorrow(),
+        allocations = emptyList(),
+        attendanceSummary = emptyList(),
+        waitingListApplications = listOf(sarWaitingList).map(::ModelSarWaitingList),
+        appointments = emptyList(),
+      ),
     )
 
     verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
@@ -173,13 +178,15 @@ class SubjectAccessRequestServiceTest {
     whenever(repository.findAttendanceBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn emptyList()
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
-      prisonerNumber = "12345",
-      fromDate = TimeSource.yesterday(),
-      toDate = TimeSource.tomorrow(),
-      allocations = emptyList(),
-      attendanceSummary = emptyList(),
-      waitingListApplications = emptyList(),
-      appointments = listOf(sarAppointment).map(::ModelSarAppointment),
+      SubjectAccessRequestData(
+        prisonerNumber = "12345",
+        fromDate = TimeSource.yesterday(),
+        toDate = TimeSource.tomorrow(),
+        allocations = emptyList(),
+        attendanceSummary = emptyList(),
+        waitingListApplications = emptyList(),
+        appointments = listOf(sarAppointment).map(::ModelSarAppointment),
+      ),
     )
 
     verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
@@ -196,13 +203,15 @@ class SubjectAccessRequestServiceTest {
     whenever(repository.findAttendanceBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn listOf(allAttendance, allAttendance2)
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
-      prisonerNumber = "12345",
-      fromDate = TimeSource.yesterday(),
-      toDate = TimeSource.tomorrow(),
-      allocations = emptyList(),
-      attendanceSummary = listOf(modelSarAttendanceSummary),
-      waitingListApplications = emptyList(),
-      appointments = emptyList(),
+      SubjectAccessRequestData(
+        prisonerNumber = "12345",
+        fromDate = TimeSource.yesterday(),
+        toDate = TimeSource.tomorrow(),
+        allocations = emptyList(),
+        attendanceSummary = listOf(modelSarAttendanceSummary),
+        waitingListApplications = emptyList(),
+        appointments = emptyList(),
+      ),
     )
 
     verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())
@@ -219,13 +228,15 @@ class SubjectAccessRequestServiceTest {
     whenever(repository.findAttendanceBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())) doReturn listOf(allAttendance, allAttendance2)
 
     service.getContentFor("12345", TimeSource.yesterday(), TimeSource.tomorrow()) isEqualTo SubjectAccessRequestContent(
-      prisonerNumber = "12345",
-      fromDate = TimeSource.yesterday(),
-      toDate = TimeSource.tomorrow(),
-      allocations = listOf(sarAllocation).map(::ModelSarAllocation),
-      attendanceSummary = listOf(modelSarAttendanceSummary),
-      waitingListApplications = listOf(sarWaitingList).map(::ModelSarWaitingList),
-      appointments = listOf(sarAppointment).map(::ModelSarAppointment),
+      SubjectAccessRequestData(
+        prisonerNumber = "12345",
+        fromDate = TimeSource.yesterday(),
+        toDate = TimeSource.tomorrow(),
+        allocations = listOf(sarAllocation).map(::ModelSarAllocation),
+        attendanceSummary = listOf(modelSarAttendanceSummary),
+        waitingListApplications = listOf(sarWaitingList).map(::ModelSarWaitingList),
+        appointments = listOf(sarAppointment).map(::ModelSarAppointment),
+      ),
     )
 
     verify(repository).findAllocationsBy("12345", TimeSource.yesterday(), TimeSource.tomorrow())


### PR DESCRIPTION
The SAR response object was not conforming to the API specification and was missing the root node 'content'.

All SAR data should be in the root node as follows below:

```
{
  content: { .. data goes here ... }
}
```

![image](https://github.com/ministryofjustice/hmpps-activities-management-api/assets/60104344/6003c833-3b71-4ca9-8903-e73453b4e454)
