### PR TITLE
SAA-2282: Add a new parameter to the rollout response for identifying a prison is live to users

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/RolloutPrisonPlan.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/RolloutPrisonPlan.kt
@@ -12,20 +12,25 @@ data class RolloutPrisonPlan(
   @Schema(description = "The prison code of the requested prison", example = "PVI")
   var prisonCode: String,
 
-  @Schema(description = "Flag to indicate if this prison is presently rolled out for activities", example = "true")
+  @Schema(description = "Flag to indicate if activities are enabled", example = "true")
   var activitiesRolledOut: Boolean,
 
   @Schema(description = "The date activities rolled out. Can be null if the prison is not yet scheduled for rollout.", example = "2022-09-30")
+  @Deprecated(message = "Not populated")
   @JsonFormat(pattern = "yyyy-MM-dd")
   val activitiesRolloutDate: LocalDate? = null,
 
-  @Schema(description = "Flag to indicate if this prison is presently rolled out for appointments", example = "true")
+  @Schema(description = "Flag to indicate if this appointments are enabled", example = "true")
   var appointmentsRolledOut: Boolean,
 
   @Schema(description = "The date appointments rolled out. Can be null if the prison is not yet scheduled for rollout.", example = "2022-09-30")
+  @Deprecated(message = "Not populated")
   @JsonFormat(pattern = "yyyy-MM-dd")
   val appointmentsRolloutDate: LocalDate? = null,
 
   @Schema(description = "max days to expire events based on prisoner movement, default is 21")
   val maxDaysToExpiry: Int = 21,
+
+  @Schema(description = "Flag to indicate if this prison is presently rolled out and live to the prison", example = "true")
+  var prisonLive: Boolean,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/RolloutPrisonPlan.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/RolloutPrisonPlan.kt
@@ -16,16 +16,16 @@ data class RolloutPrisonPlan(
   var activitiesRolledOut: Boolean,
 
   @Schema(description = "The date activities rolled out. Can be null if the prison is not yet scheduled for rollout.", example = "2022-09-30")
-  @Deprecated(message = "Not populated")
   @JsonFormat(pattern = "yyyy-MM-dd")
+  @Deprecated(message = "Not populated")
   val activitiesRolloutDate: LocalDate? = null,
 
-  @Schema(description = "Flag to indicate if this appointments are enabled", example = "true")
+  @Schema(description = "Flag to indicate if appointments are enabled", example = "true")
   var appointmentsRolledOut: Boolean,
 
   @Schema(description = "The date appointments rolled out. Can be null if the prison is not yet scheduled for rollout.", example = "2022-09-30")
-  @Deprecated(message = "Not populated")
   @JsonFormat(pattern = "yyyy-MM-dd")
+  @Deprecated(message = "Not populated")
   val appointmentsRolloutDate: LocalDate? = null,
 
   @Schema(description = "max days to expire events based on prisoner movement, default is 21")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/refdata/RolloutPrisonService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/refdata/RolloutPrisonService.kt
@@ -11,6 +11,7 @@ data class PrisonPlan(
   val code: String,
   val activities: Boolean,
   val appointments: Boolean,
+  val prisonLive: Boolean,
 )
 
 @Service
@@ -24,11 +25,13 @@ class RolloutPrisonService(
   private fun getPrison(code: String): PrisonPlan {
     val activities = activitiesLive.split(",").contains(code)
     val appointments = appointmentsLive.split(",").contains(code)
+    val prisonLive = prisonsLive.split(",").contains(code)
 
     return PrisonPlan(
       code = code,
       activities = activities,
       appointments = appointments,
+      prisonLive = prisonLive,
     )
   }
 
@@ -39,6 +42,7 @@ class RolloutPrisonService(
       prisonCode = code,
       activitiesRolledOut = prisonPlan.activities,
       appointmentsRolledOut = prisonPlan.appointments,
+      prisonLive = prisonPlan.prisonLive,
     )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/RolloutPrisonTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/RolloutPrisonTest.kt
@@ -13,6 +13,7 @@ class RolloutPrisonTest {
     maxDaysToExpiry = 5,
     activitiesRolledOut = true,
     appointmentsRolledOut = true,
+    prisonLive = true,
   )
 
   @Test

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -374,6 +374,7 @@ internal fun rolloutPrison(prisonCode: String = PENTONVILLE_PRISON_CODE) = Rollo
   activitiesRolledOut = true,
   appointmentsRolledOut = true,
   maxDaysToExpiry = 1,
+  prisonLive = true,
 )
 
 internal fun prisonRegime(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/RolloutIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/RolloutIntegrationTest.kt
@@ -14,10 +14,20 @@ import java.time.LocalTime
 class RolloutIntegrationTest : IntegrationTestBase() {
 
   @Test
-  fun `get inactive rollout prison HMP Moorland - both active activities and appointments`() {
+  fun `get active rollout prison HMP Moorland - both active activities and appointments and the prison is live`() {
     with(webTestClient.getPrisonByCode("MDI")!!) {
       assertThat(activitiesRolledOut).isTrue
       assertThat(appointmentsRolledOut).isTrue
+      assertThat(prisonLive).isTrue
+    }
+  }
+
+  @Test
+  fun `get active rollout prison - both active activities and appointments and the prison not live`() {
+    with(webTestClient.getPrisonByCode("IWI")!!) {
+      assertThat(activitiesRolledOut).isTrue
+      assertThat(appointmentsRolledOut).isTrue
+      assertThat(prisonLive).isFalse
     }
   }
 
@@ -27,9 +37,9 @@ class RolloutIntegrationTest : IntegrationTestBase() {
 
     assertThat(prisonPlanList).hasSize(3)
     with(prisonPlanList) {
-      this.single { it.prisonCode == "RSI" }
-      this.single { it.prisonCode == "PVI" }
-      this.single { it.prisonCode == "MDI" }
+      this.single { it.prisonCode == "RSI" && it.prisonLive }
+      this.single { it.prisonCode == "PVI" && it.prisonLive }
+      this.single { it.prisonCode == "MDI" && it.prisonLive }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAttendanceRecordsJobTest.kt
@@ -25,25 +25,22 @@ class ManageAttendanceRecordsJobTest : JobsTestBase() {
       RolloutPrisonPlan(
         MOORLAND_PRISON_CODE,
         activitiesRolledOut = true,
-        activitiesRolloutDate = TimeSource.today(),
         appointmentsRolledOut = false,
-        appointmentsRolloutDate = null,
+        prisonLive = true,
       ),
       RolloutPrisonPlan(
         PENTONVILLE_PRISON_CODE,
         activitiesRolledOut = true,
-        activitiesRolloutDate = TimeSource.today(),
         appointmentsRolledOut = false,
-        appointmentsRolloutDate = null,
+        prisonLive = true,
       ),
     )
     on { getByPrisonCode(PENTONVILLE_PRISON_CODE) } doReturn
       RolloutPrisonPlan(
         PENTONVILLE_PRISON_CODE,
         activitiesRolledOut = true,
-        activitiesRolloutDate = TimeSource.today(),
         appointmentsRolledOut = false,
-        appointmentsRolloutDate = null,
+        prisonLive = true,
       )
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/RolloutPrisonPlanTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/RolloutPrisonPlanTest.kt
@@ -2,28 +2,24 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
 
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 
 class RolloutPrisonPlanTest : ModelTest() {
 
   @Test
   fun `dates are serialized correctly`() {
-    val originalRolloutDate = LocalDate.parse("01 Feb 2023", dateFormatter)
-
-    val expectedRolloutDate = "2023-02-01"
-
     val rolloutPrison = RolloutPrisonPlan(
       prisonCode = "MDI",
       activitiesRolledOut = true,
-      activitiesRolloutDate = originalRolloutDate,
       appointmentsRolledOut = true,
-      appointmentsRolloutDate = originalRolloutDate,
+      prisonLive = true,
     )
 
     val json = objectMapper.writeValueAsString(rolloutPrison)
     val jsonMap = objectMapper.readValue(json, Map::class.java)
 
-    assertThat(jsonMap["activitiesRolloutDate"]).isEqualTo(expectedRolloutDate)
-    assertThat(jsonMap["appointmentsRolloutDate"]).isEqualTo(expectedRolloutDate)
+    assertThat(jsonMap["prisonCode"]).isEqualTo("MDI")
+    assertThat(jsonMap["activitiesRolledOut"]).isEqualTo(true)
+    assertThat(jsonMap["appointmentsRolledOut"]).isEqualTo(true)
+    assertThat(jsonMap["prisonLive"]).isEqualTo(true)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/RolloutControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/RolloutControllerTest.kt
@@ -12,11 +12,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.rolloutPrison
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ModelTest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RolloutPrisonPlan
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.PrisonRegimeService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.RolloutPrisonService
-import java.time.LocalDate
 
 @WebMvcTest(controllers = [RolloutController::class])
 @ContextConfiguration(classes = [RolloutController::class])
@@ -62,13 +60,11 @@ class RolloutControllerTest : ControllerTestBase<RolloutController>() {
 
   @Test
   fun `get list of all rolled out prisons`() {
-    val originalRolloutDate = LocalDate.parse("01 Feb 2023", ModelTest.dateFormatter)
     val rolloutPrison = RolloutPrisonPlan(
       prisonCode = "LPI",
       activitiesRolledOut = true,
-      activitiesRolloutDate = originalRolloutDate,
       appointmentsRolledOut = true,
-      appointmentsRolloutDate = originalRolloutDate,
+      prisonLive = true,
     )
     whenever(prisonService.getRolloutPrisons(prisonsLive = true)).thenReturn(listOf(rolloutPrison))
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageScheduledInstancesServiceTest.kt
@@ -251,9 +251,9 @@ class ManageScheduledInstancesServiceTest {
   companion object {
 
     val rolledOutPrisons = listOf(
-      RolloutPrisonPlan("MDI", true, LocalDate.of(2022, 11, 1), true, LocalDate.of(2022, 11, 1), 21),
-      RolloutPrisonPlan("LEI", true, LocalDate.of(2022, 11, 1), true, LocalDate.of(2022, 11, 1), 21),
-      RolloutPrisonPlan("XXX", false, null, true, LocalDate.of(2022, 11, 1), 21),
+      RolloutPrisonPlan("MDI", true, LocalDate.of(2022, 11, 1), true, LocalDate.of(2022, 11, 1), 21, prisonLive = true),
+      RolloutPrisonPlan("LEI", true, LocalDate.of(2022, 11, 1), true, LocalDate.of(2022, 11, 1), 21, prisonLive = true),
+      RolloutPrisonPlan("XXX", false, null, true, LocalDate.of(2022, 11, 1), 21, prisonLive = false),
     )
 
     val yesterday: LocalDate = LocalDate.now().minusDays(1)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateActivityServiceTest.kt
@@ -127,10 +127,9 @@ class MigrateActivityServiceTest {
   private fun rolledOutPrison(prisonCode: String) = RolloutPrisonPlan(
     prisonCode = prisonCode,
     activitiesRolledOut = true,
-    activitiesRolloutDate = LocalDate.now().minusDays(1),
     appointmentsRolledOut = false,
-    appointmentsRolloutDate = null,
     maxDaysToExpiry = 21,
+    prisonLive = false,
   )
 
   val now: LocalDateTime = LocalDate.now().atStartOfDay().plusHours(4)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventServiceMultiplePrisonersTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventServiceMultiplePrisonersTest.kt
@@ -104,7 +104,7 @@ class ScheduledEventServiceMultiplePrisonersTest {
 
   // --- Private utility functions used to set up the mocked responses ---
 
-  private fun setupRolledOutPrisonMock(activitiesRolledOut: Boolean, appointmentsRolledOut: Boolean) {
+  private fun setupRolledOutPrisonMock(activitiesRolledOut: Boolean, appointmentsRolledOut: Boolean, prisonLive: Boolean) {
     val prisonCode = "MDI"
 
     whenever(rolloutPrisonRepository.getByPrisonCode(prisonCode))
@@ -114,6 +114,7 @@ class ScheduledEventServiceMultiplePrisonersTest {
           activitiesRolledOut = activitiesRolledOut,
           appointmentsRolledOut = appointmentsRolledOut,
           maxDaysToExpiry = 21,
+          prisonLive = prisonLive,
         ),
       )
   }
@@ -346,7 +347,7 @@ class ScheduledEventServiceMultiplePrisonersTest {
       val timeSlot: TimeSlot = TimeSlot.AM
 
       setupMultiplePrisonerApiMocks(prisonerNumbers, today, timeSlot)
-      setupRolledOutPrisonMock(true, false)
+      setupRolledOutPrisonMock(true, false, true)
 
       val activityEntity = activityFromDbInstance(sessionDate = today)
       whenever(
@@ -500,7 +501,7 @@ class ScheduledEventServiceMultiplePrisonersTest {
       val timeSlot: TimeSlot = TimeSlot.AM
 
       setupMultiplePrisonerApiMocks(prisonerNumbers, tomorrow, timeSlot)
-      setupRolledOutPrisonMock(true, false)
+      setupRolledOutPrisonMock(true, false, true)
 
       val activityEntity = activityFromDbInstance(sessionDate = tomorrow)
       whenever(
@@ -621,7 +622,7 @@ class ScheduledEventServiceMultiplePrisonersTest {
       val timeSlot: TimeSlot = TimeSlot.AM
 
       setupMultiplePrisonerApiMocks(prisonerNumbers, today, timeSlot)
-      setupRolledOutPrisonMock(true, true)
+      setupRolledOutPrisonMock(true, true, true)
 
       val activityEntity = activityFromDbInstance(sessionDate = today)
       whenever(
@@ -747,7 +748,7 @@ class ScheduledEventServiceMultiplePrisonersTest {
 
     @BeforeEach
     fun beforeEach() {
-      setupRolledOutPrisonMock(true, true)
+      setupRolledOutPrisonMock(true, true, true)
 
       whenever(prisonRegimeService.getPrisonRegimesByDaysOfWeek(any())).thenReturn(
         mapOf(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventServiceSinglePrisonerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventServiceSinglePrisonerTest.kt
@@ -111,7 +111,7 @@ class ScheduledEventServiceSinglePrisonerTest {
 
   // --- Private utility functions used to set up the mocked responses ---
 
-  private fun setupRolledOutPrisonMock(activitiesRolledOut: Boolean, appointmentsRolledOut: Boolean) {
+  private fun setupRolledOutPrisonMock(activitiesRolledOut: Boolean, appointmentsRolledOut: Boolean, prisonLive: Boolean = true) {
     val prisonCode = "MDI"
     whenever(rolloutPrisonRepository.getByPrisonCode(prisonCode))
       .thenReturn(
@@ -120,6 +120,7 @@ class ScheduledEventServiceSinglePrisonerTest {
           activitiesRolledOut = activitiesRolledOut,
           appointmentsRolledOut = appointmentsRolledOut,
           maxDaysToExpiry = 21,
+          prisonLive = prisonLive,
         ),
       )
   }


### PR DESCRIPTION
Add a new parameter to the rollout response for identifying a prison is live to users
Deprecate the rollout dates for activities and appointments (Need to update the frontend before removing)
Still to do is to add a live prison filter to the /rollout endpoint and remove the rollout dates