### PR TITLE
SAA-2239: Default to on-wing if activity also has location id

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/PrisonerScheduledActivityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/PrisonerScheduledActivityRepository.kt
@@ -69,6 +69,7 @@ interface PrisonerScheduledActivityRepository : JpaRepository<PrisonerScheduledA
     SELECT sa FROM PrisonerScheduledActivity sa 
     WHERE (sa.prisonCode = :prisonCode
     AND sa.sessionDate = :date
+    AND sa.onWing = false
     AND sa.internalLocationId in :internalLocationIds)
     AND (:timeSlot IS NULL OR sa.timeSlot = :timeSlot)
     """,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
@@ -109,6 +109,7 @@ class InternalLocationService(
 
   private fun getLocationActivitiesMap(prisonCode: String, date: LocalDate, timeSlot: TimeSlot?): Map<Long, PrisonerScheduledActivity> =
     prisonerScheduledActivityRepository.findByPrisonCodeAndDateAndTimeSlot(prisonCode, date, timeSlot)
+      .filterNot { it.onWing }
       .filterNot { it.internalLocationId == null }
       .associateBy { it.internalLocationId!!.toLong() }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityService.kt
@@ -223,7 +223,7 @@ class MigrateActivityService(
     }.apply {
       addSchedule(
         description = this.summary,
-        internalLocation = request.internalLocationId?.let { prisonApiClient.getLocation(it).block() },
+        internalLocation = if (!onWing) request.internalLocationId?.let { prisonApiClient.getLocation(it).block() } else null,
         capacity = if (request.capacity == 0) 1 else request.capacity,
         startDate = this.startDate,
         endDate = this.endDate,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/LocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/LocationIntegrationTest.kt
@@ -25,6 +25,7 @@ class LocationIntegrationTest : IntegrationTestBase() {
   private val activityLocation1 = internalLocation(1L, prisonCode = prisonCode, description = "MDI-ACT-LOC1", userDescription = "Activity Location 1")
   private val activityLocation2 = internalLocation(2L, prisonCode = prisonCode, description = "MDI-ACT-LOC2", userDescription = "Activity Location 2")
   private val activityLocation3 = internalLocation(3L, prisonCode = prisonCode, description = "MDI-ACT-LOC3", userDescription = "Activity Location 3")
+  private val onWingActivity = internalLocation(4L, prisonCode = prisonCode, description = "MDI-ACT-LOC4", userDescription = "Activity Location 4")
   private val appointmentLocation1 = appointmentLocation(123, prisonCode, description = "MDI-APP-LOC1", userDescription = "Appointment Location 1")
   private val socialVisitsLocation = internalLocation(locationId = 5L, description = "SOCIAL VISITS", userDescription = "Social Visits")
   private val socialVisitsLocationSummary = LocationSummary(locationId = 5L, description = "SOCIAL VISITS", userDescription = "Social Visits")
@@ -209,22 +210,25 @@ class LocationIntegrationTest : IntegrationTestBase() {
 
   @Test
   @Sql("classpath:test_data/seed-activity-id-3.sql")
+  @Sql("classpath:test_data/seed-activity-id-3-on-wing.sql")
   @Sql("classpath:test_data/seed-appointment-single-id-3.sql")
   fun `get location events summaries for date with activities, appointments and visits - 200 success`() {
     val date = LocalDate.of(2022, 10, 1)
 
     prisonApiMockServer.stubGetEventLocationsBooked(prisonCode, date, null, listOf(socialVisitsLocationSummary))
-    prisonApiMockServer.stubGetEventLocations(prisonCode, listOf(activityLocation1, activityLocation2, activityLocation3, appointmentLocation1, socialVisitsLocation))
+    prisonApiMockServer.stubGetEventLocations(prisonCode, listOf(activityLocation1, activityLocation2, activityLocation3, appointmentLocation1, socialVisitsLocation, onWingActivity))
 
     val activityLocation1Instance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = activityLocation1.locationId, date = date)
     val activityLocation2Instance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = activityLocation2.locationId, date = date)
     val activityLocation3Instance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = activityLocation3.locationId, date = date)
+    val onWingLocation4Instance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = onWingActivity.locationId, date = date)
     val appointmentLocation1Instance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = appointmentLocation1.locationId, date = date)
     val socialVisitInstance = PrisonApiPrisonerScheduleFixture.visitInstance(locationId = socialVisitsLocation.locationId, date = date)
 
     prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, activityLocation1.locationId, date, null, listOf(activityLocation1Instance))
     prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, activityLocation2.locationId, date, null, listOf(activityLocation2Instance))
     prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, activityLocation3.locationId, date, null, listOf(activityLocation3Instance))
+    prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, onWingActivity.locationId, date, null, listOf(onWingLocation4Instance))
     prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, appointmentLocation1.locationId, date, null, listOf(appointmentLocation1Instance))
     prisonApiMockServer.stubScheduledVisitsForLocation(prisonCode, socialVisitsLocation.locationId, date, null, listOf(socialVisitInstance))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateIntegrationTest.kt
@@ -274,6 +274,22 @@ class MigrateIntegrationTest : IntegrationTestBase() {
     val activity = getActivity(activityId = activityId, agencyId = "FMI")
 
     assertThat(activity.schedules.first().usePrisonRegimeTime).isTrue()
+    with(activity.schedules.first().internalLocation!!) {
+      assertThat(id).isEqualTo(1)
+      assertThat(description).isEqualTo("House_block_7-1-002")
+    }
+  }
+
+  @Sql(
+    "classpath:test_data/seed-fmi-prison-regime.sql",
+  )
+  @Test
+  fun `import location code containing 'WOW'`() {
+    val activityId = migrateActivity(request = felthamRegimeTimeRequest.copy(internalLocationCode = "junkWOWkal"))
+    val activity = getActivity(activityId = activityId, agencyId = "FMI")
+
+    assertThat(activity.onWing).isTrue()
+    assertThat(activity.schedules.first().internalLocation).isNull()
   }
 
   @Sql(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
@@ -518,6 +518,7 @@ class MigrateActivityServiceTest {
       with(activityCaptor.firstValue[0]) {
         assertThat(inCell).isFalse
         assertThat(onWing).isTrue
+        assertThat(schedules().first().internalLocationId).isNull()
       }
     }
 

--- a/src/test/resources/test_data/seed-activity-id-3-on-wing.sql
+++ b/src/test/resources/test_data/seed-activity-id-3-on-wing.sql
@@ -1,0 +1,17 @@
+-- Simulates migrated date where on_wing is true and internal_location_id is set.
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid, on_wing)
+values (100, 'MDI', 2, 2, true, false, false, false, 'H', 'History', 'History Level 1', '2022-10-01', null, 'high', '2022-9-21 00:00:00', 'SEED USER', false, true);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (100, 100, 'Geography AM', 4, 'L1', 'History MDI 1', 10, '2022-10-01');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, time_slot)
+values (100, 100, '09:00:00', '12:00:00', true, 'AM');
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (100, 100, 'A11111A', 10101, 1, '2022-10-01', null, '2022-10-01 10:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+insert into scheduled_instance(scheduled_instance_id, activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, time_slot)
+values (100, 100, '2022-10-01', '09:00:00', '12:00:00', false, null, null, 'AM');
+


### PR DESCRIPTION
## Intro

3 changes:

- If migrating an activity which has a location id and a location code containing "WOW" then do not set the location id but do set on-wing to true
- When viewing movement list locations do not included activities that are both on-wing and have a location id
- When viewing movement list items remove any that are both on-wing and have a location id.

:warning: **There are ~500 activities which are on-wing and have a location id - there are no plans to fix the data**

## Before

### Movement locations before where C Wing Exercise Yard is both on wing and has a location:
<img width="644" alt="image" src="https://github.com/user-attachments/assets/231686c2-f3fe-4fed-88c9-e5d9ab811cdb">

### Movement list items where Woodworking is both on wing and has a location:
<img width="703" alt="image" src="https://github.com/user-attachments/assets/19117eb6-cad5-4fc8-ab4e-59f4b4e9db9c">

## After

### Movement locations before where C Wing Exercise Yard (removed) is both on wing and has a location:
<img width="637" alt="image" src="https://github.com/user-attachments/assets/b7501c17-721d-4e45-89f2-fc6451091afa">

### Movement list items where Woodworking (removed) is both on wing and has a location:
<img width="662" alt="image" src="https://github.com/user-attachments/assets/f9c1ac40-f217-413c-848a-602342e19a72">


