### PR TITLE
SAA-1656 create retrospective appointments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSeriesCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSeriesCreateRequest.kt
@@ -4,14 +4,12 @@ import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.Valid
 import jakarta.validation.constraints.AssertTrue
-import jakarta.validation.constraints.FutureOrPresent
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AppointmentSeriesSchedule
 import java.time.LocalDate
-import java.time.LocalDateTime
 import java.time.LocalTime
 
 @Schema(
@@ -101,7 +99,6 @@ data class AppointmentSeriesCreateRequest(
   val inCell: Boolean,
 
   @field:NotNull(message = "Start date must be supplied")
-  @field:FutureOrPresent(message = "Start date must not be in the past")
   @Schema(
     description = "The date of the first appointment in the series",
   )
@@ -153,9 +150,9 @@ data class AppointmentSeriesCreateRequest(
   @AssertTrue(message = "Internal location id must be supplied if in cell = false")
   private fun isInternalLocationId() = inCell || internalLocationId != null
 
-  @AssertTrue(message = "Start time must be in the future")
-  private fun isStartTime() = startDate == null || startTime == null || startDate < LocalDate.now() || LocalDateTime.of(startDate, startTime) > LocalDateTime.now()
-
   @AssertTrue(message = "End time must be after the start time")
   private fun isEndTime() = startTime == null || endTime == null || endTime > startTime
+
+  @AssertTrue(message = "Start date must not be more than 5 days ago")
+  private fun isStartDate() = startDate == null || startDate > LocalDate.now().minusDays(6)
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSeriesCreateRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSeriesCreateRequestTest.kt
@@ -52,21 +52,15 @@ class AppointmentSeriesCreateRequestTest {
   }
 
   @Test
-  fun `start date must not be in the past`() {
-    val request = appointmentSeriesCreateRequest(startDate = LocalDate.now().minusDays(1))
-    assertSingleValidationError(validator.validate(request), "startDate", "Start date must not be in the past")
-  }
-
-  @Test
   fun `start time must be supplied`() {
     val request = appointmentSeriesCreateRequest(startTime = null)
     assertSingleValidationError(validator.validate(request), "startTime", "Start time must be supplied")
   }
 
   @Test
-  fun `start time must be in the future`() {
+  fun `start time can be in the past`() {
     val request = appointmentSeriesCreateRequest(startDate = LocalDate.now(), startTime = LocalTime.now().minusMinutes(1), endTime = LocalTime.now().plusHours(1))
-    assertSingleValidationError(validator.validate(request), "startTime", "Start time must be in the future")
+    assertThat(validator.validate(request)).isEmpty()
   }
 
   @Test
@@ -130,6 +124,24 @@ class AppointmentSeriesCreateRequestTest {
       validator.validate(request),
       "tierCode",
       "Tier code must be supplied",
+    )
+  }
+
+  @Test
+  fun `appointment series can be created 5 days in the past`() {
+    val startDate = LocalDate.now().minusDays(5)
+    val request = appointmentSeriesCreateRequest(startDate = startDate)
+    assertThat(validator.validate(request)).isEmpty()
+  }
+
+  @Test
+  fun `appointment series cannot be created 6 days in the past`() {
+    val startDate = LocalDate.now().minusDays(6)
+    val request = appointmentSeriesCreateRequest(startDate = startDate)
+    assertSingleValidationError(
+      validator.validate(request),
+      "startDate",
+      "Start date must not be more than 5 days ago",
     )
   }
 


### PR DESCRIPTION
Change the create an appointment request API to allow retrospective appointments to be created. The API now allows appointments to be created for 5 days in the past. 