### PR TITLE
BAVL-25: Remove API validation for mandatory comments on VLB

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/AppointmentSeriesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/AppointmentSeriesService.kt
@@ -65,7 +65,6 @@ class AppointmentSeriesService(
     checkCaseloadAccess(request.prisonCode!!)
 
     request.failIfMaximumAppointmentInstancesExceeded()
-    request.failIfCategoryIsVideoLinkAndMissingExtraInfo()
     val categoryDescription = request.categoryDescription()
     val locationDescription = request.locationDescription()
     val prisonNumberBookingIdMap = request.createNumberBookingIdMap()
@@ -112,15 +111,6 @@ class AppointmentSeriesService(
     val repeatCount = schedule?.numberOfAppointments ?: 1
     require(prisonerNumbers.size * repeatCount <= maxAppointmentInstances) {
       "You cannot schedule more than ${maxAppointmentInstances / prisonerNumbers.size} appointments for this number of attendees."
-    }
-  }
-
-  private fun AppointmentSeriesCreateRequest.failIfCategoryIsVideoLinkAndMissingExtraInfo() {
-    // Should fail when category is VLB and extra information is mandatory
-    if (categoryCode == "VLB") {
-      require(extraInformation?.isNotEmpty() == true) {
-        "Enter the court name and any extra information"
-      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/AppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/AppointmentService.kt
@@ -67,8 +67,6 @@ class AppointmentService(
     val startTimeInMs = System.currentTimeMillis()
     val now = LocalDateTime.now()
 
-    request.failIfCategoryIsVideoLinkAndMissingExtraInfo()
-
     val appointment = appointmentRepository.findOrThrowNotFound(appointmentId)
     val appointmentSeries = appointment.appointmentSeries
     val appointmentsToUpdate = appointmentSeries.applyToAppointments(appointment, request.applyTo, "update", false)
@@ -246,13 +244,5 @@ class AppointmentService(
     }
 
     return uncancelledAppointmentSeries
-  }
-  private fun AppointmentUpdateRequest.failIfCategoryIsVideoLinkAndMissingExtraInfo() {
-    // Should fail when category is VLB and extra information is mandatory
-    if (categoryCode == "VLB") {
-      require(extraInformation?.isNotEmpty() == true) {
-        "Enter the court name and any extra information"
-      }
-    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSeriesServiceTest.kt
@@ -8,7 +8,6 @@ import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.AdditionalAnswers
@@ -111,7 +110,6 @@ class AppointmentSeriesServiceTest {
 
   private val prisonCode = "TPR"
   private val categoryCode = "CHAP"
-  private val vlbCategoryCode = "VLB"
   private val internalLocationId = 1L
 
   private val service = AppointmentSeriesService(
@@ -832,38 +830,5 @@ class AppointmentSeriesServiceTest {
     with(telemetryPropertyMap.firstValue) {
       this[ORIGINAL_ID_PROPERTY_KEY] isEqualTo "789"
     }
-  }
-
-  @Test
-  fun `failIfCategoryIsVideoLinkAndMissingExtraInfo should throw exception when category is VLB and extraInformation is empty`() {
-    val request = appointmentSeriesCreateRequest(categoryCode = vlbCategoryCode, extraInformation = "")
-
-    assertThrows<IllegalArgumentException> {
-      service.createAppointmentSeries(request, principal)
-    }
-  }
-
-  @Test
-  fun `failIfCategoryIsVideoLinkAndMissingExtraInfo should not throw exception when category is not VLB and extraInformation is empty`() {
-    addCaseloadIdToRequestHeader(prisonCode)
-    val request = appointmentSeriesCreateRequest(categoryCode = categoryCode, internalLocationId = internalLocationId, extraInformation = "")
-
-    assertDoesNotThrow {
-      service.createAppointmentSeries(request, principal)
-    }
-  }
-
-  @Test
-  fun `failIfCategoryIsVideoLinkAndMissingExtraInfo should not throw exception when category is VLB and extraInformation is not empty`() {
-    addCaseloadIdToRequestHeader(prisonCode)
-    val request = appointmentSeriesCreateRequest(categoryCode = vlbCategoryCode, internalLocationId = internalLocationId, inCell = true, extraInformation = "Extra information - Video Link of Session Court")
-
-    whenever(referenceCodeService.getScheduleReasonsMap(ScheduleReasonEventType.APPOINTMENT))
-      .thenReturn(mapOf(vlbCategoryCode to appointmentCategoryReferenceCode(categoryCode, "Video Link Booking")))
-
-    assertDoesNotThrow {
-      service.createAppointmentSeries(request, principal)
-    }
-    appointmentSeriesEntityCaptor.firstValue.appointments().single().extraInformation isEqualTo "Extra information - Video Link of Session Court"
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentServiceTest.kt
@@ -6,8 +6,6 @@ import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertDoesNotThrow
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
@@ -21,14 +19,12 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.appoint
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.CancelAppointmentsJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.UncancelAppointmentsJob
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.job.UpdateAppointmentsJob
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.appointment.AppointmentRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.appointment.AppointmentCancelDomainService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.appointment.AppointmentService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.appointment.AppointmentUpdateDomainService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.ReferenceCodeDomain
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.ReferenceCodeService
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.ScheduleReasonEventType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.CaseloadAccessException
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.FakeSecurityContext
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.addCaseloadIdToRequestHeader
@@ -121,28 +117,5 @@ class AppointmentServiceTest {
     val entity = appointmentSeries.appointments().first()
     whenever(appointmentRepository.findById(entity.appointmentId)).thenReturn(Optional.of(entity))
     assertThatThrownBy { service.getAppointmentDetailsById(entity.appointmentId) }.isInstanceOf(CaseloadAccessException::class.java)
-  }
-
-  @Test
-  fun `failIfCategoryIsVideoLinkAndMissingExtraInfo should throw exception when category is VLB and extraInformation is empty`() {
-    val request = AppointmentUpdateRequest(categoryCode = "VLB", extraInformation = "")
-
-    assertThrows<IllegalArgumentException> {
-      service.updateAppointment(1L, request, principal)
-    }
-  }
-
-  @Test
-  fun `failIfCategoryIsVideoLinkAndMissingExtraInfo should not throw exception when category is VLB and extraInformation is not empty`() {
-    addCaseloadIdToRequestHeader("TPR")
-    val request = AppointmentUpdateRequest(categoryCode = "VLB", extraInformation = "Video Link Session Court")
-    val appointmentSeries = appointmentSeriesEntity()
-    val entity = appointmentSeries.appointments().first()
-    whenever(appointmentRepository.findById(entity.appointmentId)).thenReturn(Optional.of(entity))
-    whenever(referenceCodeService.getScheduleReasonsMap(ScheduleReasonEventType.APPOINTMENT)).thenReturn(mapOf("VLB" to appointmentCategoryReferenceCode("")))
-
-    assertDoesNotThrow {
-      service.updateAppointment(1L, request, principal)
-    }
   }
 }


### PR DESCRIPTION
BVLS is now syncing appointments without comments. Acceptance criteria [here](https://dsdmoj.atlassian.net/jira/software/c/projects/BAVL/boards/1496?assignee=632ac92661dbef2805bcbd96&selectedIssue=BAVL-236#:~:text=%E2%80%98Extra%20Information%E2%80%99%20field%20validation%20is%20changed%20from%20Mandatory%20to%20Optional)

Validation is still in place for this on A&A frontend for now