### PR TITLE
Revert "Update plugin org.jetbrains.kotlin.plugin.spring to v2"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
       name: hmpps/java
       tag: << pipeline.parameters.java-version >>
     environment:
-      _JAVA_OPTIONS: -Xmx2048m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
+      _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:
       - checkout
       - restore_cache:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import org.openapitools.generator.gradle.plugin.tasks.GenerateTask
 
 plugins {
   id("uk.gov.justice.hmpps.gradle-spring-boot") version "5.15.6"
-  kotlin("plugin.spring") version "2.0.0"
+  kotlin("plugin.spring") version "1.9.24"
   kotlin("plugin.jpa") version "1.9.24"
   jacoco
   id("org.openapi.generator") version "7.5.0"


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-activities-management-api#890

Fails to build Docker image as [out of mem](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-activities-management-api/4921/workflows/9dc0107d-aa11-4b4b-8c6d-ec7ee330c225/jobs/17137?invite=true#step-111-21903_75)