### PR TITLE
SAA-1750: Add start date to the activity pay to allow a future date changes for an activity pay rates

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPay.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPay.kt
@@ -12,6 +12,7 @@ import org.hibernate.Hibernate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.PrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPayLite
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonPayBand
+import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPay as ModelActivityPay
 
 @Entity
@@ -38,6 +39,8 @@ data class ActivityPay(
   var pieceRate: Int? = null,
 
   var pieceRateItems: Int? = null,
+
+  val startDate: LocalDate? = null,
 ) {
   override fun equals(other: Any?): Boolean {
     if (this === other) return true
@@ -62,6 +65,7 @@ data class ActivityPay(
     rate = rate,
     pieceRate = pieceRate,
     pieceRateItems = pieceRateItems,
+    startDate = startDate,
   )
 
   fun toModelLite() = ActivityPayLite(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityPay.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityPay.kt
@@ -1,6 +1,7 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
 
 import io.swagger.v3.oas.annotations.media.Schema
+import java.time.LocalDate
 
 @Schema(description = "Describes the pay rates and bands which apply to an activity")
 data class ActivityPay(
@@ -25,4 +26,7 @@ data class ActivityPay(
 
   @Schema(description = "Where payment is related to the number of items produced in a batch of a product, this is the batch size that attract 1 x pieceRate", example = "10")
   val pieceRateItems: Int? = null,
+
+  @Schema(description = "The effective start date for this pay rate", example = "2024-06-18")
+  val startDate: LocalDate? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequest.kt
@@ -151,4 +151,12 @@ data class ActivityCreateRequest(
       EventTierType.valueOf(tierCode) != EventTierType.FOUNDATION ||
       (EventTierType.valueOf(tierCode) == EventTierType.FOUNDATION && attendanceRequired) ||
       (EventTierType.valueOf(tierCode) == EventTierType.FOUNDATION && !attendanceRequired && !paid)
+
+  @AssertTrue(message = "Activity pay rate effective date must not be more than 30 days in the future")
+  private fun isMaximumFuturePayDate() =
+    !paid || (pay.isNotEmpty() && !pay.any { it -> it.startDate?.isAfter(LocalDate.now().plusDays(30)) == true })
+
+  @AssertTrue(message = "Activity pay rate effective date must be unique for a given incentive level and pay band")
+  private fun isDuplicateFuturePayDate() =
+    !paid || (pay.isNotEmpty() && pay.groupingBy { it.incentiveLevel + it.startDate + it.payBandId }.eachCount().filter { it.value > 1 }.isEmpty())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityPayCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityPayCreateRequest.kt
@@ -1,10 +1,12 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request
 
+import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.NotEmpty
 import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Positive
 import jakarta.validation.constraints.Size
+import java.time.LocalDate
 
 @Schema(description = "Describes the pay rates and bands to be created for an activity")
 data class ActivityPayCreateRequest(
@@ -34,4 +36,12 @@ data class ActivityPayCreateRequest(
   @field:Positive(message = "The piece rate items must be a positive integer")
   @Schema(description = "Where payment is related to the number of items produced in a batch of a product, this is the batch size that attract 1 x pieceRate", example = "10")
   val pieceRateItems: Int? = null,
+
+  @Schema(
+    description = "The effective start date for this pay rate",
+    example = "2022-12-23",
+  )
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+  val startDate: LocalDate? = null,
+
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityUpdateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityUpdateRequest.kt
@@ -105,4 +105,12 @@ data class ActivityUpdateRequest(
 
   @AssertTrue(message = "Paid activity must have at least one pay rate associated with it")
   private fun isPaid() = !pay.isNullOrEmpty() || (paid == null || !paid)
+
+  @AssertTrue(message = "Activity pay rate effective date must not be more than 30 days in the future")
+  private fun isMaximumFuturePayDate() =
+    pay.isNullOrEmpty() || (pay.isNotEmpty() && !pay.any { it -> it.startDate?.isAfter(LocalDate.now().plusDays(30)) == true })
+
+  @AssertTrue(message = "Activity pay rate effective date must be unique for a given incentive level and pay band")
+  private fun isDuplicateFuturePayDate() =
+    pay.isNullOrEmpty() || (pay.isNotEmpty() && pay.groupingBy { it.incentiveLevel + it.startDate + it.payBandId }.eachCount().filter { it.value > 1 }.isEmpty())
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityService.kt
@@ -186,6 +186,7 @@ class ActivityService(
             rate = it.rate,
             pieceRate = it.pieceRate,
             pieceRateItems = it.pieceRateItems,
+            startDate = it.startDate,
           )
         }
         request.minimumEducationLevel.forEach {
@@ -629,6 +630,7 @@ class ActivityService(
             rate = it.rate,
             pieceRate = it.pieceRate,
             pieceRateItems = it.pieceRateItems,
+            startDate = it.startDate,
           )
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
@@ -109,7 +109,7 @@ class MigrateActivityService(
             val iep = prisonIncentiveLevels.find { iep -> iep.levelCode == it.incentiveLevel && iep.active }
               ?: logAndThrowValidationException("Failed to migrate activity ${request.description}. Activity incentive level ${it.incentiveLevel} is not active in this prison")
 
-            activity.addPay(it.incentiveLevel, iep.levelName, payBand, it.rate, null, null)
+            activity.addPay(it.incentiveLevel, iep.levelName, payBand, it.rate, null, null, null)
           }
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -310,6 +310,7 @@ private fun List<EntityActivityPay>.toModelActivityPayList() = map {
     rate = it.rate,
     pieceRate = it.pieceRate,
     pieceRateItems = it.pieceRateItems,
+    startDate = it.startDate,
   )
 }
 

--- a/src/main/resources/migrations/common/V2024.07.18__add_activity_pay_start_date.sql
+++ b/src/main/resources/migrations/common/V2024.07.18__add_activity_pay_start_date.sql
@@ -1,0 +1,1 @@
+ALTER TABLE activity_pay ADD COLUMN start_date date;

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPayTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityPayTest.kt
@@ -4,12 +4,16 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.PrisonPayBand
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import java.time.LocalDate
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.PrisonPayBand as PrisonPayBandModel
 
 class ActivityPayTest {
   @Test
   fun `entity is converted to model`() {
     val activity = activityEntity()
+
+    val payStartDate = LocalDate.now()
+
     val activityPayEntity = ActivityPay(
       1,
       activity,
@@ -26,6 +30,7 @@ class ActivityPayTest {
       rate = 100,
       pieceRate = 150,
       pieceRateItems = 1,
+      startDate = payStartDate,
     )
 
     with(activityPayEntity.toModel()) {
@@ -45,6 +50,7 @@ class ActivityPayTest {
       assertThat(rate).isEqualTo(100)
       assertThat(pieceRate).isEqualTo(150)
       assertThat(pieceRateItems).isEqualTo(1)
+      assertThat(payStartDate).isEqualTo(payStartDate)
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
@@ -362,6 +362,7 @@ class ActivityTest {
       rate = 30,
       pieceRate = 40,
       pieceRateItems = 50,
+      startDate = null,
     )
 
     activity.addPay(
@@ -371,6 +372,7 @@ class ActivityTest {
       rate = 40,
       pieceRate = 50,
       pieceRateItems = 60,
+      startDate = null,
     )
 
     assertThat(activity.activityPay()).containsExactlyInAnyOrder(
@@ -396,6 +398,53 @@ class ActivityTest {
   }
 
   @Test
+  fun `can add pay bands to paid activity with a pay band and iep combinations to activity`() {
+    val activity = activityEntity(noPayBands = true, paid = true).also { assertThat(it.activityPay()).isEmpty() }
+
+    activity.addPay(
+      incentiveNomisCode = "STD",
+      incentiveLevel = "Standard",
+      payBand = lowPayBand,
+      rate = 30,
+      pieceRate = 40,
+      pieceRateItems = 50,
+      startDate = null,
+    )
+
+    activity.addPay(
+      incentiveNomisCode = "STD",
+      incentiveLevel = "Standard",
+      payBand = mediumPayBand,
+      rate = 50,
+      pieceRate = 50,
+      pieceRateItems = 60,
+      startDate = LocalDate.now(),
+    )
+
+    assertThat(activity.activityPay()).containsExactlyInAnyOrder(
+      ActivityPay(
+        incentiveNomisCode = "STD",
+        incentiveLevel = "Standard",
+        payBand = lowPayBand,
+        rate = 30,
+        pieceRate = 40,
+        pieceRateItems = 50,
+        activity = activity,
+      ),
+      ActivityPay(
+        incentiveNomisCode = "STD",
+        incentiveLevel = "Standard",
+        payBand = mediumPayBand,
+        rate = 40,
+        pieceRate = 50,
+        pieceRateItems = 60,
+        activity = activity,
+        startDate = LocalDate.now(),
+      ),
+    )
+  }
+
+  @Test
   fun `cannot add pay bands to unpaid activity`() {
     val activity = activityEntity(noPayBands = true, paid = false).also { assertThat(it.activityPay()).isEmpty() }
 
@@ -407,13 +456,14 @@ class ActivityTest {
         rate = 30,
         pieceRate = 40,
         pieceRateItems = 50,
+        startDate = null,
       )
     }.isInstanceOf(IllegalArgumentException::class.java)
       .hasMessage("Unpaid activity 'Maths' cannot have pay rates added to it")
   }
 
   @Test
-  fun `cannot add duplicate pay band and iep combinations to activity`() {
+  fun `cannot add duplicate pay band, start date and iep combinations to activity`() {
     val activity = activityEntity(noPayBands = true).also { assertThat(it.activityPay()).isEmpty() }
 
     activity.addPay(
@@ -423,6 +473,7 @@ class ActivityTest {
       rate = 30,
       pieceRate = 40,
       pieceRateItems = 50,
+      startDate = null,
     )
 
     val exception = assertThrows<IllegalArgumentException> {
@@ -433,10 +484,10 @@ class ActivityTest {
         rate = 40,
         pieceRate = 50,
         pieceRateItems = 60,
+        startDate = null,
       )
     }
-
-    assertThat(exception.message).isEqualTo("The pay band and incentive level combination must be unique for each pay rate")
+    assertThat(exception.message).isEqualTo("The pay band, incentive level and start date combination must be unique for each pay rate")
   }
 
   @Test
@@ -548,6 +599,76 @@ class ActivityTest {
         pieceRateItems = 50,
       ),
     )
+  }
+
+  @Test
+  fun `can fetch activity pay for a particular band and incentive code when there are multiple historic pays`() {
+    val activity = activityEntity()
+
+    activity.addPay(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBand = lowPayBand,
+      rate = 33,
+      pieceRate = 45,
+      pieceRateItems = 55,
+      startDate = LocalDate.now().minusDays(10),
+    )
+
+    activity.addPay(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBand = lowPayBand,
+      rate = 34,
+      pieceRate = 45,
+      pieceRateItems = 55,
+      startDate = LocalDate.now().minusDays(1),
+    )
+
+    val currentPay = activity.activityPayFor(lowPayBand, "BAS")
+
+    assertThat(currentPay!!.rate).isEqualTo(34)
+    assertThat(currentPay!!.startDate).isEqualTo(LocalDate.now().minusDays(1))
+  }
+
+  @Test
+  fun `can fetch activity pay for a particular band and incentive code when there are multiple historic and future pays`() {
+    val activity = activityEntity()
+
+    activity.addPay(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBand = lowPayBand,
+      rate = 35,
+      pieceRate = 45,
+      pieceRateItems = 55,
+      startDate = LocalDate.now().minusDays(1),
+    )
+
+    activity.addPay(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBand = lowPayBand,
+      rate = 65,
+      pieceRate = 65,
+      pieceRateItems = 65,
+      startDate = LocalDate.now().plusDays(1),
+    )
+
+    activity.addPay(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBand = lowPayBand,
+      rate = 75,
+      pieceRate = 75,
+      pieceRateItems = 75,
+      startDate = LocalDate.now().plusDays(6),
+    )
+
+    val currentPay = activity.activityPayFor(lowPayBand, "BAS")
+
+    assertThat(currentPay!!.rate).isEqualTo(35)
+    assertThat(currentPay!!.startDate).isEqualTo(LocalDate.now().minusDays(1))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -336,6 +336,55 @@ class AllocationTest {
   }
 
   @Test
+  fun `is able to get allocation pay with multiple activity pays`() {
+    val allocation = allocation()
+
+    allocation.activitySchedule.activity.addPay(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBand = lowPayBand,
+      rate = 35,
+      pieceRate = 45,
+      pieceRateItems = 55,
+      startDate = LocalDate.now().minusDays(5),
+    )
+
+    allocation.activitySchedule.activity.addPay(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBand = lowPayBand,
+      rate = 50,
+      pieceRate = 50,
+      pieceRateItems = 60,
+      startDate = LocalDate.now().minusDays(1),
+    )
+
+    allocation.activitySchedule.activity.addPay(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBand = lowPayBand,
+      rate = 55,
+      pieceRate = 50,
+      pieceRateItems = 60,
+      startDate = LocalDate.now().plusDays(4),
+    )
+
+    val allocationPay = allocation.allocationPay("BAS")
+
+    assertThat(allocationPay).isEqualTo(
+      ActivityPay(
+        activity = allocation.activitySchedule.activity,
+        incentiveNomisCode = "BAS",
+        incentiveLevel = "Basic",
+        payBand = lowPayBand,
+        rate = 50,
+        pieceRate = 50,
+        pieceRateItems = 60,
+      ),
+    )
+  }
+
+  @Test
   fun `planned deallocation is updated when new end date is before planned`() {
     val allocation = allocation().apply {
       endDate = null

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonapi.overrides.ReferenceCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toPrisonerNumber
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityPay
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityScheduleSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityState
@@ -107,6 +108,7 @@ internal fun activityEntity(
         rate = 30,
         pieceRate = 40,
         pieceRateItems = 50,
+        startDate = null,
       )
     }
     if (!noMinimumEducationLevels) {
@@ -118,6 +120,26 @@ internal fun activityEntity(
       )
     }
   }
+
+internal fun activityPayEntity(payStartDate: LocalDate? = null) =
+  ActivityPay(
+    1,
+    activity = activityEntity(),
+    incentiveNomisCode = "STD",
+    incentiveLevel = "Standard",
+    payBand = PrisonPayBand(
+      prisonPayBandId = 1,
+      displaySequence = 1,
+      nomisPayBand = 1,
+      payBandAlias = "Low",
+      payBandDescription = "Pay band 1",
+      prisonCode = "MDI",
+    ),
+    rate = 100,
+    pieceRate = 150,
+    pieceRateItems = 1,
+    startDate = payStartDate,
+  )
 
 internal fun activitySummary(
   category: ActivityCategory = activityCategory(),
@@ -397,6 +419,24 @@ fun attendanceList(): List<AllAttendance> = listOf(
     attendanceRequired = true,
     eventTier = null,
   ),
+)
+
+internal fun activityPayCreateRequest(
+  incentiveNomisCode: String = "123",
+  incentiveLevel: String = "level",
+  payBandId: Long = 12,
+  rate: Int? = null,
+  pieceRate: Int? = null,
+  pieceRateItems: Int? = 10,
+  startDate: LocalDate? = null,
+) = ActivityPayCreateRequest(
+  incentiveNomisCode = incentiveNomisCode,
+  incentiveLevel = incentiveLevel,
+  payBandId = payBandId,
+  rate = rate,
+  pieceRate = pieceRate,
+  pieceRateItems = pieceRateItems,
+  startDate = startDate,
 )
 
 internal fun activityCreateRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/ActivityCreateRequestTest.kt
@@ -6,14 +6,39 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityCreateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityPayCreateRequest
+import java.time.LocalDate
 
-class ActivityCreateRequestTest {
+class ActivityCreateRequestTest : ValidatorBase<ActivityCreateRequest>() {
 
   private val validator: Validator = Validation.buildDefaultValidatorFactory().validator
 
   @Test
   fun `valid create activity request`() {
     val ar = activityCreateRequest()
+    assertThat(validator.validate(ar)).isEmpty()
+  }
+
+  @Test
+  fun `valid create activity request with a pay rate effective from date`() {
+    val apr = activityPayCreateRequest(startDate = LocalDate.now().plusDays(2))
+    val ar = activityCreateRequest(paid = true).copy(pay = listOf(apr))
+    assertThat(validator.validate(ar)).isEmpty()
+  }
+
+  @Test
+  fun `valid create activity request with a pay rate effective from date of 30 days`() {
+    val apr = activityPayCreateRequest(startDate = LocalDate.now().plusDays(30))
+    val ar = activityCreateRequest(paid = true).copy(pay = listOf(apr))
+    assertThat(validator.validate(ar)).isEmpty()
+  }
+
+  @Test
+  fun `Valid activity with same incentive level, payband and different effective pay from date`() {
+    val apr1 = activityPayCreateRequest(startDate = LocalDate.now().plusDays(5))
+    val apr2 = activityPayCreateRequest(startDate = LocalDate.now().plusDays(25))
+    val ar = activityCreateRequest(paid = true).copy(pay = listOf(apr1, apr2))
+
     assertThat(validator.validate(ar)).isEmpty()
   }
 
@@ -63,6 +88,23 @@ class ActivityCreateRequestTest {
       assertThat(it.propertyPath.toString()).isEqualTo("paid")
       assertThat(it.message).isEqualTo("Paid activity must have at least one pay rate associated with it")
     }
+  }
+
+  @Test
+  fun `Paid activity with an effective pay from date must be a maximum of 30 days in the future`() {
+    val apr = activityPayCreateRequest(startDate = LocalDate.now().plusDays(31))
+    val ar = activityCreateRequest(paid = true).copy(pay = listOf(apr))
+
+    ar failsWithSingle ModelError("maximumFuturePayDate", "Activity pay rate effective date must not be more than 30 days in the future")
+  }
+
+  @Test
+  fun `Paid activity with an effective pay from date must be unique`() {
+    val apr1 = activityPayCreateRequest(startDate = LocalDate.now().plusDays(25))
+    val apr2 = activityPayCreateRequest(startDate = LocalDate.now().plusDays(25))
+    val ar = activityCreateRequest(paid = true).copy(pay = listOf(apr1, apr2))
+
+    ar failsWithSingle ModelError("duplicateFuturePayDate", "Activity pay rate effective date must be unique for a given incentive level and pay band")
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityServiceTest.kt
@@ -37,6 +37,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activit
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityCategory2
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityPayCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activitySummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.eligibilityRuleFemale
@@ -82,7 +83,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.transform
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
-import java.util.*
+import java.util.Optional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity as ActivityEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.EligibilityRule as EligibilityRuleEntity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity as ModelActivity
@@ -288,6 +289,108 @@ class ActivityServiceTest {
         ).isEmpty()
       }
     }
+  }
+
+  @Test
+  fun `createActivity - success - with multiple pay rates for the same incentive level and pay band`() {
+    val apr1 = activityPayCreateRequest(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBandId = 1,
+      rate = 125,
+    )
+
+    val apr2 = activityPayCreateRequest(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBandId = 1,
+      rate = 150,
+      startDate = LocalDate.now().plusDays(25),
+    )
+
+    val createActivityRequest = mapper.read<ActivityCreateRequest>("activity/activity-create-request-1.json")
+      .copy(startDate = TimeSource.tomorrow(), pay = listOf(apr1, apr2))
+
+    whenever(activityCategoryRepository.findById(1)).thenReturn(Optional.of(activityCategory()))
+    whenever(eventTierRepository.findByCode("TIER_2")).thenReturn(eventTier())
+    whenever(eventOrganiserRepository.findByCode("PRISON_STAFF")).thenReturn(eventOrganiser())
+    whenever(eligibilityRuleRepository.findById(eligibilityRuleOver21.eligibilityRuleId)).thenReturn(
+      Optional.of(
+        eligibilityRuleOver21,
+      ),
+    )
+    whenever(prisonPayBandRepository.findByPrisonCode("MDI")).thenReturn(prisonPayBandsLowMediumHigh())
+    whenever(prisonApiClient.getEducationLevel("1")).thenReturn(Mono.just(educationLevel))
+    whenever(prisonApiClient.getStudyArea("ENGLA")).thenReturn(Mono.just(studyArea))
+    whenever(activityRepository.saveAndFlush(any())).thenAnswer {
+        invocation ->
+      invocation.getArgument(0, ActivityEntity::class.java)
+    }
+
+    service().createActivity(createActivityRequest, "SCH_ACTIVITY")
+
+    verify(activityRepository).saveAndFlush(activityCaptor.capture())
+    verify(activityCategoryRepository).findById(1)
+    verify(eventTierRepository).findByCode("TIER_2")
+    verify(eventOrganiserRepository).findByCode("PRISON_STAFF")
+    verify(eligibilityRuleRepository).findById(any())
+
+    with(activityCaptor.firstValue) {
+      assertThat(eligibilityRules()).hasSize(1)
+      assertThat(activityPay()).hasSize(2)
+      assertThat(activityMinimumEducationLevel()).hasSize(1)
+      assertThat(activityCategory).isEqualTo(activityCategory())
+      assertThat(activityTier).isEqualTo(eventTier())
+      assertThat(organiser).isEqualTo(eventOrganiser())
+    }
+
+    val metricsPropertiesMap = mapOf(
+      PRISON_CODE_PROPERTY_KEY to createActivityRequest.prisonCode,
+      ACTIVITY_NAME_PROPERTY_KEY to createActivityRequest.summary,
+      EVENT_TIER_PROPERTY_KEY to activityCaptor.firstValue.activityTier.description,
+      EVENT_ORGANISER_PROPERTY_KEY to activityCaptor.firstValue.organiser!!.description,
+    )
+    verify(telemetryClient).trackEvent(TelemetryEvent.ACTIVITY_CREATED.value, metricsPropertiesMap, activityMetricsMap())
+    verify(outboundEventsService).send(OutboundEvent.ACTIVITY_SCHEDULE_CREATED, 0)
+  }
+
+  @Test
+  fun `createActivity - fails when the pay band, incentive level and start date are not unique`() {
+    val apr1 = activityPayCreateRequest(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBandId = 1,
+      rate = 125,
+      startDate = LocalDate.now().plusDays(25),
+    )
+
+    val apr2 = activityPayCreateRequest(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBandId = 1,
+      rate = 150,
+      startDate = LocalDate.now().plusDays(25),
+    )
+
+    val createActivityRequest = mapper.read<ActivityCreateRequest>("activity/activity-create-request-1.json")
+      .copy(startDate = TimeSource.tomorrow(), pay = listOf(apr1, apr2))
+
+    whenever(activityCategoryRepository.findById(1)).thenReturn(Optional.of(activityCategory()))
+    whenever(eventTierRepository.findByCode("TIER_2")).thenReturn(eventTier())
+    whenever(eventOrganiserRepository.findByCode("PRISON_STAFF")).thenReturn(eventOrganiser())
+    whenever(eligibilityRuleRepository.findById(eligibilityRuleOver21.eligibilityRuleId)).thenReturn(
+      Optional.of(
+        eligibilityRuleOver21,
+      ),
+    )
+    whenever(prisonPayBandRepository.findByPrisonCode("MDI")).thenReturn(prisonPayBandsLowMediumHigh())
+    whenever(prisonApiClient.getEducationLevel("1")).thenReturn(Mono.just(educationLevel))
+    whenever(prisonApiClient.getStudyArea("ENGLA")).thenReturn(Mono.just(studyArea))
+
+    assertThatThrownBy {
+      service().createActivity(createActivityRequest, "SCH_ACTIVITY")
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("The pay band, incentive level and start date combination must be unique for each pay rate")
   }
 
   @Test
@@ -1040,6 +1143,99 @@ class ActivityServiceTest {
   }
 
   @Test
+  fun `updateActivity - update pay with multiple pay rates for the same incentive level and pay band`() {
+    val apr1 = activityPayCreateRequest(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBandId = 1,
+      rate = 125,
+      pieceRate = 150,
+      pieceRateItems = 10,
+    )
+
+    val apr2 = activityPayCreateRequest(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBandId = 1,
+      rate = 150,
+      pieceRate = 150,
+      pieceRateItems = 10,
+      startDate = LocalDate.now().plusDays(25),
+    )
+
+    val updateActivityRequest: ActivityUpdateRequest =
+      mapper.read<ActivityUpdateRequest>("activity/activity-update-request-3.json").copy(pay = listOf(apr1, apr2))
+
+    val activityEntity: ActivityEntity = activityEntity(noPayBands = true).copy(activityId = 17)
+
+    whenever(
+      activityRepository.findByActivityIdAndPrisonCodeWithFilters(
+        17,
+        MOORLAND_PRISON_CODE,
+        LocalDate.now(),
+      ),
+    ).thenReturn(activityEntity)
+    whenever(activityRepository.saveAndFlush(any())).thenReturn(activityEntity)
+    whenever(prisonPayBandRepository.findByPrisonCode(MOORLAND_PRISON_CODE)).thenReturn(prisonPayBandsLowMediumHigh())
+
+    service().updateActivity(MOORLAND_PRISON_CODE, 17, updateActivityRequest, "SCH_ACTIVITY")
+
+    verify(activityRepository).saveAndFlush(activityCaptor.capture())
+
+    with(activityCaptor.firstValue) {
+      assertThat(activityPay()).hasSize(2)
+    }
+
+    with(activityCaptor.firstValue.activityPay()) {
+      single { it.startDate == null }
+      single { it.startDate == java.time.LocalDate.now().plusDays(25) }
+    }
+  }
+
+  @Test
+  fun `updateActivity - update pay with multiple pay rates for the same incentive level, pay band and start date fails`() {
+    val apr1 = activityPayCreateRequest(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBandId = 1,
+      rate = 125,
+      pieceRate = 150,
+      pieceRateItems = 10,
+      startDate = LocalDate.now().plusDays(25),
+    )
+
+    val apr2 = activityPayCreateRequest(
+      incentiveNomisCode = "BAS",
+      incentiveLevel = "Basic",
+      payBandId = 1,
+      rate = 150,
+      pieceRate = 150,
+      pieceRateItems = 10,
+      startDate = LocalDate.now().plusDays(25),
+    )
+
+    val updateActivityRequest: ActivityUpdateRequest =
+      mapper.read<ActivityUpdateRequest>("activity/activity-update-request-3.json").copy(pay = listOf(apr1, apr2))
+
+    val activityEntity: ActivityEntity = activityEntity(noPayBands = true).copy(activityId = 17)
+
+    whenever(
+      activityRepository.findByActivityIdAndPrisonCodeWithFilters(
+        17,
+        MOORLAND_PRISON_CODE,
+        LocalDate.now(),
+      ),
+    ).thenReturn(activityEntity)
+    whenever(activityRepository.saveAndFlush(any())).thenReturn(activityEntity)
+    whenever(prisonPayBandRepository.findByPrisonCode(MOORLAND_PRISON_CODE)).thenReturn(prisonPayBandsLowMediumHigh())
+
+    assertThatThrownBy {
+      service().updateActivity(MOORLAND_PRISON_CODE, 17, updateActivityRequest, "TEST")
+    }.isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("The pay band, incentive level and start date combination must be unique for each pay rate")
+  }
+
+  @Test
   fun `updateActivity - update pay band where someone is allocated to it`() {
     val updateActivityRequest: ActivityUpdateRequest = mapper.read("activity/activity-update-request-6.json")
     val activityEntity: ActivityEntity = activityEntity()
@@ -1066,7 +1262,38 @@ class ActivityServiceTest {
       assertThat(activityPay()).hasSize(1)
       assertThat(schedules().first().allocations().first().payBand?.prisonPayBandId).isEqualTo(updateActivityRequest.pay!!.first().payBandId)
     }
+    verify(outboundEventsService).send(OutboundEvent.ACTIVITY_SCHEDULE_UPDATED, 1L)
+    verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, 0L)
+  }
 
+  @Test
+  fun `updateActivity - update pay band where there is multiple pays for the same incentive level and nomic code and someone is allocated to it`() {
+    val updateActivityRequest: ActivityUpdateRequest = mapper.read("activity/activity-update-request-7.json")
+    val activityEntity: ActivityEntity = activityEntity()
+
+    whenever(
+      activityRepository.findByActivityIdAndPrisonCodeWithFilters(
+        17,
+        MOORLAND_PRISON_CODE,
+        LocalDate.now(),
+      ),
+    ).thenReturn(activityEntity)
+    whenever(activityRepository.saveAndFlush(any())).thenReturn(activityEntity)
+    whenever(prisonPayBandRepository.findByPrisonCode(MOORLAND_PRISON_CODE)).thenReturn(prisonPayBandsLowMediumHigh())
+
+    val prisonerNumbers = activityEntity.schedules().first().allocations().map { it.prisonerNumber }
+    val prisoners = prisonerNumbers.map { PrisonerSearchPrisonerFixture.instance(prisonerNumber = it) }
+    whenever(prisonerSearchApiClient.findByPrisonerNumbers(prisonerNumbers)).thenReturn(prisoners)
+
+    service().updateActivity(MOORLAND_PRISON_CODE, 17, updateActivityRequest, "SCH_ACTIVITY")
+
+    verify(activityRepository).saveAndFlush(activityCaptor.capture())
+
+    with(activityCaptor.firstValue) {
+      assertThat(activityPay()).hasSize(2)
+      assertThat(schedules().first().allocations().first().payBand?.prisonPayBandId).isEqualTo(updateActivityRequest.pay!!.last().payBandId)
+    }
+    verify(outboundEventsService).send(OutboundEvent.ACTIVITY_SCHEDULE_UPDATED, 1L)
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, 0L)
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
@@ -241,6 +241,7 @@ class ScheduledInstanceServiceTest {
         rate = 50,
         pieceRate = 60,
         pieceRateItems = 70,
+        startDate = null,
       )
       schedule.apply {
         this.allocatePrisoner(

--- a/src/test/resources/__files/activity/activity-update-request-7.json
+++ b/src/test/resources/__files/activity/activity-update-request-7.json
@@ -1,0 +1,21 @@
+{
+  "pay": [
+    {
+      "incentiveNomisCode": "BAS",
+      "incentiveLevel": "Basic",
+      "payBandId": 2,
+      "rate": 150,
+      "pieceRate": 150,
+      "pieceRateItems": 10
+    },
+    {
+      "incentiveNomisCode": "BAS",
+      "incentiveLevel": "Basic",
+      "payBandId": 2,
+      "rate": 150,
+      "pieceRate": 150,
+      "pieceRateItems": 10,
+      "startDate": "2024-06-25"
+    }
+  ]
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,6 +13,7 @@ spring:
     show-sql: true
     properties:
       hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
         generate_statistics: false
 
   datasource:


### PR DESCRIPTION
Include getting the current dates pay rate and storing in the database