### PR TITLE
SAA-1823: Handle merge events from all prisons

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -38,6 +38,7 @@ import java.time.LocalTime
 
 internal fun activityModel(activity: Activity) = transform(activity)
 
+const val LIVERPOOL_PRISON_CODE = "LPI"
 const val MOORLAND_PRISON_CODE = "MDI"
 const val PENTONVILLE_PRISON_CODE = "PVI"
 const val RISLEY_PRISON_CODE = "RSI"

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -38,6 +38,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.appo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.appointment.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.HmppsAuditEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.InmateDetailFixture
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.activeInLiverpoolInmate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.activeInMoorlandInmate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.activeInMoorlandPrisoner
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.activeInPentonvilleInmate
@@ -779,7 +780,7 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
 
   @Test
   @Sql("classpath:test_data/seed-offender-merged-event-old-and-new-allocations.sql")
-  fun `offender merged event replaces old prisoner and new prisoner records with new prisoner number and booking ID`() {
+  fun `offender merged event replaces old prisoner and new prisoner records with new prisoner number and booking ID for rolled out prison`() {
     val (oldPrisonerNumber, newPrisonerNumber) = "A11111A" to "B11111B"
     val (oldBookingId, newBookingId) = 111111L to 999999L
     val oldPrisonNumberAndOldBooking = oldPrisonerNumber to oldBookingId
@@ -806,6 +807,39 @@ class InboundEventsIntegrationTest : IntegrationTestBase() {
     waitingListRepository.findAll().map { it.prisonerNumber to it.bookingId } containsExactlyInAnyOrder listOf(newPrisonerNumberAndNewBooking, newPrisonerNumberAndNewBooking)
     auditRepository.findAll().map { it.prisonerNumber }.all { it == newPrisonerNumber } isBool true
     eventReviewRepository.findAll().map { it.prisonerNumber to it.bookingId?.toLong() } containsExactlyInAnyOrder listOf(newPrisonerNumberAndNewBooking, newPrisonerNumberAndNewBooking)
+    appointmentAttendeeRepository.findAll().map { it.prisonerNumber to it.bookingId } containsExactlyInAnyOrder listOf(newPrisonerNumberAndNewBooking, newPrisonerNumberAndNewBooking)
+  }
+
+  @Test
+  @Sql("classpath:test_data/seed-offender-merged-event-old-and-new-allocations.sql")
+  fun `offender merged event replaces old prisoner and new prisoner records with new prisoner number and booking ID for non-rolled out prison`() {
+    val (oldPrisonerNumber, newPrisonerNumber) = "A11111A" to "B11111B"
+    val (oldBookingId, newBookingId) = 111111L to 999999L
+    val oldPrisonNumberAndOldBooking = oldPrisonerNumber to oldBookingId
+    val newPrisonerNumberAndOldBooking = newPrisonerNumber to oldBookingId
+
+    prisonApiMockServer.stubGetPrisonerDetails(activeInLiverpoolInmate.copy(offenderNo = newPrisonerNumber, bookingId = 999999))
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumber(activeInLiverpoolInmate.copy(offenderNo = newPrisonerNumber, bookingId = 999999).convert())
+
+    // Check all set to the old prisoner number and booking ID before event is processed
+    allocationRepository.findAll().map { it.prisonerNumber to it.bookingId } containsExactlyInAnyOrder listOf(oldPrisonNumberAndOldBooking, newPrisonerNumberAndOldBooking)
+    attendanceRepository.findAll().single().prisonerNumber isEqualTo oldPrisonerNumber
+    waitingListRepository.findAll().map { it.prisonerNumber to it.bookingId } containsExactlyInAnyOrder listOf(oldPrisonNumberAndOldBooking, newPrisonerNumberAndOldBooking)
+    auditRepository.findAll().single().prisonerNumber isEqualTo oldPrisonerNumber
+    eventReviewRepository.findAll().map { it.prisonerNumber to it.bookingId?.toLong() } containsExactlyInAnyOrder listOf(oldPrisonNumberAndOldBooking)
+    appointmentAttendeeRepository.findAll().map { it.prisonerNumber to it.bookingId } containsExactlyInAnyOrder listOf(oldPrisonNumberAndOldBooking, newPrisonerNumberAndOldBooking)
+
+    service.process(offenderMergedEvent(prisonerNumber = newPrisonerNumber, removedPrisonerNumber = oldPrisonerNumber))
+
+    val newPrisonerNumberAndNewBooking = newPrisonerNumber to newBookingId
+
+    // Check all set to the new prisoner number after event is processed
+    allocationRepository.findAll().map { it.prisonerNumber to it.bookingId } containsExactlyInAnyOrder listOf(newPrisonerNumberAndNewBooking, newPrisonerNumberAndNewBooking)
+    attendanceRepository.findAll().single().prisonerNumber isEqualTo newPrisonerNumber
+    waitingListRepository.findAll().map { it.prisonerNumber to it.bookingId } containsExactlyInAnyOrder listOf(newPrisonerNumberAndNewBooking, newPrisonerNumberAndNewBooking)
+    auditRepository.findAll().map { it.prisonerNumber }.all { it == newPrisonerNumber } isBool true
+    // New event will not be logged by InterestingEventHandler as it is not for rolled out prison
+    eventReviewRepository.findAll().map { it.prisonerNumber to it.bookingId?.toLong() } containsExactlyInAnyOrder listOf(newPrisonerNumberAndNewBooking)
     appointmentAttendeeRepository.findAll().map { it.prisonerNumber to it.bookingId } containsExactlyInAnyOrder listOf(newPrisonerNumberAndNewBooking, newPrisonerNumberAndNewBooking)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InmateDetailFixture.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InmateDetailFixture.kt
@@ -3,12 +3,14 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.InmateDetail
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.model.PrisonerDetailSearchCriteria
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.LIVERPOOL_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.PENTONVILLE_PRISON_CODE
 import java.time.LocalDate
 
 val activeInMoorlandInmate = InmateDetailFixture.instance(agencyId = MOORLAND_PRISON_CODE)
 val activeInPentonvilleInmate = InmateDetailFixture.instance(agencyId = PENTONVILLE_PRISON_CODE)
+val activeInLiverpoolInmate = InmateDetailFixture.instance(agencyId = LIVERPOOL_PRISON_CODE)
 
 fun InmateDetail.convert(): Prisoner {
   return Prisoner(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderMergedEventHandlerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/events/handlers/OffenderMergedEventHandlerTest.kt
@@ -6,31 +6,25 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.stub
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.api.PrisonApiApplicationClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.Feature
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.FeatureSwitches
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rolloutPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AllocationRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AuditRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.EventReviewRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.WaitingListRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.appointment.AppointmentAttendeeRepository
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.refdata.RolloutPrisonRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.InmateDetailFixture
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.TransactionHandler
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.offenderMergedEvent
-import java.time.LocalDate
 
 class OffenderMergedEventHandlerTest {
-  private val rolloutPrisonRepository: RolloutPrisonRepository = mock()
   private val prisonerApiClient: PrisonApiApplicationClient = mock()
   private val allocationRepository: AllocationRepository = mock()
   private val attendanceRepository: AttendanceRepository = mock()
@@ -43,7 +37,6 @@ class OffenderMergedEventHandlerTest {
   // Define old and new prisoner numbers in the merge
   private val oldNumber = "A1111AA"
   private val newNumber = "B2222BB"
-  private val oldBookingId = 111111L
   private val newBookingId = 999999L
 
   private val prisonerSearchResult = InmateDetailFixture.instance(
@@ -55,7 +48,6 @@ class OffenderMergedEventHandlerTest {
   )
 
   private val handler = OffenderMergedEventHandler(
-    rolloutPrisonRepository,
     prisonerApiClient,
     allocationRepository,
     attendanceRepository,
@@ -69,25 +61,6 @@ class OffenderMergedEventHandlerTest {
 
   @BeforeEach
   fun beforeTests() {
-    reset(
-      rolloutPrisonRepository,
-      prisonerApiClient,
-      allocationRepository,
-      attendanceRepository,
-      waitingListRepository,
-      auditRepository,
-      eventReviewRepository,
-      appointmentAttendeeRepository,
-    )
-
-    rolloutPrisonRepository.stub {
-      on { findByCode(MOORLAND_PRISON_CODE) } doReturn
-        rolloutPrison().copy(
-          activitiesToBeRolledOut = true,
-          activitiesRolloutDate = LocalDate.now().plusDays(-1),
-        )
-    }
-
     prisonerApiClient.stub {
       on { getPrisonerDetailsLite(newNumber) } doReturn prisonerSearchResult
     }
@@ -106,7 +79,6 @@ class OffenderMergedEventHandlerTest {
     handler.handle(inboundEvent).also { it.isSuccess() isBool true }
 
     verify(prisonerApiClient).getPrisonerDetailsLite(newNumber)
-    verify(rolloutPrisonRepository).findByCode(MOORLAND_PRISON_CODE)
 
     verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(MOORLAND_PRISON_CODE, newNumber)
     verify(allocationRepository).findByPrisonCodeAndPrisonerNumber(MOORLAND_PRISON_CODE, oldNumber)
@@ -149,31 +121,5 @@ class OffenderMergedEventHandlerTest {
     verify(auditRepository).findByPrisonCodeAndPrisonerNumber(MOORLAND_PRISON_CODE, oldNumber)
     verify(auditRepository).mergeOldPrisonerNumberToNew(oldNumber, newNumber)
     verify(auditRepository).save(any())
-  }
-
-  @Test
-  fun `inbound merged event is ignored when the prisoner is not at a rolled out prison`() {
-    val inboundEvent = offenderMergedEvent(prisonerNumber = newNumber, removedPrisonerNumber = oldNumber)
-
-    rolloutPrisonRepository.stub {
-      on { findByCode(MOORLAND_PRISON_CODE) } doReturn
-        rolloutPrison().copy(
-          activitiesToBeRolledOut = false,
-          activitiesRolloutDate = null,
-        )
-    }
-
-    handler.handle(inboundEvent).also { it.isSuccess() isBool true }
-
-    verify(prisonerApiClient).getPrisonerDetailsLite(newNumber)
-    verify(rolloutPrisonRepository).findByCode(MOORLAND_PRISON_CODE)
-    verifyNoInteractions(
-      allocationRepository,
-      attendanceRepository,
-      waitingListRepository,
-      auditRepository,
-      eventReviewRepository,
-      appointmentAttendeeRepository,
-    )
   }
 }


### PR DESCRIPTION
Will handle merge event from all prisons not just rolled out ones.

Will not add to `event_review` table unless prison is rolled out