### PR TITLE
SDIT-2238 Fix attendance reconciliation bug

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/AttendanceRepository.kt
@@ -47,7 +47,7 @@ interface AttendanceRepository : JpaRepository<Attendance, Long> {
 
   @Query(
     value = """
-      select new uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.BookingCount(al.bookingId, count(att)) from Attendance att 
+      select new uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.BookingCount(al.bookingId, count(distinct(att))) from Attendance att 
       join ScheduledInstance si on att.scheduledInstance = si
       join ActivitySchedule asch on si.activitySchedule = asch
       join Allocation al on al.activitySchedule = asch and att.prisonerNumber = al.prisonerNumber and al.startDate <= : date and (al.endDate is null or al.endDate >= :date)

--- a/src/test/resources/test_data/seed-activity-id-27.sql
+++ b/src/test/resources/test_data/seed-activity-id-27.sql
@@ -50,8 +50,11 @@ insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, sess
 values (6, 2, current_date, '14:00:00', '15:00:00', false, null, null, null, null, 'PM');
 
 -- allocation for prisoner 1 on activity 1 is active so will be included
+-- note we end and re-allocate on the same day to expose a bug found in the reconciliation
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
-values (1, 1, 'A11111A', 10001, 1, '2022-10-10', null, '2022-10-10 09:00:00', 'any', null, null, null, null, null, null, 'ACTIVE');
+values (1, 1, 'A11111A', 10001, 1, '2022-10-10', current_date -1, '2022-10-10 09:00:00', 'any', current_date - 1, null, null, null, null, null, 'ACTIVE');
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (8, 1, 'A11111A', 10001, 1, current_date - 1, null, current_date - 1, 'any', null, null, null, null, null, null, 'ACTIVE');
 
 -- allocation for prisoner 1 on activity 2 is active so will be included
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)


### PR DESCRIPTION
There is a bug in the attendance reconciliation where a prisoner is deallocated from an activity and then reallocated on the same day (and then attended and marked with pay). The problem is that both allocations are considered "active" and so the attendance is counted towards the count twice. To fix we make sure the attendance is only counted once.

To find an example of the bad data run SQL `select * from allocation a where booking_id = 2694358 and activity_schedule_id = 553;` This scenario has been emulated in the test data for `seed-activity-id-27.sql`.