### PR TITLE
SAA-1688: Correct Activity Attendance Editing to Match NOMIS Constraints

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -213,9 +213,9 @@ data class Attendance(
    Attendance is editable if:
    1. It has not been marked, and we are within 14 days of the session date.
    2. It has been marked, we are within 7 days of the session date and one of the following:
-      (i) It has been marked as unattended
-      (ii) It has been marked with an unpaid reason
-      (iii) It has been marked with a paid or unpaid reason AND it was marked today
+      (i) It has been marked as unattended, unpaid
+      (ii) It has been marked unattended, paid AND it was marked today
+      (iii) It has been marked attended AND it was marked today
    */
   fun editable(): Boolean {
     return (

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -210,25 +210,29 @@ data class Attendance(
   }
 
   /*
-   Very simple rules for editable attendance initially. Attendance is editable if :
+   Attendance is editable if:
    1. It has not been marked, and we are within 14 days of the session date.
-   2. It has been marked (paid or unpaid) and today is the date of the session.
-   3. It has been marked with an unpaid reason, and we are within 14 days of the session date.
-   4. It has been marked with a paid reason, it was marked today, and we are within 14 days of the session date.
+   2. It has been marked, we are within 7 days of the session date and one of the following:
+      (i) It has been marked as unattended
+      (ii) It has been marked with an unpaid reason
+      (iii) It has been marked with a paid or unpaid reason AND it was marked today
    */
   fun editable(): Boolean {
     return (
-      this.status() == AttendanceStatus.WAITING &&
-        this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(14)) ||
-        this.status == AttendanceStatus.COMPLETED &&
-        this.scheduledInstance.sessionDate.isEqual(LocalDate.now()) ||
-        this.status == AttendanceStatus.COMPLETED &&
-        this.issuePayment == false &&
-        this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(14)) ||
-        this.status == AttendanceStatus.COMPLETED &&
-        this.issuePayment == true &&
-        this.recordedTime!!.isAfter(LocalDate.now().atStartOfDay()) &&
-        this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(14))
+      (
+        this.status() == AttendanceStatus.WAITING &&
+          this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(14))
+        ) ||
+        (
+          this.status == AttendanceStatus.COMPLETED &&
+            this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(7)) &&
+            (
+              (
+                this.attendanceReason?.attended == false && this.issuePayment == false
+                ) ||
+                this.recordedTime!!.isAfter(LocalDate.now().atStartOfDay().minusSeconds(1))
+              )
+          )
       )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -211,11 +211,10 @@ data class Attendance(
 
   /*
    Attendance is editable if:
-   1. It has not been marked, and we are within 14 days of the session date.
-   2. It has been marked, we are within 7 days of the session date and one of the following:
-      (i) It has been marked as unattended, unpaid
-      (ii) It has been marked unattended, paid AND it was marked today
-      (iii) It has been marked attended AND it was marked today
+   1. If no attendance has been recorded AND it is within 14 days of the activity session date.
+   2. If attendance is Not Attended & Unpaid AND it is within 7 days of the activity session date.
+   3. If attendance is Attended AND it is the same day as the attendance was set as Attended.
+   4. If attendance is Not Attended & Paid AND it is the same day as the paid attendance was set.
    */
   fun editable(): Boolean {
     return (
@@ -230,7 +229,7 @@ data class Attendance(
               (
                 this.attendanceReason?.attended == false && this.issuePayment == false
                 ) ||
-                this.recordedTime!!.isAfter(LocalDate.now().atStartOfDay().minusSeconds(1))
+                (this.recordedTime!!.isAfter(LocalDate.now().atStartOfDay()) || this.recordedTime!!.isEqual(LocalDate.now().atStartOfDay()))
               )
           )
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceSuspensionDomainServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceSuspensionDomainServiceTest.kt
@@ -90,6 +90,7 @@ class AttendanceSuspensionDomainServiceTest {
         },
         attendanceReason = attendanceReasons()["ATTENDED"],
         prisonerNumber = "123456",
+        recordedTime = LocalDateTime.now(),
       )
 
       val suspendedAttendance = Attendance(
@@ -101,6 +102,7 @@ class AttendanceSuspensionDomainServiceTest {
         },
         attendanceReason = attendanceReasons()["SUSPENDED"],
         prisonerNumber = "123456",
+        recordedTime = LocalDateTime.now(),
       )
 
       whenever(
@@ -126,6 +128,7 @@ class AttendanceSuspensionDomainServiceTest {
           on { sessionDate } doReturn LocalDate.now().minusDays(1)
         },
         prisonerNumber = "123456",
+        recordedTime = LocalDateTime.now().minusDays(1),
       )
 
       val nonSuspended = Attendance(
@@ -137,6 +140,7 @@ class AttendanceSuspensionDomainServiceTest {
         },
         attendanceReason = attendanceReasons()["ATTENDED"],
         prisonerNumber = "123456",
+        recordedTime = LocalDateTime.now(),
       )
 
       val suspendedAttendance = Attendance(
@@ -148,6 +152,7 @@ class AttendanceSuspensionDomainServiceTest {
         },
         attendanceReason = attendanceReasons()["AUTO_SUSPENDED"],
         prisonerNumber = "123456",
+        recordedTime = LocalDateTime.now(),
       )
 
       whenever(
@@ -179,6 +184,7 @@ class AttendanceSuspensionDomainServiceTest {
         },
         attendanceReason = attendanceReasons()["SUSPENDED"],
         prisonerNumber = "123456",
+        recordedTime = LocalDateTime.now(),
       )
 
       whenever(
@@ -210,6 +216,7 @@ class AttendanceSuspensionDomainServiceTest {
         },
         attendanceReason = attendanceReasons()["AUTO_SUSPENDED"],
         prisonerNumber = "123456",
+        recordedTime = LocalDateTime.now(),
       )
 
       whenever(


### PR DESCRIPTION
Implement the following rules on when attendance has can be recorded/changed:

If attendance has been recorded as attended or not attended & paid, stop any changes after the day the attendance was recorded
If attendance has been recorded as not attended & unpaid, changes can only be made for 7 days after the activity date
If attendance has not been recorded, the user can record attendance up to 14 days after the activity date