### PR TITLE
SAA-1655: Add max days to expiry to regime endpoint DTO

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/PrisonRegime.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/PrisonRegime.kt
@@ -37,4 +37,6 @@ data class PrisonRegime(
   @JsonFormat(pattern = "HH:mm")
   val edFinish: LocalTime,
 
+  @Schema(description = "The maximum number of days to expiry", example = "21")
+  val maxDaysToExpiry: Int,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -429,6 +429,7 @@ fun transform(prisonRegime: EntityPrisonRegime) = ModelPrisonRegime(
   pmFinish = prisonRegime.pmFinish,
   edStart = prisonRegime.edStart,
   edFinish = prisonRegime.edFinish,
+  maxDaysToExpiry = prisonRegime.maxDaysToExpiry,
 )
 
 fun transform(entityEventReview: EventReview) = ModelEventReview(


### PR DESCRIPTION
This is so the UI can determine that the prisoner's movement where they have left the prison occurred `x` days ago depending on the prison's `maxDaysToExpiry` value.