### PR TITLE
SAA-1801: cancelled activity attendance recording

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -218,17 +218,32 @@ data class Attendance(
    5. If the session is 'cancelled' check the 'session date' is today. For a cancelled session, when the attendance record is created on the day the 'recorded time' is set to the session cancellation time
    */
   fun editable(): Boolean {
-    return (
-      this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(7)) && (
-        this.status == AttendanceStatus.WAITING || (
-          this.status == AttendanceStatus.COMPLETED && (
-            (this.attendanceReason?.attended == false && this.issuePayment == false) ||
-              this.recordedTime!!.toLocalDate() == LocalDate.now() ||
-              (this.scheduledInstance.sessionDate == LocalDate.now() && this.attendanceReason?.code == AttendanceReasonEnum.CANCELLED)
-            )
-          )
-        )
-      )
+    val today = LocalDate.now()
+
+    if (!this.scheduledInstance.sessionDate.isAfter(today.minusDays(7))) {
+      return false
+    }
+
+    if (this.status == AttendanceStatus.WAITING) {
+      return true
+    }
+
+    if(this.status != AttendanceStatus.COMPLETED) {
+      return false
+    }
+
+    if (this.attendanceReason?.attended == false && this.issuePayment == false) {
+      return true
+    }
+
+    if (this.scheduledInstance.sessionDate == today && this.attendanceReason?.code == AttendanceReasonEnum.CANCELLED) {
+      return true
+    }
+
+    if (this.recordedTime!!.toLocalDate() == today) {
+      return true
+    }
+    return false
   }
 
   fun hasReason(vararg reasons: AttendanceReasonEnum) = reasons.any { attendanceReason?.code == it }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -211,10 +211,11 @@ data class Attendance(
 
   /*
    Attendance is editable if:
-   1. If no attendance has been recorded AND it is within 14 days of the activity session date.
+   1. If no attendance has been recorded AND it is within 7 days of the activity session date.
    2. If attendance is Not Attended & Unpaid AND it is within 7 days of the activity session date.
    3. If attendance is Attended AND it is the same day as the attendance was set as Attended.
    4. If attendance is Not Attended & Paid AND it is the same day as the paid attendance was set.
+   5. If the session is Cancelled session use the session date not the recorded time
    */
   fun editable(): Boolean {
     return (
@@ -227,7 +228,10 @@ data class Attendance(
                   (
                     this.attendanceReason?.attended == false && this.issuePayment == false
                     ) ||
-                    (this.recordedTime!!.isAfter(LocalDate.now().atStartOfDay()) || this.recordedTime!!.isEqual(LocalDate.now().atStartOfDay()))
+                    (this.recordedTime!!.isAfter(LocalDate.now().atStartOfDay()) || this.recordedTime!!.isEqual(LocalDate.now().atStartOfDay())) ||
+                    // attendance records are created on the day.
+                    // For a cancelled attendance records we need to consider the session date, not the recorded time to allow uncancelling on the day
+                    (this.scheduledInstance.sessionDate.isEqual(LocalDate.now()) && this.attendanceReason?.code == AttendanceReasonEnum.CANCELLED)
                   )
               )
           )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -224,10 +224,11 @@ data class Attendance(
           this.status == AttendanceStatus.COMPLETED && (
             (this.attendanceReason?.attended == false && this.issuePayment == false) ||
               this.recordedTime!!.toLocalDate() == LocalDate.now() ||
-              (this.scheduledInstance.sessionDate == LocalDate.now() && this.attendanceReason?.code == AttendanceReasonEnum.CANCELLED))
+              (this.scheduledInstance.sessionDate == LocalDate.now() && this.attendanceReason?.code == AttendanceReasonEnum.CANCELLED)
             )
           )
         )
+      )
   }
 
   fun hasReason(vararg reasons: AttendanceReasonEnum) = reasons.any { attendanceReason?.code == it }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -211,26 +211,23 @@ data class Attendance(
 
   /*
    Attendance is editable if:
-   1. If no attendance has been recorded AND it is within 7 days of the activity session date.
-   2. If attendance is Not Attended & Unpaid AND it is within 7 days of the activity session date.
-   3. If attendance is Attended AND it is the same day as the attendance was set as Attended.
-   4. If attendance is Not Attended & Paid AND it is the same day as the paid attendance was set.
-   5. If the session is Cancelled session use the session date not the recorded time
+   1. If no attendance has been recorded, and it is within 7 days of the activity session date.
+   2. If attendance is set to 'not attended', 'unpaid', and it is within 7 days of the activity 'session date'.
+   3. If attendance is set to 'attended', and it is still the same day that the attendance was marked.
+   4. If attendance is set to 'not attended', 'paid', and it is the same day that the attendance was marked.
+   5. If the session is 'cancelled' check the 'session date' is today. For a cancelled session, when the attendance record is created on the day the 'recorded time' is set to the session cancellation time
    */
   fun editable(): Boolean {
     return (
       this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(7)) && (
-        this.status() == AttendanceStatus.WAITING || (
+        this.status == AttendanceStatus.WAITING || (
           this.status == AttendanceStatus.COMPLETED && (
-            this.attendanceReason?.attended == false && this.issuePayment == false ||
-              this.recordedTime!!.toLocalDate().isEqual(LocalDate.now()) ||
-              // attendance records are created on the day.
-              // For a cancelled attendance records we need to consider the session date, not the recorded time to allow uncancelling on the day
-              (this.scheduledInstance.sessionDate.isEqual(LocalDate.now()) && this.attendanceReason?.code == AttendanceReasonEnum.CANCELLED)
+            (this.attendanceReason?.attended == false && this.issuePayment == false) ||
+              this.recordedTime!!.toLocalDate() == LocalDate.now() ||
+              (this.scheduledInstance.sessionDate == LocalDate.now() && this.attendanceReason?.code == AttendanceReasonEnum.CANCELLED))
             )
           )
         )
-      )
   }
 
   fun hasReason(vararg reasons: AttendanceReasonEnum) = reasons.any { attendanceReason?.code == it }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -219,22 +219,17 @@ data class Attendance(
    */
   fun editable(): Boolean {
     return (
-      this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(7)) &&
-        (
-          this.status() == AttendanceStatus.WAITING ||
-            (
-              this.status == AttendanceStatus.COMPLETED &&
-                (
-                  (
-                    this.attendanceReason?.attended == false && this.issuePayment == false
-                    ) ||
-                    (this.recordedTime!!.isAfter(LocalDate.now().atStartOfDay()) || this.recordedTime!!.isEqual(LocalDate.now().atStartOfDay())) ||
-                    // attendance records are created on the day.
-                    // For a cancelled attendance records we need to consider the session date, not the recorded time to allow uncancelling on the day
-                    (this.scheduledInstance.sessionDate.isEqual(LocalDate.now()) && this.attendanceReason?.code == AttendanceReasonEnum.CANCELLED)
-                  )
-              )
+      this.scheduledInstance.sessionDate.isAfter(LocalDate.now().minusDays(7)) && (
+        this.status() == AttendanceStatus.WAITING || (
+          this.status == AttendanceStatus.COMPLETED && (
+            this.attendanceReason?.attended == false && this.issuePayment == false ||
+              this.recordedTime!!.toLocalDate().isEqual(LocalDate.now()) ||
+              // attendance records are created on the day.
+              // For a cancelled attendance records we need to consider the session date, not the recorded time to allow uncancelling on the day
+              (this.scheduledInstance.sessionDate.isEqual(LocalDate.now()) && this.attendanceReason?.code == AttendanceReasonEnum.CANCELLED)
+            )
           )
+        )
       )
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Attendance.kt
@@ -228,7 +228,7 @@ data class Attendance(
       return true
     }
 
-    if(this.status != AttendanceStatus.COMPLETED) {
+    if (this.status != AttendanceStatus.COMPLETED) {
       return false
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
@@ -14,6 +14,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isClose
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import java.time.LocalDate
 import java.time.LocalDateTime
+import java.time.LocalTime
 import java.time.temporal.ChronoUnit
 
 class AttendanceTest {
@@ -190,6 +191,20 @@ class AttendanceTest {
   }
 
   @Test
+  fun `attendance is editable - COMPLETED, paid, session today, cancelled 5 days ago`() {
+    val instanceToday = instance.copy(sessionDate = LocalDate.now(), startTime = LocalTime.of(1, 0), endTime = LocalTime.of(1,30))
+    val attendance = Attendance(
+      scheduledInstance = instanceToday,
+      initialIssuePayment = true,
+      prisonerNumber = "A1234AA",
+      status = AttendanceStatus.COMPLETED,
+      recordedTime = LocalDateTime.now().minusDays(5),
+      attendanceReason = attendanceReason(AttendanceReasonEnum.CANCELLED),
+    )
+    assertThat(attendance.editable()).isTrue
+  }
+
+  @Test
   fun `attendance is editable - COMPLETED, unpaid, session was 6 days ago, marked six days ago, not attended`() {
     val instanceTenDaysAgo = instance.copy(sessionDate = LocalDate.now().minusDays(6))
     val attendance = Attendance(
@@ -218,10 +233,10 @@ class AttendanceTest {
   }
 
   @Test
-  fun `attendance is not editable - COMPLETED, paid, session was 1 day ago, marked six days ago, not attended`() {
-    val instanceTenDaysAgo = instance.copy(sessionDate = LocalDate.now().minusDays(1))
+  fun `attendance is not editable - COMPLETED, paid, session was 1 day ago, marked 1 day ago, not attended`() {
+    val instanceOneDaysAgo = instance.copy(sessionDate = LocalDate.now().minusDays(1))
     val attendance = Attendance(
-      scheduledInstance = instanceTenDaysAgo,
+      scheduledInstance = instanceOneDaysAgo,
       initialIssuePayment = true,
       prisonerNumber = "A1234AA",
       status = AttendanceStatus.COMPLETED,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceTest.kt
@@ -192,7 +192,7 @@ class AttendanceTest {
 
   @Test
   fun `attendance is editable - COMPLETED, paid, session today, cancelled 5 days ago`() {
-    val instanceToday = instance.copy(sessionDate = LocalDate.now(), startTime = LocalTime.of(1, 0), endTime = LocalTime.of(1,30))
+    val instanceToday = instance.copy(sessionDate = LocalDate.now(), startTime = LocalTime.of(1, 0), endTime = LocalTime.of(1, 30))
     val attendance = Attendance(
       scheduledInstance = instanceToday,
       initialIssuePayment = true,

--- a/src/test/resources/test_data/seed-activity-id-29.sql
+++ b/src/test/resources/test_data/seed-activity-id-29.sql
@@ -1,0 +1,20 @@
+INSERT INTO activity
+(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, updated_time, updated_by, on_wing, off_wing, activity_organiser_id, paid)
+VALUES(558, 'WDI', 9, 1, true, false, false, false, 'H', 'Library Access sessions', 'Library Access sessions', '2024-05-20', NULL, 'high', '2024-05-14 11:30:52.412', 'TQJ73Y', '2024-05-16 11:38:41.655', 'TQJ73Y', false, false, NULL, true);
+
+INSERT INTO activity_schedule
+(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date, runs_on_bank_holiday, updated_time, updated_by, instances_last_updated_time, schedule_weeks)
+VALUES(558, 558, 'Library Access sessions', 15536, 'LIBRARY', 'LIBRARY', 80, '2024-05-20', NULL, true, '2024-05-16 11:38:41.655', 'TQJ73Y', '2024-06-21 04:00:58.157', 1);
+
+INSERT INTO allocation
+(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status, planned_deallocation_id, deallocation_case_note_id)
+VALUES(17657, 558, 'A4786AJ', 80947, 1, '2024-05-23', NULL, '2024-05-16 13:04:00.000', 'TQJ73Y', NULL, NULL, NULL, NULL, NULL, NULL, 'ACTIVE', NULL, NULL);
+
+INSERT INTO scheduled_instance
+(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, "comment")
+VALUES(122405, 558, now(), '13:45:00', '16:30:00', true, current_timestamp - interval '5 days', 'MQD05I', 'Staff unavailable', '');
+
+INSERT INTO attendance
+(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, "comment", recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces, issue_payment, case_note_id, incentive_level_warning_issued, other_absence_reason)
+VALUES(680879, 122405, 'A4786AJ', 8, 'Staff unavailable', current_timestamp - interval '5 days', 'MQD05I', 'COMPLETED', 159, NULL, NULL, true, NULL, NULL, NULL);
+


### PR DESCRIPTION
Creating attendance records for cancelled activity use cancelled time for the attendance recorded time. Need to allow attendance records to be edited for uncancelling an activity on the day