### PR TITLE
SAA-2067: Improve speed of retrieving scheduled instances for multiple attendances

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Activity.kt
@@ -297,30 +297,36 @@ data class Activity(
 
   fun ends(date: LocalDate) = date == endDate
 
-  fun toModelLite() = ActivityLite(
-    id = activityId,
-    prisonCode = prisonCode,
-    attendanceRequired = attendanceRequired,
-    inCell = inCell,
-    onWing = onWing,
-    offWing = offWing,
-    pieceWork = pieceWork,
-    outsideWork = outsideWork,
-    payPerSession = ModelPayPerSession.valueOf(payPerSession.name),
-    summary = summary,
-    description = description,
-    category = activityCategory.toModel(),
-    riskLevel = riskLevel,
-    minimumEducationLevel = activityMinimumEducationLevel().toModel(),
-    capacity = schedules().sumOf { schedule -> schedule.capacity },
-    allocated = schedules().sumOf { schedule ->
-      schedule.allocations().filterNot { it.status(PrisonerStatus.ENDED) }.size
-    },
-    endDate = endDate,
-    createdTime = createdTime,
-    activityState = getActivityState(),
-    paid = paid,
-  )
+  fun toModelLite(includeAllocations: Boolean = true): ActivityLite {
+    val numAllocated = if (includeAllocations) {
+      schedules().sumOf { schedule -> schedule.allocations().filterNot { it.status(PrisonerStatus.ENDED) }.size }
+    } else {
+      0
+    }
+
+    return ActivityLite(
+      id = activityId,
+      prisonCode = prisonCode,
+      attendanceRequired = attendanceRequired,
+      inCell = inCell,
+      onWing = onWing,
+      offWing = offWing,
+      pieceWork = pieceWork,
+      outsideWork = outsideWork,
+      payPerSession = ModelPayPerSession.valueOf(payPerSession.name),
+      summary = summary,
+      description = description,
+      category = activityCategory.toModel(),
+      riskLevel = riskLevel,
+      minimumEducationLevel = activityMinimumEducationLevel().toModel(),
+      capacity = schedules().sumOf { schedule -> schedule.capacity },
+      allocated = numAllocated,
+      endDate = endDate,
+      createdTime = createdTime,
+      activityState = getActivityState(),
+      paid = paid,
+    )
+  }
 
   fun isPaid() = paid
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivitySchedule.kt
@@ -345,11 +345,11 @@ data class ActivitySchedule(
     }
   }
 
-  fun toModelLite() = ActivityScheduleLite(
+  fun toModelLite(includeAllocations: Boolean = true) = ActivityScheduleLite(
     id = this.activityScheduleId,
     description = this.description,
     capacity = this.capacity,
-    activity = this.activity.toModelLite(),
+    activity = this.activity.toModelLite(includeAllocations),
     scheduleWeeks = this.scheduleWeeks,
     slots = this.slots.map { it.toModel() },
     startDate = this.startDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
@@ -61,8 +61,8 @@ data class ScheduledInstance(
 
   fun dayOfWeek() = sessionDate.dayOfWeek
 
-  fun toModel() = ModelScheduledInstance(
-    activitySchedule = this.activitySchedule.toModelLite(),
+  fun toModel(includeAllocations: Boolean = true) = ModelScheduledInstance(
+    activitySchedule = this.activitySchedule.toModelLite(includeAllocations),
     id = this.scheduledInstanceId,
     date = this.sessionDate,
     startTime = this.startTime,
@@ -72,10 +72,10 @@ data class ScheduledInstance(
     cancelledBy = this.cancelledBy,
     cancelledReason = this.cancelledReason,
     comment = this.comment,
-    previousScheduledInstanceId = this.previous()?.scheduledInstanceId,
-    previousScheduledInstanceDate = this.previous()?.sessionDate,
-    nextScheduledInstanceId = this.next()?.scheduledInstanceId,
-    nextScheduledInstanceDate = this.next()?.sessionDate,
+    previousScheduledInstanceId = if (includeAllocations) this.previous()?.scheduledInstanceId else null,
+    previousScheduledInstanceDate = if (includeAllocations) this.previous()?.sessionDate else null,
+    nextScheduledInstanceId = if (includeAllocations) this.next()?.scheduledInstanceId else null,
+    nextScheduledInstanceDate = if (includeAllocations) this.next()?.sessionDate else null,
     attendances = this.attendances.map { attendance -> transform(attendance, null) },
     timeSlot = this.timeSlot,
   )
@@ -157,4 +157,4 @@ data class ScheduledInstance(
   fun isEndFuture(dateTime: LocalDateTime) = sessionDate.atTime(endTime).isAfter(dateTime)
 }
 
-fun List<ScheduledInstance>.toModel() = map { it.toModel() }
+fun List<ScheduledInstance>.toModel(includeAllocations: Boolean = true) = map { it.toModel(includeAllocations) }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
@@ -7,8 +7,6 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Schedule
 import java.time.LocalDate
 
 interface ScheduledInstanceRepository : JpaRepository<ScheduledInstance, Long> {
-  fun findAllBySessionDate(date: LocalDate): List<ScheduledInstance>
-
   @Query(
     """
     SELECT si FROM ScheduledInstance si 
@@ -28,4 +26,16 @@ interface ScheduledInstanceRepository : JpaRepository<ScheduledInstance, Long> {
     cancelled: Boolean? = null,
     timeSlot: TimeSlot? = null,
   ): List<ScheduledInstance>
+
+  @Query(
+    "select si " +
+      "from ScheduledInstance si " +
+      "join fetch si.activitySchedule asch " +
+      "join fetch asch.activity act " +
+      "join fetch act.activityCategory actc " +
+      "left join fetch si.attendances att " +
+      "left join fetch att.attendanceReason attr " +
+      "where si.scheduledInstanceId in :ids",
+  )
+  fun findByIds(ids: List<Long>): List<ScheduledInstance>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledInstanceController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledInstanceController.kt
@@ -15,6 +15,7 @@ import org.springframework.http.ResponseEntity
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -97,6 +98,57 @@ class ScheduledInstanceController(
   fun getScheduledInstanceById(
     @PathVariable("instanceId") instanceId: Long,
   ): ActivityScheduleInstance = scheduledInstanceService.getActivityScheduleInstanceById(instanceId)
+
+  @PostMapping
+  @ResponseBody
+  @Operation(
+    summary = "Get scheduled instances by their ids",
+    description = "Returns a list of scheduled instances.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "The scheduled instances found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = ActivityScheduleInstance::class)),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [
+          Content(
+            mediaType = "application/json",
+            schema = Schema(implementation = ErrorResponse::class),
+          ),
+        ],
+      ),
+    ],
+  )
+  @CaseloadHeader
+  @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN', 'NOMIS_ACTIVITIES')")
+  fun getScheduledInstancesByIds(
+    @RequestBody
+    @Parameter(
+      description = "The scheduled instance ids",
+      required = true,
+    )
+    instanceIds: List<Long>,
+  ): List<ActivityScheduleInstance> = scheduledInstanceService.getActivityScheduleInstancesByIds(instanceIds)
 
   @GetMapping(value = ["/{instanceId}/scheduled-attendees"])
   @ResponseBody

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AttendancesService.kt
@@ -11,11 +11,9 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toMedium
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.trackEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Attendance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceStatus
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.appointment.toModel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.ActivityCategoryCode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.AttendanceReasonEnum
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.EventTierType
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.toModel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.toModel
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AttendanceUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.SuspendedPrisonerActivityAttendance

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceService.kt
@@ -53,6 +53,14 @@ class ScheduledInstanceService(
   }
 
   @Transactional(readOnly = true)
+  fun getActivityScheduleInstancesByIds(ids: List<Long>) =
+    repository.findByIds(ids)
+      .also {
+        it.forEach { instance -> checkCaseloadAccess(instance.activitySchedule.activity.prisonCode) }
+      }
+      .toModel(includeAllocations = false)
+
+  @Transactional(readOnly = true)
   fun getActivityScheduleInstancesByDateRange(
     prisonCode: String,
     dateRange: LocalDateRange,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ActivityTest.kt
@@ -61,7 +61,7 @@ class ActivityTest {
   }
 
   @Test
-  fun `converted to model lite`() {
+  fun `converted to model lite with allocation details`() {
     val expectedModel = ActivityLite(
       id = 1,
       attendanceRequired = false,
@@ -81,17 +81,65 @@ class ActivityTest {
         name = "category name",
         description = "category description",
       ),
-      capacity = 0,
+      capacity = 1,
+      allocated = 2,
+      createdTime = LocalDate.now().atStartOfDay(),
+      activityState = ActivityState.LIVE,
+      paid = true,
+      minimumEducationLevel = listOf(
+        ModelActivityMinimumEducationLevel(
+          id = 0,
+          educationLevelCode = "1",
+          educationLevelDescription = "Reading Measure 1.0",
+          studyAreaCode = "ENGLA",
+          studyAreaDescription = "English Language",
+        ),
+      ),
+    )
+    assertThat(activityEntity(attendanceRequired = false).toModelLite()).isEqualTo(expectedModel)
+  }
+
+  @Test
+  fun `converted to model lite without allocation details`() {
+    val expectedModel = ActivityLite(
+      id = 1,
+      attendanceRequired = false,
+      inCell = false,
+      onWing = false,
+      offWing = false,
+      pieceWork = false,
+      outsideWork = false,
+      payPerSession = PayPerSession.H,
+      prisonCode = "MDI",
+      summary = "Maths",
+      description = "Maths basic",
+      riskLevel = "high",
+      category = ActivityCategory(
+        id = 1L,
+        code = "category code",
+        name = "category name",
+        description = "category description",
+      ),
+      capacity = 1,
       allocated = 0,
       createdTime = LocalDate.now().atStartOfDay(),
       activityState = ActivityState.LIVE,
       paid = true,
+      minimumEducationLevel = listOf(
+        ModelActivityMinimumEducationLevel(
+          id = 0,
+          educationLevelCode = "1",
+          educationLevelDescription = "Reading Measure 1.0",
+          studyAreaCode = "ENGLA",
+          studyAreaDescription = "English Language",
+        ),
+      ),
     )
-    assertThat(activityEntity().copy(attendanceRequired = false).toModelLite()).isEqualTo(expectedModel)
+    assertThat(activityEntity(attendanceRequired = false).toModelLite(includeAllocations = false)).isEqualTo(expectedModel)
   }
 
   @Test
-  fun `List converted to model lite`() {
+  fun `list converted to model lite`() {
     val expectedModel = listOf(
       ActivityLite(
         id = 1,
@@ -541,7 +589,7 @@ class ActivityTest {
     schedule.addSlot(
       weekNumber = 1,
       slotTimes = LocalTime.NOON to LocalTime.NOON.plusHours(1),
-      setOf(*DayOfWeek.values()),
+      setOf(*DayOfWeek.entries.toTypedArray()),
       timeSlot = TimeSlot.PM,
     )
 
@@ -633,7 +681,7 @@ class ActivityTest {
     val currentPay = activity.activityPayFor(lowPayBand, "BAS")
 
     assertThat(currentPay!!.rate).isEqualTo(34)
-    assertThat(currentPay!!.startDate).isEqualTo(LocalDate.now().minusDays(1))
+    assertThat(currentPay.startDate).isEqualTo(LocalDate.now().minusDays(1))
   }
 
   @Test
@@ -673,7 +721,7 @@ class ActivityTest {
     val currentPay = activity.activityPayFor(lowPayBand, "BAS")
 
     assertThat(currentPay!!.rate).isEqualTo(35)
-    assertThat(currentPay!!.startDate).isEqualTo(LocalDate.now().minusDays(1))
+    assertThat(currentPay.startDate).isEqualTo(LocalDate.now().minusDays(1))
   }
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -80,6 +80,7 @@ internal fun activityEntity(
   offWing: Boolean = false,
   riskLevel: String = "high",
   paid: Boolean = true,
+  attendanceRequired: Boolean = true,
 ) =
   Activity(
     activityId = activityId,
@@ -96,6 +97,7 @@ internal fun activityEntity(
     onWing = onWing,
     offWing = offWing,
     isPaid = paid,
+    attendanceRequired = attendanceRequired,
   ).apply {
     this.organiser = organiser
     this.endDate = endDate

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledInstanceServiceTest.kt
@@ -83,6 +83,27 @@ class ScheduledInstanceServiceTest {
   }
 
   @Nested
+  @DisplayName("getActivityScheduleInstancesByIds")
+  inner class GetActivityScheduleInstancesByIds {
+
+    @Test
+    fun `scheduled instances found - success`() {
+      addCaseloadIdToRequestHeader("MDI")
+      whenever(repository.findByIds(listOf(1, 2, 3)))
+        .thenReturn(
+          listOf(
+            ScheduledInstanceFixture.instance(id = 1, locationId = 11),
+            ScheduledInstanceFixture.instance(id = 2, locationId = 22),
+            ScheduledInstanceFixture.instance(id = 3, locationId = 33),
+          ),
+        )
+
+      assertThat(service.getActivityScheduleInstancesByIds(listOf(1, 2, 3)))
+        .extracting<Long> { it.id }.containsOnly(1, 2, 3)
+    }
+  }
+
+  @Nested
   @DisplayName("getActivityScheduleInstancesByDateRange")
   inner class GetActivityScheduleInstancesByDateRange {
     val prisonCode = "MDI"

--- a/src/test/resources/test_data/seed-activity-id-1.sql
+++ b/src/test/resources/test_data/seed-activity-id-1.sql
@@ -67,4 +67,12 @@ values (2, '2022-10-10', '14:00:00', '15:00:00', false, null, null, null, null, 
 insert into waiting_list (waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by, comments, declined_reason, updated_time, updated_by, allocation_id)
 values (1, 'PVI', 'A11111A', 111111, '2023-06-23', 1, 1, 'Fred Bloggs', 'PENDING', '2023-08-02 13:37:47.534000', 'test user', 'The prisoner has specifically requested to attend this activity', null, null, null, null);
 
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, '2022-10-11', '13:00:00', '14:00:00', false, null, null, null, null, 'PM');
+
+insert into attendance(scheduled_instance_id, prisoner_number, attendance_reason_id, comment, recorded_time, recorded_by, status, pay_amount, bonus_amount, pieces)
+values (4, 'A22222A', 1, null, null, null, 'COMPLETED', null, null, null);
+
+
+
 


### PR DESCRIPTION
- Add new POST endpoint to accept schedule instance ids and return them all in one go
- Avoid adding irrelevant allocation details in the response model
- Add `JOIN FETCH` to repo query to improve performance