### PR TITLE
SAA-1629 correcting the prisoner alert payload, personReference is not part of the payload, nomsNumber is though.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEvents.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/InboundEvents.kt
@@ -181,12 +181,8 @@ enum class Action {
 
 // ------------ New event contents here -------------------------------------------------------------
 
-data class AlertsUpdatedEvent(
-  val personReference: PersonReference,
-  val additionalInformation: AlertsUpdatedInformation,
-) : InboundEvent, EventOfInterest {
-  override fun prisonerNumber(): String =
-    personReference.identifiers.first { it.type == "NOMS" }.value
+data class AlertsUpdatedEvent(val additionalInformation: AlertsUpdatedInformation) : InboundEvent, EventOfInterest {
+  override fun prisonerNumber(): String = additionalInformation.nomsNumber
 
   override fun eventType() = InboundEventType.ALERTS_UPDATED.eventType
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/EventsFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/EventsFactory.kt
@@ -100,9 +100,6 @@ fun alertsUpdatedEvent(
   alertsAdded: Set<String> = setOf("A1", "A2"),
   alertsRemoved: Set<String> = setOf("R1", "R2"),
 ) = AlertsUpdatedEvent(
-  personReference = PersonReference(
-    identifiers = listOf(Identifier("NOMS", prisonerNumber)),
-  ),
   additionalInformation = AlertsUpdatedInformation(
     bookingId = bookingId,
     alertsAdded = alertsAdded,


### PR DESCRIPTION
End to end testing in dev confirms this alert was never tested, the structure of the message we were expecting was not correct.

This change should clean up a message we have sitting on our DLQ in dev.

Note preprod and prod are not affected as we are not listening for this event in those envs.