### PR TITLE
SAA-1509: Allow scheduled instances to filtered by cancelled status

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
@@ -16,12 +16,13 @@ interface ScheduledInstanceRepository : JpaRepository<ScheduledInstance, Long> {
       WHERE s.activity.prisonCode = :prisonCode 
       AND si.sessionDate >= :startDate
       AND si.sessionDate <= :endDate
-    )
+    ) AND (:cancelled is null or si.cancelled = :cancelled)
     """,
   )
   fun getActivityScheduleInstancesByPrisonCodeAndDateRange(
     prisonCode: String,
     startDate: LocalDate,
     endDate: LocalDate,
+    cancelled: Boolean? = null,
   ): List<ScheduledInstance>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceController.kt
@@ -74,11 +74,14 @@ class ActivityScheduleInstanceController(private val scheduledInstanceService: S
     @RequestParam(value = "slot")
     @Parameter(description = "The time slot (optional). If supplied, one of AM, PM or ED.")
     slot: TimeSlot?,
+    @RequestParam(value = "cancelled")
+    @Parameter(description = "Return cancelled scheduled instances?")
+    cancelled: Boolean?,
   ): List<ActivityScheduleInstance> {
     val dateRange = LocalDateRange(startDate, endDate)
     if (endDate.isAfter(startDate.plusMonths(3))) {
       throw ValidationException("Date range cannot exceed 3 months")
     }
-    return scheduledInstanceService.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, slot)
+    return scheduledInstanceService.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, slot, cancelled)
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
@@ -57,11 +57,13 @@ class ScheduledInstanceService(
     prisonCode: String,
     dateRange: LocalDateRange,
     slot: TimeSlot?,
+    cancelled: Boolean?,
   ): List<ActivityScheduleInstance> {
     val activities = repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(
       prisonCode,
       dateRange.start,
       dateRange.endInclusive,
+      cancelled,
     ).toModel()
 
     return if (slot != null) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleInstanceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleInstanceIntegrationTest.kt
@@ -184,13 +184,35 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
   inner class GetActivityScheduleInstances {
     @Test
     @Sql("classpath:test_data/seed-activity-id-3.sql")
-    fun `returns all 20 rows without the time slot`() {
+    fun `returns all 20 rows within the time slot`() {
       val startDate = LocalDate.of(2022, 10, 1)
       val endDate = LocalDate.of(2022, 11, 5)
 
       val scheduledInstances = webTestClient.getScheduledInstancesBy(MOORLAND_PRISON_CODE, startDate, endDate)
 
       assertThat(scheduledInstances).hasSize(20)
+    }
+
+    @Test
+    @Sql("classpath:test_data/seed-activity-id-3.sql")
+    fun `returns 18 rows within the time slot ignoring cancelled instances`() {
+      val startDate = LocalDate.of(2022, 10, 1)
+      val endDate = LocalDate.of(2022, 11, 5)
+
+      val scheduledInstances = webTestClient.getScheduledInstancesBy(MOORLAND_PRISON_CODE, startDate, endDate, null, false)
+
+      assertThat(scheduledInstances).hasSize(18)
+    }
+
+    @Test
+    @Sql("classpath:test_data/seed-activity-id-3.sql")
+    fun `returns 2 rows within the time slot for only cancelled instances`() {
+      val startDate = LocalDate.of(2022, 10, 1)
+      val endDate = LocalDate.of(2022, 11, 5)
+
+      val scheduledInstances = webTestClient.getScheduledInstancesBy(MOORLAND_PRISON_CODE, startDate, endDate, null, true)
+
+      assertThat(scheduledInstances).hasSize(2)
     }
 
     @Test
@@ -509,6 +531,7 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
     startDate: LocalDate,
     endDate: LocalDate,
     timeSlot: TimeSlot? = null,
+    cancelled: Boolean? = null,
   ) =
     get()
       .uri { builder ->
@@ -517,6 +540,7 @@ class ActivityScheduleInstanceIntegrationTest : IntegrationTestBase() {
           .queryParam("startDate", startDate)
           .queryParam("endDate", endDate)
           .maybeQueryParam("slot", timeSlot)
+          .maybeQueryParam("cancelled", cancelled)
           .build()
       }
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityScheduleInstanceControllerTest.kt
@@ -37,10 +37,11 @@ class ActivityScheduleInstanceControllerTest : ControllerTestBase<ActivitySchedu
         "MDI",
         LocalDateRange(startDate, endDate),
         TimeSlot.AM,
+        true,
       ),
     ).thenReturn(results)
 
-    val response = mockMvc.getPrisonerScheduledInstances("MDI", startDate, endDate, TimeSlot.AM)
+    val response = mockMvc.getPrisonerScheduledInstances("MDI", startDate, endDate, TimeSlot.AM, true)
       .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
       .andExpect { status { isOk() } }
       .andReturn().response
@@ -51,6 +52,7 @@ class ActivityScheduleInstanceControllerTest : ControllerTestBase<ActivitySchedu
       "MDI",
       LocalDateRange(startDate, endDate),
       TimeSlot.AM,
+      true,
     )
   }
 
@@ -169,6 +171,6 @@ class ActivityScheduleInstanceControllerTest : ControllerTestBase<ActivitySchedu
       }
   }
 
-  private fun MockMvc.getPrisonerScheduledInstances(prisonCode: String, startDate: LocalDate, endDate: LocalDate, slot: TimeSlot) =
-    get("/prisons/$prisonCode/scheduled-instances?startDate=$startDate&endDate=$endDate&slot=$slot")
+  private fun MockMvc.getPrisonerScheduledInstances(prisonCode: String, startDate: LocalDate, endDate: LocalDate, slot: TimeSlot, cancelled: Boolean) =
+    get("/prisons/$prisonCode/scheduled-instances?startDate=$startDate&endDate=$endDate&slot=$slot&cancelled=$cancelled")
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.reset
@@ -151,7 +152,7 @@ class ManageAttendancesServiceTest {
 
     instance.activitySchedule.activity.attendanceRequired = true
 
-    whenever(scheduledInstanceRepository.getActivityScheduleInstancesByPrisonCodeAndDateRange(any(), any(), any())) doReturn listOf(instance)
+    whenever(scheduledInstanceRepository.getActivityScheduleInstancesByPrisonCodeAndDateRange(any(), any(), any(), isNull())) doReturn listOf(instance)
     whenever(prisonerSearchApiClient.findByPrisonerNumbersMap(anyList())) doReturn listOf(PrisonerSearchPrisonerFixture.instance(prisonerNumber = "A1234AA")).associateBy { it.prisonerNumber }
 
     service.createAttendances(today, MOORLAND_PRISON_CODE)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
@@ -85,38 +85,57 @@ class ScheduledInstanceServiceTest {
   @Nested
   @DisplayName("getActivityScheduleInstancesByDateRange")
   inner class GetActivityScheduleInstancesByDateRange {
+    val prisonCode = "MDI"
+    val startDate = LocalDate.of(2022, 10, 1)
+    val endDate = LocalDate.of(2022, 11, 5)
+    val dateRange = LocalDateRange(startDate, endDate)
+
     @Test
     fun `get instances by date range - success`() {
-      val prisonCode = "MDI"
-      val startDate = LocalDate.of(2022, 10, 1)
-      val endDate = LocalDate.of(2022, 11, 5)
-      val dateRange = LocalDateRange(startDate, endDate)
-
-      whenever(repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(prisonCode, startDate, endDate))
+      whenever(repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(prisonCode, startDate, endDate, null))
         .thenReturn(listOf(ScheduledInstanceFixture.instance(id = 1, locationId = 22)))
 
-      val result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, null)
+      val result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, null, null)
 
       assertThat(result).hasSize(1)
     }
 
     @Test
     fun `filtered by time slot`() {
-      val prisonCode = "MDI"
-      val startDate = LocalDate.of(2022, 10, 1)
-      val endDate = LocalDate.of(2022, 11, 5)
-      val dateRange = LocalDateRange(startDate, endDate)
-
-      whenever(repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(prisonCode, startDate, endDate))
+      whenever(repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(prisonCode, startDate, endDate, null))
         .thenReturn(listOf(ScheduledInstanceFixture.instance(id = 1, locationId = 22)))
 
-      var result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, TimeSlot.PM)
+      var result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, TimeSlot.PM, null)
       assertThat(result).hasSize(1)
 
-      result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, TimeSlot.AM)
+      result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, TimeSlot.AM, null)
       assertThat(result).isEmpty()
 
-      result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, TimeSlot.ED)
+      result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, TimeSlot.ED, null)
+      assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `filtered for cancelled instances`() {
+      whenever(repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(prisonCode, startDate, endDate, true))
+        .thenReturn(listOf(ScheduledInstanceFixture.instance(id = 1, locationId = 22)))
+
+      var result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, null, true)
+      assertThat(result).hasSize(1)
+
+      result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, null, false)
+      assertThat(result).isEmpty()
+    }
+
+    @Test
+    fun `filtered for non-cancelled instances`() {
+      whenever(repository.getActivityScheduleInstancesByPrisonCodeAndDateRange(prisonCode, startDate, endDate, false))
+        .thenReturn(listOf(ScheduledInstanceFixture.instance(id = 1, locationId = 22)))
+
+      var result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, null, false)
+      assertThat(result).hasSize(1)
+
+      result = service.getActivityScheduleInstancesByDateRange(prisonCode, dateRange, null, true)
       assertThat(result).isEmpty()
     }
   }

--- a/src/test/resources/test_data/seed-activity-id-3.sql
+++ b/src/test/resources/test_data/seed-activity-id-3.sql
@@ -167,10 +167,10 @@ insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, sess
 values (18, 4, '2022-11-03', '13:00:00', '16:30:00', false, null, null);
 
 insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by)
-values (19, 4, '2022-11-04', '13:00:00', '16:30:00', false, null, null);
+values (19, 4, '2022-11-04', '13:00:00', '16:30:00', true, current_timestamp, 'ABC123');
 
 insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by)
-values (20, 4, '2022-11-05', '13:00:00', '16:30:00', false, null, null);
+values (20, 4, '2022-11-05', '13:00:00', '16:30:00', true, current_timestamp, 'ABC123');
 
 insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by)
 values (21, 5, '2022-10-10', '10:00:00', '11:00:00', false, null, null);


### PR DESCRIPTION
For daily attendance summary the UI retrieves all scheduled instances and filters them to leave the cancelled ones.  This means that we get a bad N+1 JPA effect and the UI can time out  as it waits for the API. We can shift the logic to the repo so only the cancelled scheduled instances are retrieved which will make the UI more responsive.