### PR TITLE
SAA-1887: Allocate to a session running today

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -242,7 +242,7 @@ data class ActivitySchedule(
     prisonerNumber: PrisonerNumber,
     payBand: PrisonPayBand?,
     bookingId: Long,
-    startDate: LocalDate = LocalDate.now(),
+    startDate: LocalDate,
     endDate: LocalDate? = null,
     exclusions: List<Slot>? = null,
     allocatedBy: String,
@@ -279,8 +279,9 @@ data class ActivitySchedule(
         exclusions?.onEach { exclusion ->
           slots(exclusion.weekNumber, exclusion.timeSlot())
             .also { require(it.isNotEmpty()) { "Allocating to schedule ${activitySchedule.activityScheduleId}: No ${exclusion.timeSlot()} slots in week number ${exclusion.weekNumber}" } }
+            // Only consider exclusions slots where activity slots exist
             .filter { slot -> slot.getDaysOfWeek().intersect(exclusion.getDaysOfWeek()).isNotEmpty() }
-            .forEach { slot -> this.updateExclusion(slot, exclusion.getDaysOfWeek()) }
+            .forEach { slot -> this.updateExclusion(slot, exclusion.getDaysOfWeek(), startDate) }
         }
       },
     )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -352,12 +352,12 @@ data class Allocation(
 
   fun isEnded() = status(PrisonerStatus.ENDED)
 
-  fun updateExclusion(slot: ActivityScheduleSlot, daysOfWeek: Set<DayOfWeek>): Exclusion? {
+  fun updateExclusion(slot: ActivityScheduleSlot, daysOfWeek: Set<DayOfWeek>, startDate: LocalDate): Exclusion? {
     val days = daysOfWeek.intersect(slot.getDaysOfWeek())
     val exclusion = exclusions(ExclusionsFilter.FUTURE)
       .singleOrNull { it.weekNumber == slot.weekNumber && it.slotTimes() == slot.slotTimes() }
       ?.apply { setDaysOfWeek(days) }
-      ?: Exclusion.valueOf(this, slot.slotTimes(), slot.weekNumber, days)
+      ?: Exclusion.valueOf(this, slot.slotTimes(), slot.weekNumber, days, startDate)
 
     return if (exclusion.getDaysOfWeek().isNotEmpty()) {
       if (exclusions.contains(exclusion).not()) addExclusion(exclusion)

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Exclusion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Exclusion.kt
@@ -25,7 +25,7 @@ data class Exclusion(
   @JoinColumn(name = "allocation_id", nullable = false)
   val allocation: Allocation,
 
-  val startDate: LocalDate,
+  var startDate: LocalDate,
 
   val weekNumber: Int,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AllocationUpdateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AllocationUpdateRequest.kt
@@ -2,7 +2,6 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.Future
 import jakarta.validation.constraints.FutureOrPresent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Slot
 import java.time.LocalDate
@@ -12,7 +11,7 @@ data class AllocationUpdateRequest(
 
   @Schema(description = "The date when the prisoner will start the activity", example = "2022-09-10")
   @JsonFormat(pattern = "yyyy-MM-dd")
-  @field:Future(message = "Start date must be in the future")
+  @field:FutureOrPresent(message = "Start date must not be in the past")
   val startDate: LocalDate? = null,
 
   @Schema(description = "The date when the prisoner will stop attending the activity", example = "2023-09-10")
@@ -39,4 +38,7 @@ data class AllocationUpdateRequest(
       "there can not not be exclusions defined on the same day and time slot over multiple weeks.",
   )
   val exclusions: List<Slot>? = null,
+
+  @Schema(description = "The scheduled instance id required when allocation starts today")
+  val scheduleInstanceId: Long? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/PrisonerAllocationRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/PrisonerAllocationRequest.kt
@@ -2,7 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request
 
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
-import jakarta.validation.constraints.Future
+import jakarta.validation.constraints.FutureOrPresent
 import jakarta.validation.constraints.NotBlank
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Size
@@ -22,10 +22,10 @@ data class PrisonerAllocationRequest(
   )
   val payBandId: Long? = null,
 
-  @Schema(description = "The future date when the prisoner will start the activity", example = "2022-09-10")
+  @Schema(description = "The date when the prisoner will start the activity", example = "2022-09-10")
   @JsonFormat(pattern = "yyyy-MM-dd")
   @field:NotNull(message = "Start date must be supplied")
-  @field:Future(message = "Start date must be in the future")
+  @field:FutureOrPresent(message = "Start date must not be in the past")
   val startDate: LocalDate? = null,
 
   @Schema(description = "The date when the prisoner will stop attending the activity", example = "2023-09-10")
@@ -34,4 +34,7 @@ data class PrisonerAllocationRequest(
 
   @Schema(description = "The days and times that the prisoner is excluded from this activity's schedule")
   val exclusions: List<Slot>? = null,
+
+  @Schema(description = "The scheduled instance id required when allocation starts today")
+  val scheduleInstanceId: Long? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
@@ -31,6 +31,7 @@ class AllocationsService(
   private val scheduleRepository: ActivityScheduleRepository,
   private val transactionHandler: TransactionHandler,
   private val outboundEventsService: OutboundEventsService,
+  private val manageAttendancesService: ManageAttendancesService,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -70,10 +71,19 @@ class AllocationsService(
 
       allocationRepository.saveAndFlush(allocation)
 
-      allocation.toModel()
-    }.let { allocation ->
+      val newAttendances = manageAttendancesService.createAnyAttendancesForToday(request.scheduleInstanceId, allocation)
+
+      val savedAttendances = manageAttendancesService.saveAttendances(newAttendances, allocation.activitySchedule)
+
+      allocation.toModel() to savedAttendances
+    }.let { (allocation, newAttendances) ->
+
       log.info("Sending allocation amended event for allocation ${allocation.id}")
+
       outboundEventsService.send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocation.id)
+
+      newAttendances.forEach { manageAttendancesService.sendCreatedEvent(it) }
+
       return allocation
     }
   }
@@ -90,6 +100,12 @@ class AllocationsService(
 
   private fun applyExclusionsUpdate(request: AllocationUpdateRequest, allocation: Allocation) {
     request.exclusions?.apply {
+      /*
+       End any exclusions tha have started and not ended.
+
+       Although Nomis does not have the concept of exclusion date ranges the old exclusions are needed for historical
+       reasons such as unlock and attendance lists (SAA-1379)
+       */
       allocation.endExclusions(allocation.exclusions(ExclusionsFilter.PRESENT))
 
       val newExclusions = this.map { ex -> ex.weekNumber to ex.timeSlot }
@@ -104,7 +120,7 @@ class AllocationsService(
       allocation.activitySchedule.slots(exclusion.weekNumber, exclusion.timeSlot())
         .also { require(it.isNotEmpty()) { "Updating allocation with id ${allocation.allocationId}: No ${exclusion.timeSlot()} slots in week number ${exclusion.weekNumber}" } }
         .filter { slot -> slot.getDaysOfWeek().intersect(exclusion.getDaysOfWeek()).isNotEmpty() }
-        .forEach { slot -> allocation.updateExclusion(slot, exclusion.getDaysOfWeek()) }
+        .forEach { slot -> allocation.updateExclusion(slot, exclusion.getDaysOfWeek(), maxOf(allocation.startDate, LocalDate.now())) }
     }
   }
 
@@ -115,9 +131,13 @@ class AllocationsService(
     request.startDate?.let { newStartDate ->
       val (start, end) = allocation.activitySchedule.activity.startDate to allocation.activitySchedule.activity.endDate
 
-      require(request.startDate > LocalDate.now()) { "Allocation start date must be in the future" }
+      val today = LocalDate.now()
 
-      require(allocation.startDate > LocalDate.now()) {
+      require(request.startDate >= today) { "Allocation start date must not be in the past" }
+
+      if (request.startDate == today && request.scheduleInstanceId == null) throw IllegalArgumentException("The next session must be provided when allocation start date is today")
+
+      require(allocation.startDate > today) {
         "Start date cannot be updated once allocation has started"
       }
 
@@ -130,6 +150,8 @@ class AllocationsService(
       }
 
       allocation.startDate = newStartDate
+
+      allocation.exclusions(ExclusionsFilter.FUTURE).forEach { it.startDate = newStartDate }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityScheduleTest.kt
@@ -72,7 +72,7 @@ class ActivityScheduleTest {
         ),
         capacity = 1,
         allocated = 2,
-        createdTime = LocalDate.now().atStartOfDay(),
+        createdTime = today.atStartOfDay(),
         activityState = ActivityState.LIVE,
         paid = true,
       ),
@@ -94,13 +94,13 @@ class ActivityScheduleTest {
           sundayFlag = false,
         ),
       ),
-      startDate = LocalDate.now(),
+      startDate = today,
     )
     assertThat(
       activitySchedule(
         activityEntity(),
-        timestamp = LocalDate.now().atTime(10, 20),
-        startDate = LocalDate.now(),
+        timestamp = today.atTime(10, 20),
+        startDate = today,
       ).toModelLite(),
     ).isEqualTo(expectedModel)
   }
@@ -143,7 +143,7 @@ class ActivityScheduleTest {
           ),
           capacity = 1,
           allocated = 2,
-          createdTime = LocalDate.now().atStartOfDay(),
+          createdTime = today.atStartOfDay(),
           activityState = ActivityState.LIVE,
           paid = true,
         ),
@@ -165,7 +165,7 @@ class ActivityScheduleTest {
             sundayFlag = false,
           ),
         ),
-        startDate = LocalDate.now(),
+        startDate = today,
       ),
     )
 
@@ -173,8 +173,8 @@ class ActivityScheduleTest {
       listOf(
         activitySchedule(
           activityEntity(),
-          timestamp = LocalDate.now().atTime(10, 20),
-          startDate = LocalDate.now(),
+          timestamp = today.atTime(10, 20),
+          startDate = today,
         ),
       ).toModelLite(),
     ).isEqualTo(
@@ -187,6 +187,7 @@ class ActivityScheduleTest {
     val schedule = activitySchedule(activity = activityEntity(), noAllocations = true)
 
     schedule.allocatePrisoner(
+      startDate = today,
       prisonerNumber = "123456".toPrisonerNumber(),
       payBand = lowPayBand,
       bookingId = 10001,
@@ -200,7 +201,7 @@ class ActivityScheduleTest {
       assertThat(prisonerNumber).isEqualTo("123456")
       assertThat(prisonerStatus).isEqualTo(PrisonerStatus.ACTIVE)
       assertThat(payBand).isEqualTo(lowPayBand)
-      assertThat(startDate).isEqualTo(LocalDate.now())
+      assertThat(startDate).isEqualTo(today)
       assertThat(allocatedBy).isEqualTo("FRED")
       assertThat(allocatedTime).isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
     }
@@ -212,6 +213,7 @@ class ActivityScheduleTest {
       .also { assertThat(it.allocations()).hasSize(2) }
 
     schedule.allocatePrisoner(
+      startDate = today,
       prisonerNumber = "654321".toPrisonerNumber(),
       payBand = lowPayBand,
       bookingId = 10001,
@@ -226,7 +228,7 @@ class ActivityScheduleTest {
       assertThat(prisonerStatus).isEqualTo(PrisonerStatus.ACTIVE)
       assertThat(bookingId).isEqualTo(10001)
       assertThat(payBand).isEqualTo(lowPayBand)
-      assertThat(startDate).isEqualTo(LocalDate.now())
+      assertThat(startDate).isEqualTo(today)
       assertThat(allocatedBy).isEqualTo("FREDDIE")
       assertThat(allocatedTime).isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
       assertThat(payBand).isEqualTo(lowPayBand)
@@ -239,6 +241,7 @@ class ActivityScheduleTest {
       .also { it.allocations() hasSize 2 }
 
     schedule.allocatePrisoner(
+      startDate = today,
       prisonerNumber = "654321".toPrisonerNumber(),
       payBand = lowPayBand,
       bookingId = 10001,
@@ -267,6 +270,7 @@ class ActivityScheduleTest {
 
     assertThatThrownBy {
       schedule.allocatePrisoner(
+        startDate = today,
         prisonerNumber = "654321".toPrisonerNumber(),
         payBand = lowPayBand,
         bookingId = 10001,
@@ -296,7 +300,7 @@ class ActivityScheduleTest {
       payBand = lowPayBand,
       bookingId = 10001,
       allocatedBy = "FREDDIE",
-      startDate = LocalDate.now().plusDays(1),
+      startDate = tomorrow,
     )
 
     assertThat(schedule.allocations()).hasSize(3)
@@ -307,7 +311,7 @@ class ActivityScheduleTest {
       assertThat(prisonerStatus).isEqualTo(PrisonerStatus.PENDING)
       assertThat(bookingId).isEqualTo(10001)
       assertThat(payBand).isEqualTo(lowPayBand)
-      assertThat(startDate).isEqualTo(LocalDate.now().plusDays(1))
+      assertThat(startDate).isEqualTo(tomorrow)
       assertThat(allocatedBy).isEqualTo("FREDDIE")
       assertThat(allocatedTime).isCloseTo(LocalDateTime.now(), within(60, ChronoUnit.SECONDS))
       assertThat(payBand).isEqualTo(lowPayBand)
@@ -319,6 +323,7 @@ class ActivityScheduleTest {
     val schedule = activitySchedule(activity = activityEntity(), noAllocations = true)
 
     schedule.allocatePrisoner(
+      startDate = today,
       prisonerNumber = "654321".toPrisonerNumber(),
       payBand = lowPayBand,
       bookingId = 10001,
@@ -327,6 +332,7 @@ class ActivityScheduleTest {
 
     assertThatThrownBy {
       schedule.allocatePrisoner(
+        startDate = tomorrow,
         prisonerNumber = "654321".toPrisonerNumber(),
         payBand = lowPayBand,
         bookingId = 10001,
@@ -358,6 +364,7 @@ class ActivityScheduleTest {
     val schedule = activitySchedule(activity = activityEntity(), noAllocations = true)
 
     val allocation = schedule.allocatePrisoner(
+      startDate = tomorrow,
       prisonerNumber = "654321".toPrisonerNumber(),
       payBand = lowPayBand,
       bookingId = 10001,
@@ -368,6 +375,7 @@ class ActivityScheduleTest {
 
     assertDoesNotThrow {
       schedule.allocatePrisoner(
+        startDate = today,
         prisonerNumber = "654321".toPrisonerNumber(),
         payBand = lowPayBand,
         bookingId = 10001,
@@ -382,6 +390,7 @@ class ActivityScheduleTest {
 
     assertThatThrownBy {
       schedule.allocatePrisoner(
+        startDate = today,
         prisonerNumber = "654321".toPrisonerNumber(),
         payBand = lowPayBand,
         bookingId = 10001,
@@ -544,7 +553,7 @@ class ActivityScheduleTest {
       activity = activityEntity(),
       description = "description",
       capacity = 1,
-      startDate = LocalDate.now(),
+      startDate = today,
       scheduleWeeks = 1,
     )
 
@@ -553,7 +562,7 @@ class ActivityScheduleTest {
         activity = activityEntity(),
         description = "description",
         capacity = 0,
-        startDate = LocalDate.now(),
+        startDate = today,
         scheduleWeeks = 1,
       )
     }.isInstanceOf(IllegalArgumentException::class.java)
@@ -567,7 +576,7 @@ class ActivityScheduleTest {
         activity = activityEntity(),
         description = "description",
         capacity = 1,
-        startDate = LocalDate.now(),
+        startDate = today,
         scheduleWeeks = 0,
       )
     }.isInstanceOf(IllegalArgumentException::class.java)
@@ -578,7 +587,7 @@ class ActivityScheduleTest {
         activity = activityEntity(),
         description = "description",
         capacity = 1,
-        startDate = LocalDate.now(),
+        startDate = today,
         scheduleWeeks = -1,
       )
     }.isInstanceOf(IllegalArgumentException::class.java)
@@ -750,7 +759,7 @@ class ActivityScheduleTest {
 
     assertThat(schedule.instancesLastUpdatedTime).isNull()
 
-    schedule.addInstance(LocalDate.now().plusDays(1), schedule.slots().first())
+    schedule.addInstance(tomorrow, schedule.slots().first())
 
     assertThat(schedule.instancesLastUpdatedTime).isCloseTo(LocalDateTime.now(), within(1, ChronoUnit.SECONDS))
   }
@@ -929,7 +938,7 @@ class ActivityScheduleTest {
   fun `prisoner is deallocated from schedule when they already have an ended allocation previously`() {
     val schedule = activitySchedule(activity = activityEntity())
     val originalAllocation = schedule.allocations().first().also { it.deallocateNowOn(TimeSource.today()) }
-    val newAllocation = schedule.allocatePrisoner(originalAllocation.prisonerNumber.toPrisonerNumber(), originalAllocation.payBand, originalAllocation.bookingId, allocatedBy = "test")
+    val newAllocation = schedule.allocatePrisoner(originalAllocation.prisonerNumber.toPrisonerNumber(), originalAllocation.payBand, originalAllocation.bookingId, today, allocatedBy = "test")
 
     assertThat(newAllocation.plannedDeallocation).isNull()
 
@@ -1177,6 +1186,7 @@ class ActivityScheduleTest {
       activitySchedule(activity = activityEntity(), noAllocations = true, startDate = yesterday, endDate = tomorrow)
 
     schedule.allocatePrisoner(
+      startDate = today,
       prisonerNumber = "1111111".toPrisonerNumber(),
       payBand = lowPayBand,
       bookingId = 10001,
@@ -1185,6 +1195,7 @@ class ActivityScheduleTest {
     )
 
     schedule.allocatePrisoner(
+      startDate = today,
       prisonerNumber = "2222222".toPrisonerNumber(),
       payBand = lowPayBand,
       bookingId = 20002,
@@ -1208,18 +1219,20 @@ class ActivityScheduleTest {
         activity = activityEntity(),
         noAllocations = true,
         startDate = yesterday,
-        endDate = tomorrow.plusDays(1),
+        endDate = today.plusWeeks(1),
       )
 
     val activeAllocation = schedule.allocatePrisoner(
+      startDate = today,
       prisonerNumber = "1111111".toPrisonerNumber(),
       payBand = lowPayBand,
       bookingId = 10001,
       allocatedBy = "FRED",
-      endDate = tomorrow.plusDays(1),
+      endDate = tomorrow,
     )
 
     val endedAllocation = schedule.allocatePrisoner(
+      startDate = today,
       prisonerNumber = "2222222".toPrisonerNumber(),
       payBand = lowPayBand,
       bookingId = 20002,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -395,14 +395,14 @@ class AllocationTest {
     val allocation = allocation()
     allocation.exclusions(ExclusionsFilter.ACTIVE) hasSize 0
 
-    val exclusion = allocation.updateExclusion(allocation.activitySchedule.slots().first(), setOf(DayOfWeek.MONDAY))
+    val exclusion = allocation.updateExclusion(allocation.activitySchedule.slots().first(), setOf(DayOfWeek.MONDAY), tomorrow)
 
     allocation.exclusions(ExclusionsFilter.ACTIVE) hasSize 1
     with(exclusion!!) {
       getDaysOfWeek() isEqualTo setOf(DayOfWeek.MONDAY)
     }
 
-    val updatedExclusion = allocation.updateExclusion(allocation.activitySchedule.slots().first(), setOf())
+    val updatedExclusion = allocation.updateExclusion(allocation.activitySchedule.slots().first(), setOf(), tomorrow)
 
     allocation.exclusions(ExclusionsFilter.ACTIVE) hasSize 0
     updatedExclusion isEqualTo null
@@ -465,11 +465,11 @@ class AllocationTest {
 
     allocation.exclusions(ExclusionsFilter.ACTIVE) hasSize 0
 
-    assertThatThrownBy { allocation.updateExclusion(allocation.activitySchedule.slots().first(), setOf(DayOfWeek.MONDAY)) }
+    assertThatThrownBy { allocation.updateExclusion(allocation.activitySchedule.slots().first(), setOf(DayOfWeek.MONDAY), today) }
       .isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Exclusions cannot be added where the time slot exists over multiple weeks.")
 
-    allocation.updateExclusion(allocation.activitySchedule.slots().last(), setOf(DayOfWeek.THURSDAY))
+    allocation.updateExclusion(allocation.activitySchedule.slots().last(), setOf(DayOfWeek.THURSDAY), today)
 
     allocation.exclusions(ExclusionsFilter.ACTIVE) hasSize 1
   }
@@ -731,7 +731,7 @@ class AllocationTest {
 
     allocation.canAttendOn(TimeSource.tomorrow(), prisonRegime[timeSlot]!!) isBool true
 
-    allocation.updateExclusion(allocation.activitySchedule.slots().first(), setOf(TimeSource.tomorrow().dayOfWeek))
+    allocation.updateExclusion(allocation.activitySchedule.slots().first(), setOf(TimeSource.tomorrow().dayOfWeek), today)
 
     allocation.canAttendOn(TimeSource.tomorrow(), prisonRegime[timeSlot]!!) isBool false
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -243,7 +243,7 @@ internal fun activitySchedule(
           allocatedBy = "Mr Blogs",
           startDate = startDate ?: activity.startDate,
         ).apply {
-          this.updateExclusion(slot, daysOfWeek)
+          this.updateExclusion(slot, daysOfWeek, LocalDate.now().plusDays(1))
         }
       }
     }
@@ -475,6 +475,7 @@ internal fun waitingList(
         allocatePrisoner(
           prisonerNumber = prisonerNumber.toPrisonerNumber(),
           bookingId = 10001,
+          startDate = LocalDate.now().plusDays(1),
           payBand = lowPayBand,
           allocatedBy = "Mr Blogs",
         )

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -405,7 +405,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           ),
           category = educationCategory,
           capacity = 20,
-          allocated = 4,
+          allocated = 5,
           createdTime = LocalDateTime.of(2022, 9, 21, 0, 0, 0),
           activityState = ActivityState.LIVE,
           paid = true,
@@ -459,7 +459,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
           ),
           category = educationCategory,
           capacity = 20,
-          allocated = 4,
+          allocated = 5,
           createdTime = LocalDateTime.of(2022, 9, 21, 0, 0, 0),
           activityState = ActivityState.LIVE,
           paid = true,
@@ -709,7 +709,7 @@ class ActivityIntegrationTest : IntegrationTestBase() {
     val mathsAfternoon = with(mathsLevelOneActivity.schedule("Maths PM")) {
       assertThat(capacity).isEqualTo(10)
       assertThat(this.slots[0].daysOfWeek).isEqualTo(listOf("Mon"))
-      assertThat(allocations).hasSize(2)
+      assertThat(allocations).hasSize(3)
       assertThat(internalLocation?.id).isEqualTo(2)
       assertThat(internalLocation?.code).isEqualTo("L2")
       assertThat(internalLocation?.description).isEqualTo("Location 2")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -13,6 +13,7 @@ import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.daysFromNow
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceStatus
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ExclusionsFilter
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingListStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.AttendanceReasonEnum
@@ -49,6 +50,7 @@ import java.time.LocalDateTime
   properties = [
     "feature.event.activities.prisoner.allocation-amended=true",
     "feature.event.activities.prisoner.attendance-amended=true",
+    "feature.event.activities.prisoner.attendance-created=true",
     "spring.jpa.properties.hibernate.enable_lazy_load_no_trans=true",
   ],
 )
@@ -159,6 +161,46 @@ class AllocationIntegrationTest : IntegrationTestBase() {
     )
 
     webTestClient.waitingListApplication(MOORLAND_PRISON_CODE, request, PENTONVILLE_PRISON_CODE).expectStatus().isForbidden
+  }
+
+  @Sql("classpath:test_data/seed-activity-id-1.sql")
+  @Test
+  fun `update allocation start date to today`() {
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumber("A1234BC")
+
+    webTestClient.updateAllocation(
+      PENTONVILLE_PRISON_CODE,
+      6,
+      AllocationUpdateRequest(
+        startDate = TimeSource.today(),
+        scheduleInstanceId = 2L,
+      ),
+    )
+
+    allocationRepository.findById(6).get().also {
+      it.startDate isEqualTo TimeSource.today()
+      it.exclusions(ExclusionsFilter.ACTIVE).forEach {
+        it.startDate = TimeSource.today()
+      }
+    }
+
+    val newAttendance = attendanceRepository.findAll().filter { it.scheduledInstance.sessionDate == TimeSource.today() }
+      .also { it.size isEqualTo 1 }
+      .first()
+
+    verify(eventsPublisher, times(2)).send(eventCaptor.capture())
+
+    with(eventCaptor.firstValue) {
+      eventType isEqualTo "activities.prisoner.allocation-amended"
+      additionalInformation isEqualTo PrisonerAllocatedInformation(6)
+      occurredAt isCloseTo TimeSource.now()
+    }
+
+    with(eventCaptor.secondValue) {
+      eventType isEqualTo "activities.prisoner.attendance-created"
+      additionalInformation isEqualTo PrisonerAttendanceInformation(newAttendance.attendanceId)
+      occurredAt isCloseTo TimeSource.now()
+    }
   }
 
   @Sql("classpath:test_data/seed-activity-id-1.sql")

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/PrisonIntegrationTest.kt
@@ -58,7 +58,7 @@ class PrisonIntegrationTest : IntegrationTestBase() {
         ),
         category = educationCategory,
         capacity = 20,
-        allocated = 4,
+        allocated = 5,
         createdTime = LocalDateTime.of(2022, 9, 21, 0, 0, 0),
         activityState = ActivityState.LIVE,
         paid = true,
@@ -78,7 +78,7 @@ class PrisonIntegrationTest : IntegrationTestBase() {
         activityName = "Maths Level 1",
         category = educationCategory,
         capacity = 10,
-        allocated = 4,
+        allocated = 5,
         waitlisted = 1,
         createdTime = LocalDateTime.of(2022, 9, 21, 0, 0, 0),
         activityState = ActivityState.LIVE,
@@ -180,7 +180,7 @@ class PrisonIntegrationTest : IntegrationTestBase() {
     }
 
     val afternoonSchedule = with(schedules.single { it.description == "Maths PM" }) {
-      allocations.map(Allocation::prisonerNumber) containsExactly listOf("A11111A", "A22222A")
+      allocations.map(Allocation::prisonerNumber) containsExactly listOf("A11111A", "A22222A", "A1234BC")
       instances hasSize 1
       this
     }
@@ -225,7 +225,7 @@ class PrisonIntegrationTest : IntegrationTestBase() {
       webTestClient.getSchedulesByPrison("PVI", LocalDate.of(2022, 10, 10), TimeSlot.PM)!!
 
     val schedule = with(schedules.single { it.description == "Maths PM" }) {
-      allocations.map(Allocation::prisonerNumber) containsExactly listOf("A11111A", "A22222A")
+      allocations.map(Allocation::prisonerNumber) containsExactly listOf("A11111A", "A22222A", "A1234BC")
       instances hasSize 1
       this
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AllocationUpdateRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AllocationUpdateRequestTest.kt
@@ -11,11 +11,11 @@ class AllocationUpdateRequestTest {
   private val validator: Validator = Validation.buildDefaultValidatorFactory().validator
 
   @Test
-  fun `start date must be in the future`() {
+  fun `start date must not be in the past`() {
     val request = AllocationUpdateRequest(
-      startDate = TimeSource.today(),
+      startDate = TimeSource.yesterday(),
     )
-    assertSingleValidationError(validator.validate(request), "startDate", "Start date must be in the future")
+    assertSingleValidationError(validator.validate(request), "startDate", "Start date must not be in the past")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/PrisonerAllocationRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/PrisonerAllocationRequestTest.kt
@@ -11,13 +11,13 @@ class PrisonerAllocationRequestTest {
   private val validator: Validator = Validation.buildDefaultValidatorFactory().validator
 
   @Test
-  fun `start date must be in the future`() {
+  fun `start date must not be in the past`() {
     val request = PrisonerAllocationRequest(
       prisonerNumber = "G4793VF",
       payBandId = 11,
-      startDate = TimeSource.today(),
+      startDate = TimeSource.yesterday(),
     )
-    assertSingleValidationError(validator.validate(request), "startDate", "Start date must be in the future")
+    assertSingleValidationError(validator.validate(request), "startDate", "Start date must not be in the past")
   }
 
   private fun assertSingleValidationError(validate: MutableSet<ConstraintViolation<PrisonerAllocationRequest>>, propertyName: String, message: String) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
@@ -980,6 +980,7 @@ class ActivityServiceTest {
         payBand = lowPayBand,
         bookingId = 10001,
         allocatedBy = "FRED",
+        startDate = LocalDate.now().plusDays(1),
         endDate = updateActivityRequest.endDate?.plusYears(1),
       )
 
@@ -988,6 +989,7 @@ class ActivityServiceTest {
         payBand = lowPayBand,
         bookingId = 20002,
         allocatedBy = "BOB",
+        startDate = LocalDate.now().plusDays(2),
         endDate = null,
       )
     }
@@ -1787,7 +1789,7 @@ class ActivityServiceTest {
         allocatedBy = "Mr Blogs",
         startDate = startDate,
       ).apply {
-        this.updateExclusion(slot, setOf(tomorrow.dayOfWeek))
+        this.updateExclusion(slot, setOf(tomorrow.dayOfWeek), tomorrow)
       }
     }
 
@@ -1853,7 +1855,7 @@ class ActivityServiceTest {
         allocatedBy = "Mr Blogs",
         startDate = startDate,
       ).apply {
-        this.updateExclusion(slot, setOf(tomorrow.dayOfWeek))
+        this.updateExclusion(slot, setOf(tomorrow.dayOfWeek), tomorrow)
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
@@ -4,6 +4,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers.anyList
 import org.mockito.kotlin.any
@@ -36,6 +38,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.PENTONV
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activitySchedule
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.attendanceReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.attendanceReasons
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
@@ -47,6 +50,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.
 import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
+import java.util.*
 
 class ManageAttendancesServiceTest {
   private val scheduledInstanceRepository: ScheduledInstanceRepository = mock()
@@ -542,6 +546,86 @@ class ManageAttendancesServiceTest {
 
     assertThat(attendance.status()).isEqualTo(AttendanceStatus.COMPLETED)
     verifyNoInteractions(outboundEventsService)
+  }
+
+  @Nested
+  @DisplayName("Create attendances for today")
+  inner class UpdateAppointments {
+    private lateinit var allocation: Allocation
+
+    @BeforeEach
+    fun init() {
+      allocation = allocation()
+    }
+
+    @Test
+    fun `should do nothing if no schedule instance id was provided`() {
+      assertThat(service.createAnyAttendancesForToday(null, allocation)).isEmpty()
+    }
+
+    @Test
+    fun `should throw an exception if the provided schedule id does not match the allocation schedule id`() {
+      whenever(scheduledInstanceRepository.findById(123)).thenReturn(Optional.of(instance.copy(123)))
+
+      assertThatThrownBy {
+        service.createAnyAttendancesForToday(123, allocation)
+      }.isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessage("Allocation does not belong to same activity schedule as selected instance")
+    }
+
+    @Test
+    fun `should create an attendance record`() {
+      whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[0]))
+
+      val attendances = service.createAnyAttendancesForToday(1, allocation)
+
+      assertThat(attendances).hasSize(1)
+      assertThat(attendances.first().scheduledInstance).isEqualTo(allocation.activitySchedule.instances().first())
+    }
+
+    @Test
+    fun `should not create an attendance record if session date is not today`() {
+      allocation.activitySchedule.removeInstances(allocation.activitySchedule.instances())
+      allocation.activitySchedule.addInstance(TimeSource.tomorrow(), allocation.activitySchedule.slots().first())
+
+      whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[0]))
+
+      val attendances = service.createAnyAttendancesForToday(1, allocation)
+
+      assertThat(attendances).isEmpty()
+    }
+
+    @Test
+    fun `should only create an attendance records if session time is on or after the selected scheduled instance start time`() {
+      val firstSlot = allocation.activitySchedule.slots().first()
+
+      allocation.activitySchedule.addSlot(firstSlot.weekNumber, firstSlot.startTime.plusHours(1) to firstSlot.endTime.plusHours(1), firstSlot.getDaysOfWeek())
+      allocation.activitySchedule.addSlot(firstSlot.weekNumber, firstSlot.startTime.plusHours(2) to firstSlot.endTime.plusHours(2), firstSlot.getDaysOfWeek())
+
+      allocation.activitySchedule.addInstance(TimeSource.today(), allocation.activitySchedule.slots()[1])
+      allocation.activitySchedule.addInstance(TimeSource.today(), allocation.activitySchedule.slots()[2])
+
+      whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[1]))
+      whenever(scheduledInstanceRepository.findById(2)).thenReturn(Optional.of(allocation.activitySchedule.instances()[2]))
+
+      val attendances = service.createAnyAttendancesForToday(1, allocation)
+
+      // Should not contain first instance as it is before the second instance that is selected
+      assertThat(attendances).hasSize(2)
+      assertThat(attendances[0].scheduledInstance).isEqualTo(allocation.activitySchedule.instances()[1])
+      assertThat(attendances[1].scheduledInstance).isEqualTo(allocation.activitySchedule.instances()[2])
+    }
+
+    @Test
+    fun `should only create an attendance records if prisoner is able to attend`() {
+      allocation.deallocateNowWithReason(DeallocationReason.ENDED)
+
+      whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[0]))
+
+      val attendances = service.createAnyAttendancesForToday(1, allocation)
+
+      assertThat(attendances).isEmpty()
+    }
   }
 
   private fun setUpActivityWithAttendanceFor(activityStartDate: LocalDate) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
@@ -1089,6 +1089,7 @@ class MigrateActivityServiceTest {
       // The expected allocation - required so final check succeeds
       schedule.allocatePrisoner(
         prisonerNumber = "A1234BB".toPrisonerNumber(),
+        startDate = LocalDate.now().plusDays(1),
         payBand = lowPayBand,
         bookingId = 1,
         allocatedBy = MIGRATION_USER,
@@ -1123,6 +1124,7 @@ class MigrateActivityServiceTest {
       // The expected allocation - required so final check succeeds
       schedule.allocatePrisoner(
         prisonerNumber = "A1234BB".toPrisonerNumber(),
+        startDate = LocalDate.now().plusDays(1),
         payBand = lowPayBand,
         bookingId = 1,
         allocatedBy = MIGRATION_USER,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
@@ -245,6 +245,7 @@ class ScheduledInstanceServiceTest {
       schedule.apply {
         this.allocatePrisoner(
           prisonerNumber = "A1234AB".toPrisonerNumber(),
+          startDate = LocalDate.now().plusDays(1),
           bookingId = 10002,
           payBand = prisonPayBandsLowMediumHigh()[1],
           allocatedBy = "Mr Blogs",

--- a/src/test/resources/test_data/seed-activity-id-1.sql
+++ b/src/test/resources/test_data/seed-activity-id-1.sql
@@ -46,17 +46,25 @@ values (4, 2, 'A11111A', 10001, 3, '2022-10-12', null, '2022-10-10 10:00:00', 'M
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (5, 2, 'A22222A', 10002, 3, '2022-10-12', null, '2022-10-10 10:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (6, 2, 'A1234BC', 10004, 3, current_timestamp + interval '2 day', null, '2022-10-10 10:00:00', 'MRS BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
 values (1, '2022-10-10', '10:00:00', '11:00:00', false, null, null, null, null);
 
-insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
-values (1, 1, 'A11111A', null, null, null, null, 'WAITING', null, null, null);
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (2, current_timestamp, '10:00:00', '11:00:00', false, null, null, null, null);
 
-insert into attendance(attendance_id, scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
-values (2, 1, 'A22222A', null, null, null, null, 'WAITING', null, null, null);
+insert into attendance(scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (1, 'A11111A', null, null, null, null, 'WAITING', null, null, null);
+
+insert into attendance(scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (1, 'A22222A', null, null, null, null, 'WAITING', null, null, null);
 
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
 values (2, '2022-10-10', '14:00:00', '15:00:00', false, null, null, null, null);
 
 insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
 values (1, 'PVI', 'A11111A', 111111, '2023-06-23', 1, 1, 'Fred Bloggs', 'PENDING', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);
+
+

--- a/src/test/resources/test_data/seed-activity-id-7.sql
+++ b/src/test/resources/test_data/seed-activity-id-7.sql
@@ -10,5 +10,8 @@ values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
 insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag)
 values (1, 1, '09:00:00', '12:00:00', true);
 
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment)
+values (1, current_timestamp, '10:00:00', '11:00:00', false, null, null, null, null);
+
 insert into waiting_list(waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by)
 values (1, 'MDI', 'G4793VF', 1134676, '2023-08-08', 1, 1, 'Prison staff', 'APPROVED', '2023-08-10', 'SEED USER')


### PR DESCRIPTION
Allow a new allocation to happen for a session(s) today indicated by the user choosing the scheduled instance in the UI.
Similar for update an allocation.
If prisoner can attend the sessions then new activities will be created and messages posted for synch.
This can also work for sessions earlier in the day should the user dawdle in the UI