### PR TITLE
SAA-1751: replace h2 with test containers postgres for integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ parameters:
   java-version:
     type: string
     default: "21.0"
+  postgres-version:
+    type: string
+    default: "14"
 
 jobs:
   validate:
@@ -21,7 +24,7 @@ jobs:
       name: hmpps/java
       tag: << pipeline.parameters.java-version >>
     environment:
-      _JAVA_OPTIONS: -Xmx512m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
+      _JAVA_OPTIONS: -Xmx2048m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
     steps:
       - checkout
       - restore_cache:
@@ -45,8 +48,12 @@ jobs:
 
   integration-test:
     executor:
-      name: hmpps/java
-      tag: << pipeline.parameters.java-version >>
+      name: hmpps/java_postgres
+      jdk_tag: << pipeline.parameters.java-version >>
+      postgres_tag: << pipeline.parameters.postgres-version >>
+      postgres_db: "activities"
+      postgres_username: "activities"
+      postgres_password: "activities"
     resource_class: medium+
     environment:
       _JAVA_OPTIONS: -Xmx2048m -XX:ParallelGCThreads=2 -XX:ConcGCThreads=2 -Djava.util.concurrent.ForkJoinPool.common.parallelism=2 -Dorg.gradle.daemon=false -Dkotlin.compiler.execution.strategy=in-process
@@ -56,6 +63,7 @@ jobs:
           keys:
             - gradle-{{ checksum "build.gradle.kts" }}
             - gradle-
+      - hmpps/wait_till_ready_postgres
       - run:
           command: ./gradlew integrationTest
       - save_cache:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,7 +54,8 @@ dependencies {
 
   // Test dependencies
   testImplementation("org.wiremock:wiremock-standalone:3.5.4")
-  testImplementation("com.h2database:h2")
+  testImplementation("org.springframework.boot:spring-boot-testcontainers")
+  testImplementation("org.testcontainers:postgresql")
   testImplementation("io.jsonwebtoken:jjwt-impl:0.12.5")
   testImplementation("io.jsonwebtoken:jjwt-jackson:0.12.5")
   testImplementation("org.mockito:mockito-inline:5.2.0")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
 
 import net.javacrumbs.jsonunit.assertj.assertThatJson
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.tuple
 import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.argumentCaptor
@@ -108,18 +109,14 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
     )
 
     val response = webTestClient.getAllocationsBy(1, includePrisonerSummary = true)!!
-      .also { assertThat(it).hasSize(2) }
 
-    response[0].let {
-      assertThat(it.prisonerName).isEqualTo("Joe Harrison")
-      assertThat(it.cellLocation).isEqualTo("1-2-3")
-      assertThat(it.earliestReleaseDate).isEqualTo(EarliestReleaseDate(LocalDate.now()))
-    }
-    response[1].let {
-      assertThat(it.prisonerName).isEqualTo("Tim Harrison")
-      assertThat(it.cellLocation).isEqualTo("1-2-3")
-      assertThat(it.earliestReleaseDate).isEqualTo(EarliestReleaseDate(LocalDate.now().plusDays(1)))
-    }
+    // response will be in random order
+    assertThat(response)
+      .extracting(Allocation::prisonerName, Allocation::cellLocation, Allocation::earliestReleaseDate)
+      .containsOnly(
+        tuple("Tim Harrison", "1-2-3", EarliestReleaseDate(LocalDate.now().plusDays(1))),
+        tuple("Joe Harrison", "1-2-3", EarliestReleaseDate(LocalDate.now())),
+      )
   }
 
   @Sql(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentIntegrationTest.kt
@@ -832,13 +832,8 @@ class AppointmentIntegrationTest : IntegrationTestBase() {
     verify(eventsPublisher, times(12)).send(eventCaptor.capture())
 
     with(eventCaptor.allValues.filter { it.eventType == "appointments.appointment-instance.updated" }) {
-      size isEqualTo 12
-      assertThat(map { it.additionalInformation }).containsExactlyElementsOf(
-        // The update events for the specified appointment's instances are sent first
-        appointmentSeries.appointments.single { it.id == appointmentId }.attendees.map { AppointmentInstanceInformation(it.id) }
-          // Followed by the update events for the remaining instances
-          .union(appointmentSeries.appointments.filter { it.id != appointmentId }.flatMap { it.attendees }.map { AppointmentInstanceInformation(it.id) }),
-      )
+      assertThat(map { it.additionalInformation })
+        .hasSameElementsAs(appointmentSeries.appointments.flatMap { it.attendees }.map { AppointmentInstanceInformation(it.id) })
     }
 
     verifyNoMoreInteractions(eventsPublisher)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentJobIntegrationTest.kt
@@ -18,6 +18,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.daysAgo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.RISLEY_PRISON_CODE
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.containsExactlyInAnyOrder
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.movement
@@ -118,7 +119,7 @@ class AppointmentJobIntegrationTest : IntegrationTestBase() {
 
     with(webTestClient.getAppointmentSeriesById(1)!!.appointments.filterNot { it.isDeleted }) {
       flatMap { it.attendees } hasSize 7
-      single { it.id == 1L }.attendees.map { it.prisonerNumber } isEqualTo listOf(prisonNumber, "B2345CD")
+      single { it.id == 1L }.attendees.map { it.prisonerNumber } containsExactlyInAnyOrder listOf(prisonNumber, "B2345CD")
       filterNot { it.id == 1L }.flatMap { it.attendees }.map { it.prisonerNumber }.toSet() isEqualTo setOf("B2345CD")
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationTestBase.kt
@@ -13,12 +13,15 @@ import org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDO
 import org.springframework.http.HttpHeaders
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.DynamicPropertyRegistry
+import org.springframework.test.context.DynamicPropertySource
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.context.jdbc.SqlMergeMode
 import org.springframework.test.web.reactive.server.WebTestClient
 import org.springframework.web.util.UriBuilder
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.InmateDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.health.JwtAuthHelper
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.config.PostgresContainer
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.wiremock.BankHolidayApiExtension
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.wiremock.CaseNotesApiMockServer
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.wiremock.IncentivesApiMockServer
@@ -58,6 +61,17 @@ abstract class IntegrationTestBase {
     internal val nonAssociationsApiMockServer = NonAssociationsApiMockServer()
     internal val caseNotesApiMockServer = CaseNotesApiMockServer()
     internal val incentivesApiMockServer = IncentivesApiMockServer()
+    internal val db = PostgresContainer.instance
+
+    @JvmStatic
+    @DynamicPropertySource
+    fun properties(registry: DynamicPropertyRegistry) {
+      db?.run {
+        registry.add("spring.datasource.url", db::getJdbcUrl)
+        registry.add("spring.datasource.username", db::getUsername)
+        registry.add("spring.datasource.password", db::getPassword)
+      }
+    }
 
     @BeforeAll
     @JvmStatic

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/config/FeatureSwitchesTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/config/FeatureSwitchesTest.kt
@@ -1,19 +1,18 @@
-package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.config
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.TestPropertySource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.Feature
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.FeatureSwitches
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.InboundEventType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-@ActiveProfiles("test")
-class FeatureSwitchesTest {
+class FeatureSwitchesTest : IntegrationTestBase() {
 
   @TestPropertySource(
     properties = [

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/config/PostgresContainer.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/config/PostgresContainer.kt
@@ -1,0 +1,39 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.config
+
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.containers.wait.strategy.Wait
+import java.io.IOException
+import java.net.ServerSocket
+
+object PostgresContainer {
+  val instance: PostgreSQLContainer<Nothing>? by lazy { startPostgresqlContainer() }
+
+  private fun startPostgresqlContainer(): PostgreSQLContainer<Nothing>? {
+    if (isPostgresRunning()) {
+      log.warn("Using existing Postgres database")
+      return null
+    }
+    log.info("Creating a Postgres database")
+    return PostgreSQLContainer<Nothing>("postgres:14").apply {
+      withEnv("HOSTNAME_EXTERNAL", "localhost")
+      withDatabaseName("activities")
+      withUsername("activities")
+      withPassword("activities")
+      setWaitStrategy(Wait.forListeningPort())
+      withReuse(true)
+
+      start()
+    }
+  }
+
+  private fun isPostgresRunning(): Boolean =
+    try {
+      val serverSocket = ServerSocket(5432)
+      serverSocket.localPort == 0
+    } catch (e: IOException) {
+      true
+    }
+
+  private val log = LoggerFactory.getLogger(this::class.java)
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/entity/AuditableEntityListenerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/entity/AuditableEntityListenerTest.kt
@@ -1,4 +1,4 @@
-package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.entity
 
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
@@ -10,13 +10,13 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.test.context.ActiveProfiles
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AuditableEntityListener
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.enumeration.ServiceName
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.IntegrationTestBase
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.ActivityCreatedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.audit.PrisonerDeallocatedEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AuditService
@@ -26,10 +26,8 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.clearCasel
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.MOCK)
-@ActiveProfiles("test")
 @ExtendWith(FakeSecurityContext::class)
-class AuditableEntityListenerTest(@Autowired private val listener: AuditableEntityListener) {
+class AuditableEntityListenerTest(@Autowired private val listener: AuditableEntityListener) : IntegrationTestBase() {
 
   @MockBean
   private lateinit var auditService: AuditService

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -16,16 +16,16 @@ spring:
         generate_statistics: false
 
   datasource:
-    url: 'jdbc:h2:mem:activities-db;MODE=PostgreSQL'
+    url: jdbc:postgresql://localhost:5432/activities
     username: activities
-    password: dummy
+    password: activities
+    hikari:
+      minimumIdle: 2
+      maximumPoolSize: 20
+      idleTimeout: 5000
 
   flyway:
     locations: classpath:/migrations/common
-
-  h2:
-    console:
-      enabled: true
 
 server:
   shutdown: immediate

--- a/src/test/resources/test_data/clean-all-data.sql
+++ b/src/test/resources/test_data/clean-all-data.sql
@@ -1,41 +1,37 @@
-SET REFERENTIAL_INTEGRITY FALSE;
-
 --Common
-truncate table event_tier restart identity;
-truncate table event_organiser restart identity;
-
---Activities
-truncate table activity_category restart identity;
-truncate table eligibility_rule restart identity;
-truncate table rollout_prison restart identity;
-truncate table attendance restart identity;
-truncate table attendance_reason restart identity;
-truncate table scheduled_instance restart identity;
-truncate table activity_schedule_suspension restart identity;
-truncate table allocation restart identity;
-truncate table planned_deallocation restart identity;
-truncate table activity_pay restart identity;
-truncate table activity_minimum_education_level restart identity;
-truncate table activity_schedule restart identity;
-truncate table activity_schedule_slot restart identity;
-truncate table activity_eligibility restart identity;
-truncate table eligibility_rule restart identity;
-truncate table activity restart identity;
-truncate table exclusion restart identity;
-truncate table prison_pay_band restart identity;
-truncate table prison_regime restart identity;
-truncate table event_review restart identity;
-truncate table attendance_history restart identity;
-truncate table waiting_list restart identity;
-truncate table local_audit restart identity;
-truncate table planned_suspension restart identity;
+truncate table event_tier restart identity cascade;
+truncate table event_organiser restart identity cascade;
+--
+-- --Activities
+truncate table activity_category restart identity cascade;
+truncate table eligibility_rule restart identity cascade;
+truncate table rollout_prison restart identity cascade;
+truncate table attendance restart identity cascade;
+truncate table attendance_reason restart identity cascade;
+truncate table scheduled_instance restart identity cascade;
+truncate table activity_schedule_suspension restart identity cascade;
+truncate table allocation restart identity cascade;
+truncate table planned_deallocation restart identity cascade;
+truncate table activity_pay restart identity cascade;
+truncate table activity_minimum_education_level restart identity cascade;
+truncate table activity_schedule restart identity cascade;
+truncate table activity_schedule_slot restart identity cascade;
+truncate table activity_eligibility restart identity cascade;
+truncate table eligibility_rule restart identity cascade;
+truncate table activity restart identity cascade;
+truncate table exclusion restart identity cascade;
+truncate table prison_pay_band restart identity cascade;
+truncate table prison_regime restart identity cascade;
+truncate table event_review restart identity cascade;
+truncate table attendance_history restart identity cascade;
+truncate table waiting_list restart identity cascade;
+truncate table local_audit restart identity cascade;
+truncate table planned_suspension restart identity cascade;
 
 --Appointments
-truncate table appointment_attendee restart identity;
-truncate table appointment restart identity;
-truncate table appointment_series_schedule restart identity;
-truncate table appointment_series restart identity;
-truncate table appointment_set_appointment_series restart identity;
-truncate table appointment_set restart identity;
-
-SET REFERENTIAL_INTEGRITY TRUE;
+truncate table appointment_attendee restart identity cascade;
+truncate table appointment restart identity cascade;
+truncate table appointment_series_schedule restart identity cascade;
+truncate table appointment_series restart identity cascade;
+truncate table appointment_set_appointment_series restart identity cascade;
+truncate table appointment_set restart identity cascade;

--- a/src/test/resources/test_data/event-review-data.sql
+++ b/src/test/resources/test_data/event-review-data.sql
@@ -1,48 +1,48 @@
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data, event_description)
-values (1L, 'myservice', 'event-name', '2023-5-10 10:20:00', 'MDI', 'G1234DX', 1, 'aaaaaaa', null);
+values (1, 'myservice', 'event-name', '2023-5-10 10:20:00', 'MDI', 'G1234DX', 1, 'aaaaaaa', null);
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data, event_description)
-values (2L, 'myservice', 'event-name', '2023-5-10 10:21:00', 'MDI', 'G1234DY', 1, 'aaaaaaa', 'TEMPORARY_RELEASE');
+values (2, 'myservice', 'event-name', '2023-5-10 10:21:00', 'MDI', 'G1234DY', 1, 'aaaaaaa', 'TEMPORARY_RELEASE');
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (3L, 'myservice', 'event-name', '2023-5-10 10:22:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
+values (3, 'myservice', 'event-name', '2023-5-10 10:22:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (4L, 'myservice', 'event-name', '2023-5-10 10:23:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
+values (4, 'myservice', 'event-name', '2023-5-10 10:23:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (5L, 'myservice', 'event-name', '2023-5-10 10:24:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
+values (5, 'myservice', 'event-name', '2023-5-10 10:24:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number,booking_id,	event_data)
-values (6L, 'myservice', 'event-name', '2023-5-10 10:25:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
+values (6, 'myservice', 'event-name', '2023-5-10 10:25:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (7L, 'myservice', 'event-name', '2023-5-10 10:26:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
+values (7, 'myservice', 'event-name', '2023-5-10 10:26:00', 'MDI', 'G1234DD', 1, 'aaaaaaa');
 
 -- Different prisoner below
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (8L, 'myservice', 'event-name', '2023-5-10 10:27:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
+values (8, 'myservice', 'event-name', '2023-5-10 10:27:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (9L, 'myservice', 'event-name', '2023-5-10 10:28:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
+values (9, 'myservice', 'event-name', '2023-5-10 10:28:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (10L, 'myservice', 'event-name', '2023-5-10 10:29:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
+values (10, 'myservice', 'event-name', '2023-5-10 10:29:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (11L, 'myservice', 'event-name', '2023-5-10 10:30:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
+values (11, 'myservice', 'event-name', '2023-5-10 10:30:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
 
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (12L, 'myservice', 'event-name', '2023-5-10 10:31:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
+values (12, 'myservice', 'event-name', '2023-5-10 10:31:00', 'MDI', 'A1234AA', 1, 'aaaaaaa');
 
 -- ACKNOWLEDGED
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data, acknowledged_time, acknowledged_by)
-values (13L, 'myservice', 'event-name', '2023-5-10 10:32:00', 'MDI', 'A1234AA', 1, 'aaaaaaa', '2023-5-11 10:29:00', 'YYY');
+values (13, 'myservice', 'event-name', '2023-5-10 10:32:00', 'MDI', 'A1234AA', 1, 'aaaaaaa', '2023-5-11 10:29:00', 'YYY');
 
 -- Different date
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (14L, 'myservice', 'event-name', '2023-5-11 11:30:01', 'MDI', 'G1234DD', 1, 'aaaaaaa');
+values (14, 'myservice', 'event-name', '2023-5-11 11:30:01', 'MDI', 'G1234DD', 1, 'aaaaaaa');
 
 -- Different date
 insert into event_review (event_review_id, service_identifier, event_type, event_time, prison_code, prisoner_number, booking_id, event_data)
-values (15L, 'myservice', 'event-name', '2023-5-11 11:31:02', 'MDI', 'G1234DD', 1, 'aaaaaaa');
+values (15, 'myservice', 'event-name', '2023-5-11 11:31:02', 'MDI', 'G1234DD', 1, 'aaaaaaa');

--- a/src/test/resources/test_data/seed-activity-id-11.sql
+++ b/src/test/resources/test_data/seed-activity-id-11.sql
@@ -2,7 +2,7 @@
 -- Test data for activity offender deallocation for an activity ending today.  Note one allocation is already ended, 3 are not.  This is to ensure it does not try end it again.
 --
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 2, current_date - 1, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_timestamp - interval '2 day', current_timestamp - interval '1 day', 'high', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
@@ -11,19 +11,19 @@ insert into activity_minimum_education_level(activity_minimum_education_level_id
 values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date)
-values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date - 2, current_date - 1);
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_timestamp - interval '2 day', current_timestamp - interval '1 day');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (1, 1, 'A11111A', 10001, 1, current_date - 2, null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (1, 1, 'A11111A', 10001, 1, current_timestamp - interval '2 day', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (2, 1, 'A22222A', 10002, 2, current_date - 2, current_date - 1, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (2, 1, 'A22222A', 10002, 2, current_timestamp - interval '2 day', current_timestamp - interval '1 day', '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (3, 1, 'A33333A', 10003, 2, current_date - 1, current_date, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (3, 1, 'A33333A', 10003, 2, current_timestamp - interval '1 day', current_timestamp, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (4, 1, 'A33333A', 10004, 2, current_date - 2, current_date - 2, '2022-10-10 09:00:00', 'MRS BLOGS', current_timestamp - 1, 'Activities Management Service', 'ENDED', null, null, null, 'ENDED');
+values (4, 1, 'A33333A', 10004, 2, current_timestamp - interval '2 day', current_timestamp - interval '2 day', '2022-10-10 09:00:00', 'MRS BLOGS', current_timestamp - interval '1 day', 'Activities Management Service', 'ENDED', null, null, null, 'ENDED');
 
 insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
 values (1, 'PVI', 'A11111A', 111111, '2023-06-23', 1, 1, 'Fred Bloggs', 'PENDING', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);

--- a/src/test/resources/test_data/seed-allocations-due-to-expire.sql
+++ b/src/test/resources/test_data/seed-allocations-due-to-expire.sql
@@ -5,10 +5,10 @@ INSERT INTO prison_regime (prison_code, am_start, am_finish, pm_start, pm_finish
 VALUES('PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date - 10, null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_timestamp - interval '10 day', null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
-values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', current_date - 10, null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+values (2, 'PVI', 1, 1, true, false, false, false, 'H', 'English', 'English Level 1', current_timestamp - interval '10 day', null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
 
 insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
 values (1, 1, 'BAS', 'Basic', 1, 125, 150, 1);
@@ -17,16 +17,16 @@ insert into activity_minimum_education_level(activity_minimum_education_level_id
 values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date)
-values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date - 1, null);
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_timestamp - interval '1 day', null);
 
 insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date)
-values (2, 2, 'English AM', 1, 'L1', 'Location 1', 10, current_date - 1, null);
+values (2, 2, 'English AM', 1, 'L1', 'Location 1', 10, current_timestamp - interval '1 day', null);
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (1, 1, 'A11111A', 10001, 1, current_date - 10, null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, current_timestamp - 5, 'Activities Management Service', 'Temporarily released from prison', 'AUTO_SUSPENDED');
+values (1, 1, 'A11111A', 10001, 1, current_timestamp + interval '10 day', null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, current_timestamp - interval '5 hour', 'Activities Management Service', 'Temporarily released from prison', 'AUTO_SUSPENDED');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (2, 2, 'A11111A', 10001, 1, current_date + 1, null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'PENDING');
+values (2, 2, 'A11111A', 10001, 1, current_timestamp + interval '1 day', null, '2022-10-10 09:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'PENDING');
 
 insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
 values (1, 'PVI', 'A11111A', 10001, '2023-06-23', 2, 2, 'Fred Bloggs', 'PENDING', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);

--- a/src/test/resources/test_data/seed-attendances-two-days-old-waiting.sql
+++ b/src/test/resources/test_data/seed-attendances-two-days-old-waiting.sql
@@ -16,10 +16,10 @@ insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_
 values (1, 1, '10:00:00', '11:00:00', true);
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (1, 1, 'A11111A', 10001, 1, '2022-10-10', null, current_timestamp - 15, 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (1, 1, 'A11111A', 10001, 1, '2022-10-10', null, current_timestamp - interval '15 hour', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
 values (1, current_date - 2, '10:00:00', '11:00:00', false, null, null, null, null);
 
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
-values (1, 1, 'A11111A', 9, null, current_timestamp - 2, 'MR BLOGS', 'WAITING', null, null, null);
+values (1, 1, 'A11111A', 9, null, current_timestamp - interval '2 hour', 'MR BLOGS', 'WAITING', null, null, null);

--- a/src/test/resources/test_data/seed-attendances-yesterdays-completed.sql
+++ b/src/test/resources/test_data/seed-attendances-yesterdays-completed.sql
@@ -16,10 +16,10 @@ insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_
 values (1, 1, '10:00:00', '11:00:00', true);
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (1, 1, 'A11111A', 10001, 1, '2022-10-10', null, current_timestamp - 1, 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (1, 1, 'A11111A', 10001, 1, '2022-10-10', null, current_timestamp - interval '1 hour', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
 values (1, current_date - 1, '10:00:00', '11:00:00', false, null, null, null, null);
 
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
-values (1, 1, 'A11111A', 9, null, current_timestamp - 1, 'MR BLOGS', 'COMPLETED', null, null, null);
+values (1, 1, 'A11111A', 9, null, current_timestamp - interval '1 hour', 'MR BLOGS', 'COMPLETED', null, null, null);

--- a/src/test/resources/test_data/seed-attendances-yesterdays-waiting.sql
+++ b/src/test/resources/test_data/seed-attendances-yesterdays-waiting.sql
@@ -16,10 +16,10 @@ insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_
 values (1, 1, '10:00:00', '11:00:00', true);
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (1, 1, 'A11111A', 10001, 1, '2022-10-10', null, current_timestamp - 1, 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (1, 1, 'A11111A', 10001, 1, '2022-10-10', null, current_timestamp - interval '1 hour', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
 values (1, current_date - 1, '10:00:00', '11:00:00', false, null, null, null, null);
 
 insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
-values (1, 1, 'A11111A', 9, null, current_timestamp - 1, 'MR BLOGS', 'WAITING', null, null, null);
+values (1, 1, 'A11111A', 9, null, current_timestamp - interval '1 hour', 'MR BLOGS', 'WAITING', null, null, null);

--- a/src/test/resources/test_data/seed-offender-merged-event-old-and-new-allocations.sql
+++ b/src/test/resources/test_data/seed-offender-merged-event-old-and-new-allocations.sql
@@ -32,7 +32,7 @@ insert into allocation(allocation_id, activity_schedule_id, prisoner_number, boo
 values (1, 1, 'A11111A', 111111, 1, '2022-10-10', '2022-10-10', '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ENDED');
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (2, 1, 'B11111B', 111111, 1, current_date, null, current_timestamp - 1, 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+values (2, 1, 'B11111B', 111111, 1, current_date, null, current_timestamp - interval '1 hour', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
 values (1, current_date, '00:01:00', '00:02:00', false, null, null, null, null);


### PR DESCRIPTION
Replaced H2 with Postgres for integration tests.

Will use TestContainers locally unless there is already a Postgres DB on port 5432 in which case it will try to use that so maybe remap your port in [docker-compose.yml](https://github.com/ministryofjustice/hmpps-activities-management-api/blob/main/docker-compose.yml#L10).

CircleCI uses [java_postgres](https://circleci.com/developer/orbs/orb/ministryofjustice/hmpps#executors-java_postgres) orb to spin up postgres and then [waits for it](https://circleci.com/developer/orbs/orb/ministryofjustice/hmpps#commands-wait_till_ready_postgres) before running tests.

There were a few tests that were unnecessarily strict on ordering of lists so I have fixed those **but some more may arise**.