### PR TITLE
SAA-1639 increase bank holiday service cache to expire every 7 days

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/CacheConfiguration.kt
@@ -25,13 +25,13 @@ class CacheConfiguration {
   @CacheEvict(value = [PRISON_INCENTIVE_LEVELS_CACHE_NAME])
   @Scheduled(fixedDelay = TTL_HOURS_PRISONER_INCENTIVE_LEVELS, timeUnit = TimeUnit.HOURS)
   fun cacheEvictPrisonerIncentiveLevels() {
-    log.info("Evicting cache: $PRISON_INCENTIVE_LEVELS_CACHE_NAME")
+    log.info("Evicting cache: $PRISON_INCENTIVE_LEVELS_CACHE_NAME after $TTL_HOURS_PRISONER_INCENTIVE_LEVELS hours" )
   }
 
   @CacheEvict(value = [BANK_HOLIDAYS_CACHE_NAME])
   @Scheduled(fixedDelay = TTL_HOURS_BANK_HOLIDAYS, timeUnit = TimeUnit.HOURS)
   fun cacheEvictBankHolidays() {
-    log.info("Evicting cache: $BANK_HOLIDAYS_CACHE_NAME")
+    log.info("Evicting cache: $BANK_HOLIDAYS_CACHE_NAME after $TTL_HOURS_BANK_HOLIDAYS hours")
   }
 
   companion object {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/CacheConfiguration.kt
@@ -25,7 +25,7 @@ class CacheConfiguration {
   @CacheEvict(value = [PRISON_INCENTIVE_LEVELS_CACHE_NAME])
   @Scheduled(fixedDelay = TTL_HOURS_PRISONER_INCENTIVE_LEVELS, timeUnit = TimeUnit.HOURS)
   fun cacheEvictPrisonerIncentiveLevels() {
-    log.info("Evicting cache: $PRISON_INCENTIVE_LEVELS_CACHE_NAME after $TTL_HOURS_PRISONER_INCENTIVE_LEVELS hours" )
+    log.info("Evicting cache: $PRISON_INCENTIVE_LEVELS_CACHE_NAME after $TTL_HOURS_PRISONER_INCENTIVE_LEVELS hours")
   }
 
   @CacheEvict(value = [BANK_HOLIDAYS_CACHE_NAME])

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/CacheConfiguration.kt
@@ -22,16 +22,23 @@ class CacheConfiguration {
     return ConcurrentMapCacheManager(BANK_HOLIDAYS_CACHE_NAME, PRISON_INCENTIVE_LEVELS_CACHE_NAME)
   }
 
-  @CacheEvict(allEntries = true, cacheNames = [BANK_HOLIDAYS_CACHE_NAME, PRISON_INCENTIVE_LEVELS_CACHE_NAME])
-  @Scheduled(fixedDelay = TTL_HOURS, timeUnit = TimeUnit.HOURS)
-  fun cacheEvict() {
-    log.info("Evicting caches: $BANK_HOLIDAYS_CACHE_NAME, $PRISON_INCENTIVE_LEVELS_CACHE_NAME")
+  @CacheEvict(value = [PRISON_INCENTIVE_LEVELS_CACHE_NAME])
+  @Scheduled(fixedDelay = TTL_HOURS_PRISONER_INCENTIVE_LEVELS, timeUnit = TimeUnit.HOURS)
+  fun cacheEvictPrisonerIncentiveLevels() {
+    log.info("Evicting cache: $PRISON_INCENTIVE_LEVELS_CACHE_NAME")
+  }
+
+  @CacheEvict(value = [BANK_HOLIDAYS_CACHE_NAME])
+  @Scheduled(fixedDelay = TTL_HOURS_BANK_HOLIDAYS, timeUnit = TimeUnit.HOURS)
+  fun cacheEvictBankHolidays() {
+    log.info("Evicting cache: $BANK_HOLIDAYS_CACHE_NAME")
   }
 
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
     const val BANK_HOLIDAYS_CACHE_NAME: String = "bankHolidays"
     const val PRISON_INCENTIVE_LEVELS_CACHE_NAME: String = "prisonIncentiveLevels"
-    const val TTL_HOURS: Long = 24
+    const val TTL_HOURS_PRISONER_INCENTIVE_LEVELS: Long = 24
+    const val TTL_HOURS_BANK_HOLIDAYS: Long = 24 * 7
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/CacheConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/CacheConfiguration.kt
@@ -23,22 +23,22 @@ class CacheConfiguration {
   }
 
   @CacheEvict(value = [PRISON_INCENTIVE_LEVELS_CACHE_NAME])
-  @Scheduled(fixedDelay = TTL_HOURS_PRISONER_INCENTIVE_LEVELS, timeUnit = TimeUnit.HOURS)
+  @Scheduled(fixedDelay = TTL_HOURS_PRISONER_INCENTIVE_LEVELS, timeUnit = TimeUnit.DAYS)
   fun cacheEvictPrisonerIncentiveLevels() {
-    log.info("Evicting cache: $PRISON_INCENTIVE_LEVELS_CACHE_NAME after $TTL_HOURS_PRISONER_INCENTIVE_LEVELS hours")
+    log.info("Evicting cache: $PRISON_INCENTIVE_LEVELS_CACHE_NAME after $TTL_HOURS_PRISONER_INCENTIVE_LEVELS day")
   }
 
   @CacheEvict(value = [BANK_HOLIDAYS_CACHE_NAME])
-  @Scheduled(fixedDelay = TTL_HOURS_BANK_HOLIDAYS, timeUnit = TimeUnit.HOURS)
+  @Scheduled(fixedDelay = TTL_HOURS_BANK_HOLIDAYS, timeUnit = TimeUnit.DAYS)
   fun cacheEvictBankHolidays() {
-    log.info("Evicting cache: $BANK_HOLIDAYS_CACHE_NAME after $TTL_HOURS_BANK_HOLIDAYS hours")
+    log.info("Evicting cache: $BANK_HOLIDAYS_CACHE_NAME after $TTL_HOURS_BANK_HOLIDAYS days")
   }
 
   companion object {
     val log: Logger = LoggerFactory.getLogger(this::class.java)
     const val BANK_HOLIDAYS_CACHE_NAME: String = "bankHolidays"
     const val PRISON_INCENTIVE_LEVELS_CACHE_NAME: String = "prisonIncentiveLevels"
-    const val TTL_HOURS_PRISONER_INCENTIVE_LEVELS: Long = 24
-    const val TTL_HOURS_BANK_HOLIDAYS: Long = 24 * 7
+    const val TTL_HOURS_PRISONER_INCENTIVE_LEVELS: Long = 1
+    const val TTL_HOURS_BANK_HOLIDAYS: Long = 7
   }
 }


### PR DESCRIPTION
Increase the Bank Holiday Service Cache to only evict every 7 days rather than every day.

The Bank Holiday service failed during the Activity Schedule Job overnight calling the bank holiday service. As this does not change often this change will call it much less frequently and use the cached copy.

To test the same config was used, but with seconds rather than hours. You can see the output below where the 2 caches prisoner incentive and bank holidays evict at the different times.

`2024-03-25 14:33:49.121  INFO 22056 --- [           main] u.g.j.d.h.h.h.VersionOutputter$Companion : Version 2024-03-25 started |  
2024-03-25 14:34:13.055  INFO 22056 --- [   scheduling-1] g.j.d.h.h.c.CacheConfiguration$Companion : Evicting cache: prisonIncentiveLevels after 24 seconds |  
2024-03-25 14:34:37.063  INFO 22056 --- [   scheduling-1] g.j.d.h.h.c.CacheConfiguration$Companion : Evicting cache: prisonIncentiveLevels after 24 seconds |  
2024-03-25 14:35:01.071  INFO 22056 --- [   scheduling-1] g.j.d.h.h.c.CacheConfiguration$Companion : Evicting cache: prisonIncentiveLevels after 24 seconds |  
2024-03-25 14:35:25.077  INFO 22056 --- [   scheduling-1] g.j.d.h.h.c.CacheConfiguration$Companion : Evicting cache: prisonIncentiveLevels after 24 seconds |  
2024-03-25 14:35:49.085  INFO 22056 --- [   scheduling-1] g.j.d.h.h.c.CacheConfiguration$Companion : Evicting cache: prisonIncentiveLevels after 24 seconds |  
2024-03-25 14:36:13.092  INFO 22056 --- [   scheduling-1] g.j.d.h.h.c.CacheConfiguration$Companion : Evicting cache: prisonIncentiveLevels after 24 seconds |  
2024-03-25 14:36:37.056  INFO 22056 --- [   scheduling-1] g.j.d.h.h.c.CacheConfiguration$Companion : Evicting cache: bankHolidays after 168 seconds |  
2024-03-25 14:36:37.097  INFO 22056 --- [   scheduling-1] g.j.d.h.h.c.CacheConfiguration$Companion : Evicting cache: prisonIncentiveLevels after 24 seconds |  
2024-03-25 14:37:01.105  INFO 22056 --- [   scheduling-1] g.j.d.h.h.c.CacheConfiguration$Companion : Evicting cache: prisonIncentiveLevels after 24 seconds | `  