### PR TITLE
SAA-1559: Classify in cell appointments as on wing

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentUpdateDomainService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentUpdateDomainService.kt
@@ -174,10 +174,14 @@ class AppointmentUpdateDomainService(
       if (request.inCell == true) {
         it.internalLocationId = null
         it.inCell = true
+        it.onWing = true
+        it.offWing = false
       } else {
         request.internalLocationId?.apply {
           it.internalLocationId = this
           it.inCell = false
+          it.onWing = false
+          it.offWing = true
         }
       }
     }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSetService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSetService.kt
@@ -137,6 +137,8 @@ class AppointmentSetService(
       appointmentTier = tier,
       internalLocationId = if (inCell) null else internalLocationId,
       inCell = inCell,
+      onWing = inCell,
+      offWing = !inCell,
       startDate = startDate!!,
       createdBy = createdBy,
     ).also { appointmentSet ->

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentUpdateDomainServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AppointmentUpdateDomainServiceTest.kt
@@ -277,8 +277,11 @@ class AppointmentUpdateDomainServiceTest {
         auditEvent = false,
       )
 
+      /* then the series will not be updated */
       appointmentSeries.internalLocationId isEqualTo 123
+      /* then the selected appointments will be updated */
       appointmentSeries.appointments().filter { ids.contains(it.appointmentId) }.all { it.internalLocationId == 456L } isBool true
+      /* the remaining appointments will not be updated */
       appointmentSeries.appointments().filterNot { ids.contains(it.appointmentId) }.all { it.internalLocationId == 123L } isBool true
 
       response.internalLocationId isEqualTo 123
@@ -309,15 +312,24 @@ class AppointmentUpdateDomainServiceTest {
         auditEvent = false,
       )
 
+      /* then the series will not be updated */
       appointmentSeries.internalLocationId isEqualTo 123
       appointmentSeries.inCell isEqualTo false
+      appointmentSeries.onWing isEqualTo false
+      appointmentSeries.offWing isEqualTo true
+      /* then the selected appointments will be updated */
       with(appointmentSeries.appointments().filter { ids.contains(it.appointmentId) }) {
         this.all { it.internalLocationId == null } isBool true
         this.all { it.inCell } isBool true
+        this.all { it.onWing } isBool true
+        this.all { it.offWing } isBool false
       }
+      /* then the other appointments will not be updated */
       with(appointmentSeries.appointments().filterNot { ids.contains(it.appointmentId) }) {
         this.all { it.internalLocationId == 123L } isBool true
-        this.all { !it.inCell } isBool true
+        this.all { it.inCell } isBool false
+        this.all { it.onWing } isBool false
+        this.all { it.offWing } isBool true
       }
 
       response.internalLocationId isEqualTo 123


### PR DESCRIPTION
- Classify in cell appointments as on wing
- Classify internal location as off wing 
- Ensure appointment creation to handle In Cell
- Ensure appointment Set creation to handle In Cell
- Ensure appointment Series creation to handle In Cell
