### PR TITLE
Remove the 60 day restriction for viewing appointments at a location

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationController.kt
@@ -189,6 +189,7 @@ class LocationController(
       Will contain summary information about the events taking place at the location as well as the total number of
       prisoners due to arrive at the location. This endpoint supports the creation of movement lists allowing
       users to select from a sublist of only the internal locations that have events scheduled there.
+      Note that activities are only scheduled 60 days in advance. Appointments may be scheduled for any date in the future.
     """,
   )
   @ApiResponses(
@@ -232,15 +233,12 @@ class LocationController(
     prisonCode: String,
     @RequestParam(value = "date", required = true)
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
-    @Parameter(description = "Date of scheduled events (required). Format YYYY-MM-DD. Up to 60 days in the future")
+    @Parameter(description = "Date of scheduled events (required). Format YYYY-MM-DD")
     date: LocalDate,
     @RequestParam(value = "timeSlot", required = false)
     @Parameter(description = "Time slot for the scheduled events (optional). If supplied, one of AM, PM or ED.")
     timeSlot: TimeSlot?,
   ): Set<InternalLocationEventsSummary> {
-    require(date.isBefore(LocalDate.now().plusDays(61))) {
-      "Supply a date up to 60 days in the future"
-    }
     return internalLocationService.getInternalLocationEventsSummaries(
       prisonCode,
       date,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
@@ -211,6 +211,7 @@ class ScheduledEventController(
       Returns scheduled events for the prison, internal location ids, single date and an optional time slot.
       This endpoint only returns activities and appointments and these come from the local database.
       This endpoint supports the creation of movement lists.
+      Note that activities are only scheduled 60 days in advance. Appointments may be scheduled for any date in the future.
     """,
   )
   @ApiResponses(
@@ -263,9 +264,6 @@ class ScheduledEventController(
     @Parameter(description = "Set of internal location ids (required). Example [123, 456].", required = true)
     internalLocationIds: Set<Long>,
   ): Set<InternalLocationEvents> {
-    require(date.isBefore(LocalDate.now().plusDays(61))) {
-      "Supply a date up to 60 days in the future"
-    }
     return internalLocationService.getInternalLocationEvents(
       prisonCode,
       internalLocationIds,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/LocationControllerTest.kt
@@ -250,22 +250,6 @@ class LocationControllerTest : ControllerTestBase<LocationController>() {
   }
 
   @Test
-  fun `Internal location events summaries - 400 response when date is 61 days in the future`() {
-    val date = LocalDate.now().plusDays(61)
-    mockMvc.getInternalLocationEventsSummaries(prisonCode, date, null)
-      .andExpect { status { isBadRequest() } }
-      .andExpect {
-        content {
-          jsonPath("$.userMessage") {
-            value("Exception: Supply a date up to 60 days in the future")
-          }
-        }
-      }
-
-    verifyNoInteractions(internalLocationService)
-  }
-
-  @Test
   fun `Internal location events summaries - 500 response when service throws exception`() {
     val date = LocalDate.now()
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
@@ -535,23 +535,6 @@ class ScheduledEventControllerTest : ControllerTestBase<ScheduledEventController
   }
 
   @Test
-  fun `getScheduledEventsForMultipleLocations - 400 response when date is 61 days in the future`() {
-    val prisonCode = "MDI"
-    val date = LocalDate.now().plusDays(61)
-    mockMvc.getInternalLocationEvents(prisonCode, setOf(1L), date, null)
-      .andExpect { status { isBadRequest() } }
-      .andExpect {
-        content {
-          jsonPath("$.userMessage") {
-            value("Exception: Supply a date up to 60 days in the future")
-          }
-        }
-      }
-
-    verifyNoInteractions(internalLocationService)
-  }
-
-  @Test
   fun `getScheduledEventsForMultipleLocations - 500 response when service throws exception`() {
     val prisonCode = "MDI"
     val date = LocalDate.now()


### PR DESCRIPTION
The endpoint `/scheduled-events/prison/{prisonCode}/locations` was previously only used for generating movement lists.

Recently, it has also been used to allow the user to view the schedule of a room during the book a video link journey. The 60 day restriction is currently throwing the error up to the user when they try to create a booking > 60 days into the future. 

We believe the 60 day restriction was originally placed on this endpoint due to the fact that activity instanced are only scheduled 60 days in advance, however, appointments can be scheduled at any date in the future. This endpoint should be made available to view those appointments past the 60 day mark.