### PR TITLE
SAA-2216: Fix filtering of visits on movement locations

### DIFF
--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/LocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/LocationIntegrationTest.kt
@@ -16,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqual
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.InternalLocationEventsSummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.whereabouts.LocationPrefixDto
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_PRISON
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonApiPrisonerScheduleFixture
 import java.time.LocalDate
 
 class LocationIntegrationTest : IntegrationTestBase() {
@@ -23,6 +24,7 @@ class LocationIntegrationTest : IntegrationTestBase() {
 
   private val activityLocation1 = internalLocation(1L, prisonCode = prisonCode, description = "MDI-ACT-LOC1", userDescription = "Activity Location 1")
   private val activityLocation2 = internalLocation(2L, prisonCode = prisonCode, description = "MDI-ACT-LOC2", userDescription = "Activity Location 2")
+  private val activityLocation3 = internalLocation(3L, prisonCode = prisonCode, description = "MDI-ACT-LOC3", userDescription = "Activity Location 3")
   private val appointmentLocation1 = appointmentLocation(123, prisonCode, description = "MDI-APP-LOC1", userDescription = "Appointment Location 1")
   private val socialVisitsLocation = internalLocation(locationId = 5L, description = "SOCIAL VISITS", userDescription = "Social Visits")
   private val socialVisitsLocationSummary = LocationSummary(locationId = 5L, description = "SOCIAL VISITS", userDescription = "Social Visits")
@@ -212,7 +214,20 @@ class LocationIntegrationTest : IntegrationTestBase() {
     val date = LocalDate.of(2022, 10, 1)
 
     prisonApiMockServer.stubGetEventLocationsBooked(prisonCode, date, null, listOf(socialVisitsLocationSummary))
-    prisonApiMockServer.stubGetEventLocations(prisonCode, listOf(activityLocation1, activityLocation2, appointmentLocation1, socialVisitsLocation))
+    prisonApiMockServer.stubGetEventLocations(prisonCode, listOf(activityLocation1, activityLocation2, activityLocation3, appointmentLocation1, socialVisitsLocation))
+
+    val activityLocation1Instance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = activityLocation1.locationId, date = date)
+    val activityLocation2Instance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = activityLocation2.locationId, date = date)
+    val activityLocation3Instance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = activityLocation3.locationId, date = date)
+    val appointmentLocation1Instance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = appointmentLocation1.locationId, date = date)
+    val socialVisitInstance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = socialVisitsLocation.locationId, date = date)
+
+    prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, activityLocation1.locationId, date, null, listOf(activityLocation1Instance))
+    prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, activityLocation2.locationId, date, null, listOf(activityLocation2Instance))
+    prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, activityLocation3.locationId, date, null, listOf(activityLocation3Instance))
+    prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, appointmentLocation1.locationId, date, null, listOf(appointmentLocation1Instance))
+    prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, socialVisitsLocation.locationId, date, null, listOf(socialVisitInstance))
+
     manageAdjudicationsApiMockServer.stubHearingsForDate(
       agencyId = prisonCode,
       date = date,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationServiceTest.kt
@@ -119,6 +119,11 @@ class InternalLocationServiceTest {
     description = "SOCIAL VISITS",
     userDescription = "Social Visits",
   )
+  private val education3LocationSummary = LocationSummary(
+    locationId = 6L,
+    description = "EDUC-ED1-ED3",
+    userDescription = "Education 3",
+  )
 
   private val adjudicationLocation = internalLocation(
     locationId = 1000L,
@@ -196,6 +201,11 @@ class InternalLocationServiceTest {
   private val noLocationVisit = PrisonApiPrisonerScheduleFixture.visitInstance(
     eventId = 9,
     locationId = null,
+    date = LocalDate.now(),
+  )
+  private val socialVisit = PrisonApiPrisonerScheduleFixture.visitInstance(
+    eventId = 10,
+    locationId = socialVisitsLocationSummary.locationId,
     date = LocalDate.now(),
   )
 
@@ -344,7 +354,15 @@ class InternalLocationServiceTest {
       ).thenReturn(listOf(education2Activity))
       whenever(appointmentSearchRepository.findAll(any())).thenReturn(listOf(education1Appointment))
       whenever(prisonApiClient.getEventLocationsBookedAsync(prisonCode, date, null))
-        .thenReturn(listOf(education1LocationSummary, education2LocationSummary, socialVisitsLocationSummary))
+        .thenReturn(listOf(education1LocationSummary, education2LocationSummary, education3LocationSummary, socialVisitsLocationSummary))
+      whenever(prisonApiClient.getScheduledVisitsForLocationAsync(prisonCode, education1LocationSummary.locationId, date, null))
+        .thenReturn(listOf(education1Visit))
+      whenever(prisonApiClient.getScheduledVisitsForLocationAsync(prisonCode, education2LocationSummary.locationId, date, null))
+        .thenReturn(listOf(education2Visit))
+      whenever(prisonApiClient.getScheduledVisitsForLocationAsync(prisonCode, education3LocationSummary.locationId, date, null))
+        .thenReturn(emptyList())
+      whenever(prisonApiClient.getScheduledVisitsForLocationAsync(prisonCode, socialVisitsLocationSummary.locationId, date, null))
+        .thenReturn(listOf(socialVisit))
       whenever(adjudicationsHearingAdapter.getAdjudicationsByLocation(any(), any(), anyOrNull(), any())).thenReturn(
         mapOf(adjudicationLocation.locationId to listOf(adjudicationHearing)),
       )
@@ -401,6 +419,8 @@ class InternalLocationServiceTest {
           socialVisitsLocationSummary,
         ),
       )
+      whenever(prisonApiClient.getScheduledVisitsForLocationAsync(prisonCode, socialVisitsLocationSummary.locationId, date, TimeSlot.PM))
+        .thenReturn(listOf(socialVisit))
 
       service.getInternalLocationEventsSummaries(
         prisonCode,


### PR DESCRIPTION
Leverage the prison API usage endpoint to check that event locations for indeed have visits.

Before:
<img width="673" alt="image" src="https://github.com/user-attachments/assets/b645b8a2-163d-487f-961c-4e05e3753b18">

After:
<img width="576" alt="image" src="https://github.com/user-attachments/assets/11baa01c-51f3-4737-8f85-ee173a37593f">
