### PR TITLE
SAA-1619 logic for canAttendOn(...) on Allocation was not factoring the planned allocation end date.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -192,6 +192,7 @@ data class Allocation(
   private fun maybeEndDate() =
     when {
       endDate != null -> endDate
+      plannedDeallocation?.plannedDate != null -> plannedDeallocation?.plannedDate
       activitySchedule.endDate != null -> activitySchedule.endDate
       activitySchedule.activity.endDate != null -> activitySchedule.activity.endDate
       else -> null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -259,7 +259,7 @@ class AllocationTest {
   }
 
   @Test
-  fun `can update an exiting planned deallocation`() {
+  fun `can update an existing planned deallocation`() {
     val schedule: ActivitySchedule = mock {
       on { startDate } doReturn yesterday
       on { endDate } doReturn tomorrow.plusWeeks(1)
@@ -694,6 +694,17 @@ class AllocationTest {
   @Test
   fun `allocation ending yesterday cannot be attended today`() {
     val allocation = allocation(startDate = TimeSource.yesterday()).apply { endDate = TimeSource.yesterday() }
+
+    allocation.canAttendOn(TimeSource.today(), prisonRegime[TimeSlot.AM]!!) isBool false
+  }
+
+  @Test
+  fun `allocation planned to end yesterday cannot be attended today`() {
+    val allocation = allocation(startDate = TimeSource.yesterday()).apply {
+      deallocateOn(TimeSource.today(), DeallocationReason.DISMISSED, "test")
+      // Cannot add a planned deallocation with yesterday's date so have to override it manually in the test.
+      plannedDeallocation?.plannedDate = TimeSource.yesterday()
+    }
 
     allocation.canAttendOn(TimeSource.today(), prisonRegime[TimeSlot.AM]!!) isBool false
   }


### PR DESCRIPTION
This bug was spotted after the deallocation job failed and the attendance job ran successfully (in DEV)

An allocation that should have been ended due to having a planned end date did not end but an attendance record was still created when it shouldn't have been.  This was because it did not factor in the allocations planned end date.

