### PR TITLE
SAA-1781: Change the constraint for attendance marking to be a maximum of 7 days after the activity session

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -218,18 +218,17 @@ data class Attendance(
    */
   fun editable(): Boolean {
     return (
-      (
-        this.status() == AttendanceStatus.WAITING &&
-          this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(14))
-        ) ||
+      this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(7)) &&
         (
-          this.status == AttendanceStatus.COMPLETED &&
-            this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(7)) &&
+          this.status() == AttendanceStatus.WAITING ||
             (
-              (
-                this.attendanceReason?.attended == false && this.issuePayment == false
-                ) ||
-                (this.recordedTime!!.isAfter(LocalDate.now().atStartOfDay()) || this.recordedTime!!.isEqual(LocalDate.now().atStartOfDay()))
+              this.status == AttendanceStatus.COMPLETED &&
+                (
+                  (
+                    this.attendanceReason?.attended == false && this.issuePayment == false
+                    ) ||
+                    (this.recordedTime!!.isAfter(LocalDate.now().atStartOfDay()) || this.recordedTime!!.isEqual(LocalDate.now().atStartOfDay()))
+                  )
               )
           )
       )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
@@ -152,10 +152,10 @@ class AttendanceTest {
   }
 
   @Test
-  fun `attendance is editable - WAITING, session was 13 days ago`() {
-    val instanceTenDaysAgo = instance.copy(sessionDate = LocalDate.now().minusDays(13))
+  fun `attendance is editable - WAITING, session was 6 days ago`() {
+    val instanceSixDaysAgo = instance.copy(sessionDate = LocalDate.now().minusDays(6))
     val attendance = Attendance(
-      scheduledInstance = instanceTenDaysAgo,
+      scheduledInstance = instanceSixDaysAgo,
       prisonerNumber = "A1234AA",
       status = AttendanceStatus.WAITING,
     )
@@ -260,10 +260,10 @@ class AttendanceTest {
   }
 
   @Test
-  fun `attendance is NOT editable - WAITING, session was 15 days ago`() {
-    val instanceFifteenDaysAgo = instance.copy(sessionDate = LocalDate.now().minusDays(15))
+  fun `attendance is NOT editable - WAITING, session was 7 days ago`() {
+    val instanceSevenDaysAgo = instance.copy(sessionDate = LocalDate.now().minusDays(7))
     val attendance = Attendance(
-      scheduledInstance = instanceFifteenDaysAgo,
+      scheduledInstance = instanceSevenDaysAgo,
       initialIssuePayment = false,
       prisonerNumber = "A1234AA",
       status = AttendanceStatus.WAITING,


### PR DESCRIPTION
Includes the day of the appointment, so attendance is editable up to 7 days including today..