### PR TITLE
SAA-1626 adding Sentry monitoring for caught exceptions in jobs so don't go unnoticed.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsService.kt
@@ -246,7 +246,7 @@ class ManageAllocationsService(
             }?.map(Allocation::allocationId) ?: emptyList()
           }.let(::sendAllocationsAmendedEvents)
         },
-        failure = "An error occurred deallocating allocations on activity schedule ${schedule.activityScheduleId}.",
+        failure = "An error occurred deallocating allocations on activity schedule ${schedule.activityScheduleId}",
       )
     }
   }
@@ -292,7 +292,7 @@ class ManageAllocationsService(
       block()
     }
       .onFailure {
-        monitoringService.capture(failure)
+        monitoringService.capture(failure, it)
         log.error(failure, it)
       }
   }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
@@ -85,7 +85,7 @@ class ManageAttendancesService(
           }
             .onSuccess { counter += attendancesForInstance.size }
             .onFailure {
-              monitoringService.capture("Error occurred saving attendances for prison code '$prisonCode' and instance id '${instance.scheduledInstanceId}'")
+              monitoringService.capture("Error occurred saving attendances for prison code '$prisonCode' and instance id '${instance.scheduledInstanceId}'", it)
               log.error(
                 "Error occurred saving attendances for prison code '$prisonCode' and instance id '${instance.scheduledInstanceId}'",
                 it,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
@@ -35,6 +35,7 @@ class ManageAttendancesService(
   private val outboundEventsService: OutboundEventsService,
   private val prisonerSearchApiClient: PrisonerSearchApiApplicationClient,
   private val transactionHandler: TransactionHandler,
+  private val monitoringService: MonitoringService,
 ) {
 
   companion object {
@@ -84,6 +85,7 @@ class ManageAttendancesService(
           }
             .onSuccess { counter += attendancesForInstance.size }
             .onFailure {
+              monitoringService.capture("Error occurred saving attendances for prison code '$prisonCode' and instance id '${instance.scheduledInstanceId}'")
               log.error(
                 "Error occurred saving attendances for prison code '$prisonCode' and instance id '${instance.scheduledInstanceId}'",
                 it,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesService.kt
@@ -54,7 +54,7 @@ class ManageScheduledInstancesService(
 
   private fun <R> continueToRunOnFailure(block: () -> R?, success: String, failure: String) =
     runCatching { block() }.onSuccess { log.info(success) }.onFailure {
-      monitoringService.capture(failure)
+      monitoringService.capture(failure, it)
       log.error(failure, it)
     }.getOrNull()
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MonitoringService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MonitoringService.kt
@@ -21,10 +21,14 @@ class MonitoringService {
     log.info("Monitoring service is ${if (Sentry.isEnabled()) "enabled" else "disabled"}")
   }
 
-  fun capture(message: String) {
+  fun capture(message: String, error: Throwable? = null) {
     // This checks for the presence of the Sentry environment variable SENTRY_DSN, it is disabled if not found.
     if (Sentry.isEnabled()) {
-      Sentry.captureMessage(message)
+      if (error == null) {
+        Sentry.captureMessage(message)
+      } else {
+        Sentry.captureMessage(message.plus(" - ${error.message}"))
+      }
       log.info("Monitoring service is enabled, message: '$message' sent")
     } else {
       log.info("Monitoring service is disabled, ignoring message: '$message'")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAllocationsServiceTest.kt
@@ -183,7 +183,8 @@ class ManageAllocationsServiceTest {
 
   @Test
   fun `should capture failures in monitoring service for any exceptions when expiring`() {
-    doThrow(RuntimeException("Something went wrong")).whenever(activityScheduleRepo).saveAndFlush(any())
+    val exception = RuntimeException("Something went wrong")
+    doThrow(exception).whenever(activityScheduleRepo).saveAndFlush(any())
     val prison = rolloutPrison()
     val activity = activityEntity(startDate = TimeSource.tomorrow())
     val schedule = activity.schedules().first()
@@ -201,7 +202,7 @@ class ManageAllocationsServiceTest {
 
     service.allocations(AllocationOperation.EXPIRING_TODAY)
 
-    verify(monitoringService).capture("An error occurred deallocating allocations on activity schedule 1.")
+    verify(monitoringService).capture("An error occurred deallocating allocations on activity schedule 1", exception)
   }
 
   @Test
@@ -474,19 +475,21 @@ class ManageAllocationsServiceTest {
 
   @Test
   fun `should capture failures in monitoring service for any exceptions when suspending`() {
-    doThrow(RuntimeException("Something went wrong")).whenever(allocationRepository).saveAndFlush(any())
+    val exception = RuntimeException("Something went wrong")
+    doThrow(exception).whenever(allocationRepository).saveAndFlush(any())
     val prison = rolloutPrison().also { whenever(rolloutPrisonRepo.findAll()) doReturn listOf(it) }
     val activeAllocation: Allocation = allocation(withPlannedSuspensions = true)
     whenever(allocationRepository.findByPrisonCodePrisonerStatus(prison.code, PrisonerStatus.ACTIVE)) doReturn listOf(activeAllocation)
 
     service.suspendAllocationsDueToBeSuspended(prison.code)
 
-    verify(monitoringService).capture("An error occurred while suspending allocations due to be suspended today")
+    verify(monitoringService).capture("An error occurred while suspending allocations due to be suspended today", exception)
   }
 
   @Test
   fun `should capture failures in monitoring service for any exceptions when unsuspending`() {
-    doThrow(RuntimeException("Something went wrong")).whenever(allocationRepository).saveAndFlush(any())
+    val exception = RuntimeException("Something went wrong")
+    doThrow(exception).whenever(allocationRepository).saveAndFlush(any())
     val prison = rolloutPrison().also { whenever(rolloutPrisonRepo.findAll()) doReturn listOf(it) }
     val suspendedAllocation: Allocation = allocation(withPlannedSuspensions = true).apply {
       activatePlannedSuspension()
@@ -496,7 +499,7 @@ class ManageAllocationsServiceTest {
     whenever(allocationRepository.findByPrisonCodePrisonerStatus(prison.code, PrisonerStatus.SUSPENDED)) doReturn listOf(suspendedAllocation)
 
     service.unsuspendAllocationsDueToBeUnsuspended(prison.code)
-    verify(monitoringService).capture("An error occurred while unsuspending allocations due to be unsuspended today")
+    verify(monitoringService).capture("An error occurred while unsuspending allocations due to be unsuspended today", exception)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
@@ -147,7 +147,8 @@ class ManageAttendancesServiceTest {
 
   @Test
   fun `should capture failures in monitoring service for any exceptions when creating attendances`() {
-    doThrow(RuntimeException("Something went wrong")).whenever(attendanceRepository).saveAllAndFlush(anyList())
+    val exception = RuntimeException("Something went wrong")
+    doThrow(exception).whenever(attendanceRepository).saveAllAndFlush(anyList())
 
     instance.activitySchedule.activity.attendanceRequired = true
 
@@ -156,7 +157,7 @@ class ManageAttendancesServiceTest {
 
     service.createAttendances(today, MOORLAND_PRISON_CODE)
 
-    verify(monitoringService).capture("Error occurred saving attendances for prison code 'MDI' and instance id '0'")
+    verify(monitoringService).capture("Error occurred saving attendances for prison code 'MDI' and instance id '0'", exception)
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesServiceTest.kt
@@ -11,6 +11,7 @@ import org.mockito.Captor
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -42,6 +43,7 @@ class ManageScheduledInstancesServiceTest {
   private val telemetryClient: TelemetryClient = mock()
   private val rolloutPrisonRepository: RolloutPrisonRepository = mock { on { findAll() } doReturn (rolledOutPrisons) }
   private val outboundEventsService: OutboundEventsService = mock()
+  private val monitoringService: MonitoringService = mock()
 
   private val activityServiceTest: ActivityService = ActivityService(
     activityRepository = activityRepository,
@@ -64,7 +66,7 @@ class ManageScheduledInstancesServiceTest {
 
   private val transactionHandler = CreateInstanceTransactionHandler(activityScheduleRepository, activityServiceTest)
 
-  private val job = ManageScheduledInstancesService(activityRepository, rolloutPrisonRepository, transactionHandler, outboundEventsService, 7L)
+  private val job = ManageScheduledInstancesService(activityRepository, rolloutPrisonRepository, transactionHandler, outboundEventsService, monitoringService, 7L)
 
   private val today = LocalDate.now()
   private val weekFromToday = today.plusWeeks(1)
@@ -217,6 +219,27 @@ class ManageScheduledInstancesServiceTest {
         assertThat(instance.sessionDate).isBetween(today, weekFromToday)
       }
     }
+  }
+
+  @Test
+  fun `should capture failures in monitoring service for any exceptions when creating schedules`() {
+    val failingTransactionHandler: CreateInstanceTransactionHandler = mock()
+
+    doThrow(RuntimeException("Something went wrong")).whenever(failingTransactionHandler).createInstancesForActivitySchedule(any(), any(), any())
+    whenever(activityRepository.getBasicForPrisonBetweenDates(any(), any(), any())) doReturn moorlandBasic
+
+    ManageScheduledInstancesService(
+      activityRepository,
+      rolloutPrisonRepository,
+      failingTransactionHandler,
+      outboundEventsService,
+      monitoringService,
+      7L,
+    ).create()
+
+    verify(monitoringService).capture("Failed to schedule instances for MDI A")
+    verify(monitoringService).capture("Failed to schedule instances for MDI B")
+    verify(monitoringService).capture("Failed to schedule instances for MDI C")
   }
 
   private fun ArgumentCaptor<ActivitySchedule>.savedSchedules(expectedNumberOfSavedSchedules: Int) =

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesServiceTest.kt
@@ -224,8 +224,8 @@ class ManageScheduledInstancesServiceTest {
   @Test
   fun `should capture failures in monitoring service for any exceptions when creating schedules`() {
     val failingTransactionHandler: CreateInstanceTransactionHandler = mock()
-
-    doThrow(RuntimeException("Something went wrong")).whenever(failingTransactionHandler).createInstancesForActivitySchedule(any(), any(), any())
+    val exception = RuntimeException("Something went wrong")
+    doThrow(exception).whenever(failingTransactionHandler).createInstancesForActivitySchedule(any(), any(), any())
     whenever(activityRepository.getBasicForPrisonBetweenDates(any(), any(), any())) doReturn moorlandBasic
 
     ManageScheduledInstancesService(
@@ -237,9 +237,9 @@ class ManageScheduledInstancesServiceTest {
       7L,
     ).create()
 
-    verify(monitoringService).capture("Failed to schedule instances for MDI A")
-    verify(monitoringService).capture("Failed to schedule instances for MDI B")
-    verify(monitoringService).capture("Failed to schedule instances for MDI C")
+    verify(monitoringService).capture("Failed to schedule instances for MDI A", exception)
+    verify(monitoringService).capture("Failed to schedule instances for MDI B", exception)
+    verify(monitoringService).capture("Failed to schedule instances for MDI C", exception)
   }
 
   private fun ArgumentCaptor<ActivitySchedule>.savedSchedules(expectedNumberOfSavedSchedules: Int) =


### PR DESCRIPTION
Exceptions raised in some of the jobs are being missed due to the nature of `try ... catch` (and not propagating).

To be clear the `try ... catch` was always intentional e.g. if attendance creation fails for one prison doesn't mean it should fail for all.

In these scenarios the jobs can complete as successful even if there were some errors during the run.  If that does happen this change should at least provide some better visibility by essentially creating a Sentry alert which will propagate to the team alerts channel.