### PR TITLE
SAA-2208: Use shorter timeout for prison api

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/WebClientConfiguration.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/config/WebClientConfiguration.kt
@@ -78,7 +78,7 @@ class WebClientConfiguration(
 
   @Bean
   fun prisonApiWebClient(authorizedClientManager: OAuth2AuthorizedClientManager, builder: WebClient.Builder) = builder
-    .authorisedWebClient(authorizedClientManager, "prison-api", prisonApiUrl, apiTimeout)
+    .authorisedWebClient(authorizedClientManager, "prison-api", prisonApiUrl, shorterTimeout)
     .also { log.info("WEB CLIENT CONFIG: creating prison api web client") }
 
   @Bean


### PR DESCRIPTION
Reduce prison-api timeout to 10 seconds allowing it to retry within the normal 30s UI timeout for example.