### PR TITLE
Revert "Update plugin io.sentry.jvm.gradle to v4.6.0"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,7 @@ plugins {
   kotlin("plugin.jpa") version "1.9.24"
   jacoco
   id("org.openapi.generator") version "7.5.0"
-  id("io.sentry.jvm.gradle") version "4.6.0"
+  id("io.sentry.jvm.gradle") version "4.5.1"
 }
 
 allOpen {


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-activities-management-api#881 because deploy [is broken](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-activities-management-api/4891/workflows/27343d50-1122-4087-8f4b-7a44cafdd3d0/jobs/17014?invite=true#step-114-5573_142)