### PR TITLE
Fix issue whereby suggested example timeslots on the appts search end…

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
@@ -53,7 +53,7 @@ data class AppointmentSearchRequest(
     The time slot to match with the appointments. Will restrict the search results to appointments that have a start
     time between the times defined by the prison for that time slot when this search parameter is supplied.
     """,
-    example = "PM",
+    example = “[\”AM\”,\”PM\”,\”ED\”]”,
   )
   val timeSlots: List<TimeSlot>? = emptyList(),
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
@@ -53,7 +53,7 @@ data class AppointmentSearchRequest(
     The time slot to match with the appointments. Will restrict the search results to appointments that have a start
     time between the times defined by the prison for that time slot when this search parameter is supplied.
     """,
-    example = “[\”AM\”,\”PM\”,\”ED\”]”,
+    example = "[\"AM\",\"PM\",\"ED\"]",
   )
   val timeSlots: List<TimeSlot>? = emptyList(),
 


### PR DESCRIPTION
…point is invalid (not a list)

Also, add the other valid options for timeslots