### PR TITLE
SAA-1582: Migrate activity location user description rather than the location code

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
@@ -7,7 +7,7 @@ import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.incentivesapi.api.IncentivesApiClient
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toPrisonerNumber
@@ -55,6 +55,7 @@ class MigrateActivityService(
   private val activityScheduleRepository: ActivityScheduleRepository,
   private val prisonerSearchApiClient: PrisonerSearchApiClient,
   private val incentivesApiClient: IncentivesApiClient,
+  private val prisonApiClient: PrisonApiClient,
   private val eventTierRepository: EventTierRepository,
   private val activityCategoryRepository: ActivityCategoryRepository,
   private val prisonPayBandRepository: PrisonPayBandRepository,
@@ -241,15 +242,7 @@ class MigrateActivityService(
     }.apply {
       addSchedule(
         description = this.summary,
-        internalLocation = request.internalLocationId?.let {
-          Location(
-            locationId = it,
-            internalLocationCode = request.internalLocationCode,
-            description = request.internalLocationDescription!!,
-            locationType = "N/A",
-            agencyId = request.prisonCode,
-          )
-        },
+        internalLocation = request.internalLocationId?.let { prisonApiClient.getLocation(it).block() },
         capacity = if (request.capacity == 0) 1 else request.capacity,
         startDate = this.startDate,
         endDate = this.endDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateActivityIntegrationTest.kt
@@ -65,6 +65,7 @@ class MigrateActivityIntegrationTest : IntegrationTestBase() {
 
     val requestBody = buildActivityMigrateRequest(nomisPayRates, nomisScheduleRules)
     incentivesApiMockServer.stubGetIncentiveLevels(requestBody.prisonCode)
+    prisonApiMockServer.stubGetLocation(1L, "prisonapi/location-id-1.json")
 
     val response = webTestClient.migrateActivity(requestBody, listOf("ROLE_NOMIS_ACTIVITIES"))
       .expectStatus().isOk
@@ -105,6 +106,7 @@ class MigrateActivityIntegrationTest : IntegrationTestBase() {
     )
 
     incentivesApiMockServer.stubGetIncentiveLevels(requestBody.prisonCode)
+    prisonApiMockServer.stubGetLocation(1L, "prisonapi/location-id-1.json")
 
     val response = webTestClient.migrateActivity(
       requestBody,
@@ -161,6 +163,8 @@ class MigrateActivityIntegrationTest : IntegrationTestBase() {
 
   @Test
   fun `migrate activity - invalid pay band in rates`() {
+    prisonApiMockServer.stubGetLocation(1L, "prisonapi/location-id-1.json")
+
     val nomisPayRates = listOf(
       NomisPayRate(incentiveLevel = "BAS", nomisPayBand = "12", rate = 110),
     )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
@@ -15,7 +15,10 @@ import org.mockito.kotlin.reset
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import reactor.core.publisher.Mono
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.incentivesapi.api.IncentivesApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.Location
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
@@ -60,6 +63,7 @@ class MigrateActivityServiceTest {
   private val activityScheduleRepository: ActivityScheduleRepository = mock()
   private val prisonerSearchApiClient: PrisonerSearchApiClient = mock()
   private val incentivesApiClient: IncentivesApiClient = mock()
+  private val prisonApiClient: PrisonApiClient = mock()
   private val eventTierRepository: EventTierRepository = mock()
   private val activityCategoryRepository: ActivityCategoryRepository = mock()
   private val prisonPayBandRepository: PrisonPayBandRepository = mock()
@@ -106,6 +110,7 @@ class MigrateActivityServiceTest {
     activityScheduleRepository,
     prisonerSearchApiClient,
     incentivesApiClient,
+    prisonApiClient,
     eventTierRepository,
     activityCategoryRepository,
     prisonPayBandRepository,
@@ -149,6 +154,17 @@ class MigrateActivityServiceTest {
           prisonIncentiveLevel(levelCode = "STD", levelName = "Standard"),
           prisonIncentiveLevel(levelCode = "ENH", levelName = "Enhanced"),
           prisonIncentiveLevel(levelCode = "EN2", levelName = "Enhanced 2", active = false),
+        ),
+      )
+      whenever(prisonApiClient.getLocation(1)).thenReturn(
+        Mono.just(
+          Location(
+            locationId = 1,
+            internalLocationCode = "011",
+            description = "MDI-1-1-011",
+            locationType = "N/A",
+            agencyId = "RSI",
+          ),
         ),
       )
       whenever(prisonRegimeService.getPrisonTimeSlots(any())).thenReturn(


### PR DESCRIPTION
Fixes the following: 

![image](https://github.com/ministryofjustice/hmpps-activities-management-api/assets/30229564/c2e9d3fb-6e90-490a-9fe8-46ca0fcb4b58)
