### PR TITLE
SAA-1948 start date only, day of week

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
@@ -37,9 +37,6 @@ data class AppointmentSearchRequest(
   @JsonFormat(pattern = "yyyy-MM-dd")
   val startDate: LocalDate,
 
-  @Deprecated("this is not supported - do not supply")
-  val endDate: LocalDate? = null,
-
   @Schema(
     description =
     """

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
@@ -35,16 +35,9 @@ data class AppointmentSearchRequest(
     """,
   )
   @JsonFormat(pattern = "yyyy-MM-dd")
-  val startDate: LocalDate? = null,
+  val startDate: LocalDate,
 
-  @Schema(
-    description =
-    """
-    The end date of the date range to match with the appointments. Start date must be supplied if an end date
-    is specified. Will restrict the search results to appointments that have a start date within the date range.
-    """,
-  )
-  @JsonFormat(pattern = "yyyy-MM-dd")
+  @Deprecated("this is not supported - do not supply")
   val endDate: LocalDate? = null,
 
   @Schema(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequestTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequestTest.kt
@@ -14,13 +14,4 @@ class AppointmentSearchRequestTest {
     val request = AppointmentSearchRequest(startDate = LocalDate.now())
     assertThat(validator.validate(request)).isEmpty()
   }
-
-  @Test
-  fun `start date must be supplied`() {
-    val request = AppointmentSearchRequest(startDate = null)
-    val result = validator.validate(request)
-    assertThat(result.size).isEqualTo(1)
-    assertThat(result.first().propertyPath.toString()).isEqualTo("startDate")
-    assertThat(result.first().message).isEqualTo("Start date must be supplied")
-  }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AppointmentControllerTest.kt
@@ -344,27 +344,6 @@ class AppointmentControllerTest : ControllerTestBase<AppointmentController>() {
   }
 
   @Test
-  fun `400 bad request response when search appointments with invalid json`() {
-    val request = AppointmentSearchRequest()
-    val mockPrincipal: Principal = mock()
-
-    mockMvc.searchAppointments("TPR", request, mockPrincipal)
-      .andDo { print() }
-      .andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
-      .andExpect {
-        status { isBadRequest() }
-        content {
-          contentType(MediaType.APPLICATION_JSON)
-          jsonPath("$.developerMessage") {
-            value(Matchers.containsString("Start date must be supplied"))
-          }
-        }
-      }
-
-    verifyNoInteractions(appointmentService)
-  }
-
-  @Test
   fun `202 accepted response when search appointments with valid json`() {
     val request = AppointmentSearchRequest(startDate = LocalDate.now())
     val expectedResponse = listOf(appointmentSearchResultModel())

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSearchServiceTest.kt
@@ -37,7 +37,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.RolloutPrisonService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.CATEGORY_CODE_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.CREATED_BY_PROPERTY_KEY
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.END_DATE_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.EVENT_TIME_MS_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.INTERNAL_LOCATION_ID_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.PRISONER_NUMBER_PROPERTY_KEY
@@ -150,49 +149,6 @@ class AppointmentSearchServiceTest {
       assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
       assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
       assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
-      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo("")
-      assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo("[]")
-      assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo("")
-      assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo("")
-      assertThat(value[PRISONER_NUMBER_PROPERTY_KEY]).isEqualTo("")
-      assertThat(value[CREATED_BY_PROPERTY_KEY]).isEqualTo("")
-    }
-
-    with(telemetryMetricsMap) {
-      assertThat(value[RESULTS_COUNT_METRIC_KEY]).isEqualTo(1.0)
-      assertThat(value[EVENT_TIME_MS_METRIC_KEY]).isNotNull()
-    }
-  }
-
-  @Test
-  fun `search by start and end date`() {
-    val request = AppointmentSearchRequest(startDate = LocalDate.now(), endDate = LocalDate.now().plusWeeks(1))
-    val result = appointmentSearchEntity()
-
-    whenever(appointmentSearchRepository.findAll(any())).thenReturn(listOf(result))
-    whenever(appointmentAttendeeSearchRepository.findByAppointmentIds(listOf(result.appointmentId))).thenReturn(result.attendees)
-    whenever(referenceCodeService.getReferenceCodesMap(ReferenceCodeDomain.APPOINTMENT_CATEGORY))
-      .thenReturn(mapOf(result.categoryCode to appointmentCategoryReferenceCode(result.categoryCode)))
-    whenever(locationService.getLocationsForAppointmentsMap(result.prisonCode))
-      .thenReturn(mapOf(result.internalLocationId!! to appointmentLocation(result.internalLocationId!!, "TPR")))
-
-    service.searchAppointments("TPR", request, principal)
-
-    verify(appointmentSearchSpecification).prisonCodeEquals("TPR")
-    verify(appointmentSearchSpecification).startDateBetween(request.startDate!!, request.endDate!!)
-    verifyNoMoreInteractions(appointmentSearchSpecification)
-
-    verify(telemetryClient).trackEvent(
-      eq(TelemetryEvent.APPOINTMENT_SEARCH.value),
-      telemetryPropertyMap.capture(),
-      telemetryMetricsMap.capture(),
-    )
-
-    with(telemetryPropertyMap) {
-      assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
-      assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
-      assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
-      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo(request.endDate.toString())
       assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo("[]")
       assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo("")
@@ -237,7 +193,6 @@ class AppointmentSearchServiceTest {
       assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
       assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
       assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
-      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo(request.timeSlots.toString())
       assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo("")
@@ -285,7 +240,6 @@ class AppointmentSearchServiceTest {
       assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
       assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
       assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
-      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo(request.timeSlots.toString())
       assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo("")
@@ -314,7 +268,7 @@ class AppointmentSearchServiceTest {
     service.searchAppointments("TPR", request, principal)
 
     verify(appointmentSearchSpecification).prisonCodeEquals("TPR")
-    verify(appointmentSearchSpecification).startDateEquals(request.startDate!!)
+    verify(appointmentSearchSpecification).startDateEquals(request.startDate)
     verify(appointmentSearchSpecification).categoryCodeEquals(request.categoryCode!!)
     verifyNoMoreInteractions(appointmentSearchSpecification)
 
@@ -328,7 +282,6 @@ class AppointmentSearchServiceTest {
       assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
       assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
       assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
-      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo("[]")
       assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo(request.categoryCode)
       assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo("")
@@ -357,7 +310,7 @@ class AppointmentSearchServiceTest {
     service.searchAppointments("TPR", request, principal)
 
     verify(appointmentSearchSpecification).prisonCodeEquals("TPR")
-    verify(appointmentSearchSpecification).startDateEquals(request.startDate!!)
+    verify(appointmentSearchSpecification).startDateEquals(request.startDate)
     verify(appointmentSearchSpecification).internalLocationIdEquals(request.internalLocationId!!)
     verifyNoMoreInteractions(appointmentSearchSpecification)
 
@@ -371,7 +324,6 @@ class AppointmentSearchServiceTest {
       assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
       assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
       assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
-      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo("[]")
       assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo(request.internalLocationId.toString())
@@ -434,7 +386,6 @@ class AppointmentSearchServiceTest {
       assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
       assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
       assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
-      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo("[]")
       assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo("")
@@ -477,7 +428,6 @@ class AppointmentSearchServiceTest {
       assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
       assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
       assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
-      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo("[]")
       assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo("")
       assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo("")

--- a/src/test/resources/test_data/seed-appointment-search.sql
+++ b/src/test/resources/test_data/seed-appointment-search.sql
@@ -17,9 +17,9 @@ VALUES (301, 201, 'B2345CD', 457);
 
 --Prisoner A1234BC, Category AC3, In cell, One week from now 12:30-14:00, Created by TEST.USER
 INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
-VALUES (102, 'INDIVIDUAL', 'MDI', 'AC3', 1, null, true, now()::date + 7, '12:30', '14:00', now()::timestamp, 'TEST.USER');
+VALUES (102, 'INDIVIDUAL', 'MDI', 'AC3', 1, null, true, now()::date, '12:30', '14:00', now()::timestamp, 'TEST.USER');
 INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
-VALUES (202, 102, 1, 'MDI', 'AC3', 1, null, true, now()::date + 7, '12:30', '14:00', now()::timestamp, 'TEST.USER');
+VALUES (202, 102, 1, 'MDI', 'AC3', 1, null, true, now()::date, '12:30', '14:00', now()::timestamp, 'TEST.USER');
 INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (302, 202, 'A1234BC', 456);
 
@@ -45,15 +45,15 @@ VALUES (304, 204, 'A1234BC', 456);
 INSERT INTO appointment_series_schedule (appointment_series_schedule_id, frequency, number_of_appointments)
 VALUES (10, 'WEEKLY', 4);
 INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, appointment_series_schedule_id, created_time, created_by)
-VALUES (110, 'GROUP', 'MDI', 'AC1', 1, 123, false, now()::date - 7, '09:00', '10:30', 10, now()::timestamp, 'TEST.USER');
+VALUES (110, 'GROUP', 'MDI', 'AC1', 1, 123, false, now()::date, '09:00', '10:30', 10, now()::timestamp, 'TEST.USER');
 INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
-VALUES (210, 110, 1, 'MDI', 'AC1', 1, 123, false, now()::date - 7, '09:00', '10:30', now()::timestamp, 'TEST.USER');
+VALUES (210, 110, 1, 'MDI', 'AC1', 1, 123, false, now()::date , '09:00', '10:30', now()::timestamp, 'TEST.USER');
 INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, updated_time, updated_by)
 VALUES (211, 110, 2, 'MDI', 'AC1', 1, 456, false, now()::date, '13:30', '15:00', now()::timestamp, 'TEST.USER', now()::timestamp, 'DIFFERENT.USER');
 INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, cancelled_time, cancellation_reason_id, cancelled_by)
-VALUES (212, 110, 3, 'MDI', 'AC1', 1, 123, false, now()::date + 7, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 2, 'DIFFERENT.USER');
+VALUES (212, 110, 3, 'MDI', 'AC1', 1, 123, false, now()::date, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 2, 'DIFFERENT.USER');
 INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, cancelled_time, cancellation_reason_id, cancelled_by, is_deleted)
-VALUES (213, 110, 4, 'MDI', 'AC1', 1, 123, false, now()::date + 14, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 1, 'DIFFERENT.USER', true);
+VALUES (213, 110, 4, 'MDI', 'AC1', 1, 123, false, now()::date, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 1, 'DIFFERENT.USER', true);
 INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (320, 210, 'A1234BC', 456);
 INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)


### PR DESCRIPTION
Resolves the day of week, for regime times, when timeslots passed in.  Issue is a date range, and different regime times not compatible in current code pattern

The endpoint request has startDate as not null, yet declared as nullable, with tests for some reason around  json, bizarre.

removing the end date, as its optional, our UI does not use it

It is being used by BAVL but will get picked up by openApi next time they generate, and they are using the same date for start and end anyway, no need to pass end.
