### PR TITLE
SAA-1572: add earliest release date to waiting list applications

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/WaitingListApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/WaitingListApplication.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingListStatus
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.EarliestReleaseDate
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -114,4 +115,7 @@ data class WaitingListApplication(
     example = "Jane Doe",
   )
   val updatedBy: String? = null,
+
+  @Schema(description = "The earliest release date of the prisoner")
+  var earliestReleaseDate: EarliestReleaseDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/WaitingListApplication.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/WaitingListApplication.kt
@@ -117,5 +117,5 @@ data class WaitingListApplication(
   val updatedBy: String? = null,
 
   @Schema(description = "The earliest release date of the prisoner")
-  var earliestReleaseDate: EarliestReleaseDate? = null,
+  val earliestReleaseDate: EarliestReleaseDate,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -123,7 +123,7 @@ class ActivityScheduleService(
             prisonerSearchApiClient.findByPrisonerNumbers(map { it.prisonerNumber })
 
           map {
-            val prisoner = prisoners.find { p -> it.prisonerNumber == p.prisonerNumber }!!
+            val prisoner = prisoners.find { p -> it.prisonerNumber == p.prisonerNumber } ?: throw NullPointerException("Prisoner ${it.prisonerNumber} not found for allocation id ${it.id}")
             it.prisonerName = "${prisoner.firstName} ${prisoner.lastName}"
             it.prisonerStatus = prisoner.status
             it.prisonerPrisonCode = prisoner.prisonId

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListService.kt
@@ -62,10 +62,8 @@ class WaitingListService(
           prisonerSearchApiClient.findByPrisonerNumbers(map { it.prisonerNumber })
 
         map {
-          val prisoner = prisoners.find { p -> it.prisonerNumber == p.prisonerNumber }
-          if (prisoner != null) {
-            it.earliestReleaseDate = determineEarliestReleaseDate(prisoner)
-          }
+          val prisoner = prisoners.find { p -> it.prisonerNumber == p.prisonerNumber } ?: throw NullPointerException("Prisoner ${it.prisonerNumber} not found for waiting list id $id")
+          it.earliestReleaseDate = determineEarliestReleaseDate(prisoner)
         }
       }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListService.kt
@@ -69,7 +69,7 @@ class WaitingListService(
           ?: throw NullPointerException("Prisoner ${it.prisonerNumber} not found for waiting list id $id")
         it.toModel(determineEarliestReleaseDate(prisoner))
       }
-  }
+    }
 
   @Transactional
   fun addPrisoner(prisonCode: String, request: WaitingListApplicationRequest, createdBy: String) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.EventOrga
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PayPerSession
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RolloutPrisonPlan
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.EarliestReleaseDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.PrisonerAllocations
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.EventPriorities
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity as EntityActivity
@@ -481,7 +482,7 @@ fun List<EntityActivityBasic>.toActivityBasicList() = map {
   transform(it)
 }
 
-fun EntityWaitingList.toModel() = ModelWaitingListApplication(
+fun EntityWaitingList.toModel(earliestReleaseDate: EarliestReleaseDate) = ModelWaitingListApplication(
   id = waitingListId,
   prisonCode = prisonCode,
   activityId = activitySchedule.activity.activityId,
@@ -499,4 +500,5 @@ fun EntityWaitingList.toModel() = ModelWaitingListApplication(
   updatedTime = updatedTime,
   updatedBy = updatedBy,
   statusUpdatedTime = statusUpdatedTime,
+  earliestReleaseDate = earliestReleaseDate,
 )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -29,6 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Slot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityMinimumEducationLevelCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityPayCreateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.EarliestReleaseDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transform
 import java.time.DayOfWeek
 import java.time.LocalDate
@@ -444,6 +445,15 @@ internal fun ActivityScheduleSlot.runEveryDayOfWeek() {
   saturdayFlag = true
   sundayFlag = true
 }
+
+internal fun earliestReleaseDate() = EarliestReleaseDate(
+  releaseDate = LocalDate.now(),
+  isTariffDate = false,
+  isImmigrationDetainee = false,
+  isRemand = false,
+  isConvictedUnsentenced = false,
+  isIndeterminateSentence = false,
+)
 
 internal fun waitingList(
   waitingListId: Long = 1,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -587,7 +587,11 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
   )
   @Test
   fun `get all waiting lists for Maths`() {
-    prisonerSearchApiMockServer.stubSearchByPrisonerNumbers()
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
+      listOf("A4065DZ"),
+      listOf(
+        PrisonerSearchPrisonerFixture.instance(prisonerNumber = "A4065DZ", firstName = "Joe", releaseDate = LocalDate.now()),
+      ),)
 
     webTestClient.getWaitingListsBy(1)!!.also { assertThat(it).hasSize(1) }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -587,6 +587,8 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
   )
   @Test
   fun `get all waiting lists for Maths`() {
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumbers()
+
     webTestClient.getWaitingListsBy(1)!!.also { assertThat(it).hasSize(1) }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -591,7 +591,8 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
       listOf("A4065DZ"),
       listOf(
         PrisonerSearchPrisonerFixture.instance(prisonerNumber = "A4065DZ", firstName = "Joe", releaseDate = LocalDate.now()),
-      ),)
+      ),
+    )
 
     webTestClient.getWaitingListsBy(1)!!.also { assertThat(it).hasSize(1) }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -587,10 +587,12 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
   )
   @Test
   fun `get all waiting lists for Maths`() {
-    prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
-      listOf("A4065DZ"),
-      listOf(
-        PrisonerSearchPrisonerFixture.instance(prisonerNumber = "A4065DZ", firstName = "Joe", releaseDate = LocalDate.now()),
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumber(
+      PrisonerSearchPrisonerFixture.instance(
+        prisonId = MOORLAND_PRISON_CODE,
+        prisonerNumber = "A4065DZ",
+        bookingId = 1,
+        status = "ACTIVE IN",
       ),
     )
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -587,14 +587,11 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
   )
   @Test
   fun `get all waiting lists for Maths`() {
-    prisonerSearchApiMockServer.stubSearchByPrisonerNumber(
-      PrisonerSearchPrisonerFixture.instance(
-        prisonId = MOORLAND_PRISON_CODE,
-        prisonerNumber = "A4065DZ",
-        bookingId = 1,
-        status = "ACTIVE IN",
-      ),
-    )
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
+      listOf("A4065DZ"),
+      listOf(
+        PrisonerSearchPrisonerFixture.instance(prisonerNumber = "A4065DZ", firstName = "Joe", releaseDate = LocalDate.now()),
+      ),)
 
     webTestClient.getWaitingListsBy(1)!!.also { assertThat(it).hasSize(1) }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleControllerTest.kt
@@ -25,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.weeksAgo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.earliestReleaseDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.waitingList
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.PrisonerAllocationRequest
@@ -199,7 +200,8 @@ class ActivityScheduleControllerTest : ControllerTestBase<ActivityScheduleContro
 
   @Test
   fun `200 response when get waiting lists by schedule identifier`() {
-    val waitingList = waitingList().toModel()
+    val earliestReleaseDate = earliestReleaseDate()
+    val waitingList = waitingList().toModel(earliestReleaseDate)
 
     whenever(waitingListService.getWaitingListsBySchedule(1)).thenReturn(listOf(waitingList))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/WaitingListApplicationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/WaitingListApplicationControllerTest.kt
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.patch
 import org.springframework.test.web.servlet.post
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.earliestReleaseDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.waitingList
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.WaitingListApplicationUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.WaitingListSearchRequest
@@ -35,7 +36,7 @@ class WaitingListApplicationControllerTest : ControllerTestBase<WaitingListAppli
 
   @Test
   fun `200 response when get by ID found`() {
-    val waitingListApplication = waitingList().toModel()
+    val waitingListApplication = waitingList().toModel(earliestReleaseDate())
 
     whenever(waitingListService.getWaitingListBy(waitingListApplication.id)).thenReturn(waitingListApplication)
 
@@ -51,7 +52,7 @@ class WaitingListApplicationControllerTest : ControllerTestBase<WaitingListAppli
 
   @Test
   fun `202 response when update waiting list`() {
-    val waitingListApplication = waitingList().toModel()
+    val waitingListApplication = waitingList().toModel(earliestReleaseDate())
 
     whenever(waitingListService.updateWaitingList(waitingListApplication.id, WaitingListApplicationUpdateRequest(), user.name)).thenReturn(waitingListApplication)
 
@@ -67,7 +68,7 @@ class WaitingListApplicationControllerTest : ControllerTestBase<WaitingListAppli
   @Test
   fun `200 response when searching waiting list application`() {
     val request = WaitingListSearchRequest()
-    val waitingListApplication = waitingList().toModel()
+    val waitingListApplication = waitingList().toModel(earliestReleaseDate())
     val pagedResult = PageImpl(listOf(waitingListApplication), Pageable.ofSize(1), 1)
 
     whenever(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -158,6 +159,19 @@ class ActivityScheduleServiceTest {
 
     assertThat(service.getAllocationsBy(1, activeOnly = false, includePrisonerSummary = true))
       .isEqualTo(expectedResponse)
+  }
+
+  @Test
+  fun `getAllocationsBy - no prisoner information throws a null pointer exception`() {
+    val schedule = schedule(PENTONVILLE_PRISON_CODE)
+
+    whenever(repository.getActivityScheduleByIdWithFilters(1)) doReturn schedule
+    whenever(prisonerSearchApiClient.findByPrisonerNumbers(listOf("A1234AA", "A1111BB"))) doReturn emptyList()
+
+    val exception = assertThrows<NullPointerException> {
+      service.getAllocationsBy(1, activeOnly = false, includePrisonerSummary = true)
+    }
+    exception.message isEqualTo "Prisoner A1234AA not found for allocation id 0"
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
@@ -5,6 +5,7 @@ import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
@@ -381,7 +382,7 @@ class WaitingListServiceTest {
   }
 
   @Test
-  fun `get waiting lists by the schedule identifier`() {
+  fun `get waiting lists by the schedule identifier throws exception when no prisoner details`() {
     val schedule = activityEntity(prisonCode = PENTONVILLE_PRISON_CODE).schedules().first()
     val allocation = schedule.allocations().first()
 
@@ -415,28 +416,10 @@ class WaitingListServiceTest {
       on { findByPrisonerNumbers(listOf("123456")) } doReturn emptyList()
     }
 
-    with(service.getWaitingListsBySchedule(1L)) {
-      assertThat(size).isEqualTo(1)
-
-      with(first()) {
-        id isEqualTo 99
-        scheduleId isEqualTo schedule.activityScheduleId
-        allocationId isEqualTo allocation.allocationId
-        prisonCode isEqualTo PENTONVILLE_PRISON_CODE
-        prisonerNumber isEqualTo "123456"
-        bookingId isEqualTo 100L
-        status isEqualTo WaitingListStatus.DECLINED
-        requestedDate isEqualTo TimeSource.today()
-        requestedBy isEqualTo "Fred"
-        comments isEqualTo "Some random test comments"
-        createdBy isEqualTo "Bob"
-        creationTime isCloseTo TimeSource.now()
-        updatedBy isEqualTo "Test"
-        updatedTime!! isCloseTo TimeSource.now()
-        declinedReason isEqualTo "Needs to attend level one activity first"
-        earliestReleaseDate isEqualTo null
-      }
+    val exception = assertThrows<NullPointerException> {
+      service.getWaitingListsBySchedule(1L)
     }
+    exception.message isEqualTo "Prisoner 123456 not found for waiting list id 1"
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
@@ -22,7 +22,6 @@ import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toPrisonerNumber
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingList
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingListStatus
@@ -30,6 +29,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAN
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.PENTONVILLE_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.earliestReleaseDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.notInWorkCategory
@@ -39,7 +39,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.Pri
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.WaitingListApplicationRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.WaitingListApplicationUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.WaitingListSearchRequest
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.EarliestReleaseDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.WaitingListRepository
@@ -461,14 +460,7 @@ class WaitingListServiceTest {
       on { findByPrisonerNumbers(listOf("G4793VF")) } doReturn listOf(prisoner)
     }
 
-    val earliestReleaseDate = EarliestReleaseDate(
-      releaseDate = releaseDate,
-      isTariffDate = releaseDate != null && prisoner.tariffDate?.isEqual(releaseDate) ?: false,
-      isConvictedUnsentenced = prisoner.legalStatus == Prisoner.LegalStatus.CONVICTED_UNSENTENCED,
-      isImmigrationDetainee = prisoner.legalStatus == Prisoner.LegalStatus.IMMIGRATION_DETAINEE,
-      isRemand = prisoner.legalStatus == Prisoner.LegalStatus.REMAND,
-      isIndeterminateSentence = prisoner.legalStatus == Prisoner.LegalStatus.INDETERMINATE_SENTENCE,
-    )
+    val earliestReleaseDate = earliestReleaseDate().copy(releaseDate = releaseDate)
 
     with(service.getWaitingListsBySchedule(1L)) {
       assertThat(size).isEqualTo(1)
@@ -489,7 +481,7 @@ class WaitingListServiceTest {
         updatedBy isEqualTo "Test"
         updatedTime!! isCloseTo TimeSource.now()
         declinedReason isEqualTo "Needs to attend level one activity first"
-        earliestReleaseDate isEqualTo earliestReleaseDate
+        earliestReleaseDate.releaseDate isEqualTo earliestReleaseDate.releaseDate
       }
     }
   }
@@ -1227,14 +1219,7 @@ class WaitingListServiceTest {
 
     val releaseDate = LocalDate.of(2030, 4, 20)
     val prisoner = PrisonerSearchPrisonerFixture.instance().copy(releaseDate = releaseDate)
-    val earliestReleaseDate = EarliestReleaseDate(
-      releaseDate = releaseDate,
-      isTariffDate = releaseDate != null && prisoner.tariffDate?.isEqual(releaseDate) ?: false,
-      isConvictedUnsentenced = prisoner.legalStatus == Prisoner.LegalStatus.CONVICTED_UNSENTENCED,
-      isImmigrationDetainee = prisoner.legalStatus == Prisoner.LegalStatus.IMMIGRATION_DETAINEE,
-      isRemand = prisoner.legalStatus == Prisoner.LegalStatus.REMAND,
-      isIndeterminateSentence = prisoner.legalStatus == Prisoner.LegalStatus.INDETERMINATE_SENTENCE,
-    )
+    val earliestReleaseDate = earliestReleaseDate().copy(releaseDate = releaseDate)
 
     prisonerSearchApiClient.stub {
       on { findByPrisonerNumber("123456") } doReturn prisoner
@@ -1262,14 +1247,7 @@ class WaitingListServiceTest {
 
     val releaseDate = LocalDate.of(2030, 4, 20)
     val prisoner = PrisonerSearchPrisonerFixture.instance().copy(releaseDate = releaseDate)
-    val earliestReleaseDate = EarliestReleaseDate(
-      releaseDate = releaseDate,
-      isTariffDate = releaseDate != null && prisoner.tariffDate?.isEqual(releaseDate) ?: false,
-      isConvictedUnsentenced = prisoner.legalStatus == Prisoner.LegalStatus.CONVICTED_UNSENTENCED,
-      isImmigrationDetainee = prisoner.legalStatus == Prisoner.LegalStatus.IMMIGRATION_DETAINEE,
-      isRemand = prisoner.legalStatus == Prisoner.LegalStatus.REMAND,
-      isIndeterminateSentence = prisoner.legalStatus == Prisoner.LegalStatus.INDETERMINATE_SENTENCE,
-    )
+    val earliestReleaseDate = earliestReleaseDate().copy(releaseDate = releaseDate)
 
     prisonerSearchApiClient.stub {
       on { findByPrisonerNumber("123456") } doReturn prisoner

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
@@ -458,7 +458,7 @@ class WaitingListServiceTest {
     val prisoner = PrisonerSearchPrisonerFixture.instance().copy(releaseDate = releaseDate)
 
     prisonerSearchApiClient.stub {
-      on { findByPrisonerNumber("G4793VF") } doReturn prisoner
+      on { findByPrisonerNumbers(listOf("G4793VF")) } doReturn listOf(prisoner)
     }
 
     val earliestReleaseDate = EarliestReleaseDate(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListServiceTest.kt
@@ -411,7 +411,6 @@ class WaitingListServiceTest {
       on { findByActivitySchedule(schedule) } doReturn listOf(waitingList)
     }
 
-    var prisoner = PrisonerSearchPrisonerFixture.instance()
     prisonerSearchApiClient.stub {
       on { findByPrisonerNumbers(listOf("123456")) } doReturn emptyList()
     }
@@ -472,13 +471,13 @@ class WaitingListServiceTest {
     }
 
     val releaseDate = LocalDate.of(2030, 4, 20)
-    var prisoner = PrisonerSearchPrisonerFixture.instance().copy(releaseDate = releaseDate)
+    val prisoner = PrisonerSearchPrisonerFixture.instance().copy(releaseDate = releaseDate)
 
     prisonerSearchApiClient.stub {
       on { findByPrisonerNumbers(listOf("G4793VF")) } doReturn listOf(prisoner)
     }
 
-    var earliestReleaseDate = EarliestReleaseDate(
+    val earliestReleaseDate = EarliestReleaseDate(
       releaseDate = releaseDate,
       isTariffDate = releaseDate != null && prisoner.tariffDate?.isEqual(releaseDate) ?: false,
       isConvictedUnsentenced = prisoner.legalStatus == Prisoner.LegalStatus.CONVICTED_UNSENTENCED,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctionsTest.kt
@@ -23,6 +23,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentInstanceEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentLocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appointmentSearchEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.earliestReleaseDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isCloseTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.lowPayBand
@@ -594,6 +595,8 @@ class TransformFunctionsTest {
     val schedule = activityEntity(prisonCode = PENTONVILLE_PRISON_CODE).schedules().first()
     val allocation = schedule.allocations().first()
 
+    val earliestReleaseDate = earliestReleaseDate()
+
     with(
       WaitingList(
         waitingListId = 99,
@@ -611,7 +614,7 @@ class TransformFunctionsTest {
         this.updatedBy = "Test"
         this.updatedTime = TimeSource.now()
         this.declinedReason = "Needs to attend level one activity first"
-      }.toModel(),
+      }.toModel(earliestReleaseDate),
     ) {
       id isEqualTo 99
       scheduleId isEqualTo schedule.activityScheduleId
@@ -629,6 +632,7 @@ class TransformFunctionsTest {
       updatedBy isEqualTo "Test"
       updatedTime!! isCloseTo TimeSource.now()
       declinedReason isEqualTo "Needs to attend level one activity first"
+      earliestReleaseDate isEqualTo earliestReleaseDate
     }
   }
 


### PR DESCRIPTION
The /schedules/{scheduleId}/waiting-list-applications needs to include the earliest release date as this is required to be shown on the Waitlist on Activity Allocation screen