### PR TITLE
BAVL-213 adds new appointment cancellation reason for cancellations via an external service.

### DIFF
--- a/src/main/resources/migrations/common/V2024.06.26__external_service_appointment_cancellation_reason.sql
+++ b/src/main/resources/migrations/common/V2024.06.26__external_service_appointment_cancellation_reason.sql
@@ -1,0 +1,2 @@
+INSERT INTO appointment_cancellation_reason (appointment_cancellation_reason_id, description, is_delete)
+VALUES   (4, 'Cancelled by external service', true);


### PR DESCRIPTION
BVLS is using the activities API to create video bookings when bookings are made in BVLS to keep the two services in sync.

When an appointment is cancelled in BVLS we also need to cancel the video booking in activities and appointments. In doing so we also need the appointment deleted.

To support this we thought a more appropriate cancellation reason would be needed as 'cancelled in error' does not really fit.

Cancellation reasons are not shared in the UI so this change should be safe.