### PR TITLE
SAA-1598 change to allow a date to be passed through upon deallocation to allow for the deallocation to be back dated.

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -907,7 +907,7 @@ class ActivityScheduleTest {
   @Test
   fun `prisoner is deallocated from schedule when they already have an ended allocation previously`() {
     val schedule = activitySchedule(activity = activityEntity())
-    val originalAllocation = schedule.allocations().first().also { it.deallocateNow() }
+    val originalAllocation = schedule.allocations().first().also { it.deallocateNowOn(TimeSource.today()) }
     val newAllocation = schedule.allocatePrisoner(originalAllocation.prisonerNumber.toPrisonerNumber(), originalAllocation.payBand, originalAllocation.bookingId, allocatedBy = "test")
 
     assertThat(newAllocation.plannedDeallocation).isNull()
@@ -1181,7 +1181,7 @@ class ActivityScheduleTest {
       bookingId = 20002,
       allocatedBy = "BILL",
       endDate = tomorrow.plusDays(1),
-    ).deallocateNow()
+    ).deallocateNowOn(TimeSource.today())
 
     assertThat(schedule.allocations()).hasSize(2)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AuditableEntityListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AuditableEntityListenerTest.kt
@@ -14,6 +14,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.enumeration.ServiceName
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.ActivityCreatedEvent
@@ -69,7 +70,7 @@ class AuditableEntityListenerTest(@Autowired private val listener: AuditableEnti
 
   @Test
   fun `prisoner deallocation audit event raised on update`() {
-    listener.onUpdate(allocation.deallocateNow())
+    listener.onUpdate(allocation.deallocateNowOn(TimeSource.today()))
 
     verify(auditService).logEvent(prisonerDeallocatedCaptor.capture())
     verifyNoMoreInteractions(auditService)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/CandidatesServiceTest.kt
@@ -104,7 +104,7 @@ class CandidatesServiceTest {
           allocation().copy(allocationId = 1, prisonerNumber = candidate.prisonerNumber),
           allocation().copy(allocationId = 2, prisonerNumber = candidate.prisonerNumber).apply {
             deallocateOn(LocalDate.now(), DeallocationReason.SECURITY, ServiceName.SERVICE_NAME.toString(), 10001)
-            deallocateNow()
+            deallocateNowOn(TimeSource.today())
           },
         ),
       )
@@ -749,7 +749,7 @@ class CandidatesServiceTest {
           bookingId = 1L,
           startDate = TimeSource.tomorrow(),
           allocatedBy = "Test",
-        ).deallocateNow()
+        ).deallocateNowOn(TimeSource.today())
       }.also { it.allocations().single().prisonerStatus isEqualTo PrisonerStatus.ENDED }
 
       candidatesSetup(schedule.activity, PrisonerSearchPrisonerFixture.pagedResult(prisonerNumbers = listOf("A1234BC")))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/AuditTransformationsTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/AuditTransformationsTest.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test
 import toPrisonerAddedToWaitingListEvent
 import toPrisonerDeallocatedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.waitingList
@@ -17,7 +18,7 @@ class AuditTransformationsTest {
 
   @Test
   fun `transform to prisoner deallocated event`() {
-    val allocation = allocation().deallocateNow()
+    val allocation = allocation().deallocateNowOn(TimeSource.today())
 
     with(allocation.toPrisonerDeallocatedEvent()) {
       assertThat(activityId).isEqualTo(allocation.activitySchedule.activity.activityId)


### PR DESCRIPTION
The logic for dellocation has changed.

We need to allow a date to be supplied upon deallocation to support back dating deallocations.

This was spotted when dellocated allocations were not using the planneded deallocation reason due to dates being out of sync e.g. actual deallocation of allocation for yesterday was happening today but the planned deallocation was for yesterday.