### PR TITLE
SAA-2278: Change the Scheduled Instance attendance to lazy load. 

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ScheduledInstance.kt
@@ -12,8 +12,6 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
-import org.hibernate.annotations.Fetch
-import org.hibernate.annotations.FetchMode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.AttendanceReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.AttendanceReasonEnum
@@ -34,9 +32,7 @@ data class ScheduledInstance(
   @JoinColumn(name = "activity_schedule_id", nullable = false)
   val activitySchedule: ActivitySchedule,
 
-  // TODO ideally should be private
-  @OneToMany(mappedBy = "scheduledInstance", fetch = FetchType.EAGER, cascade = [CascadeType.ALL], orphanRemoval = true)
-  @Fetch(FetchMode.SUBSELECT)
+  @OneToMany(mappedBy = "scheduledInstance", fetch = FetchType.LAZY, cascade = [CascadeType.ALL], orphanRemoval = true)
   val attendances: MutableList<Attendance> = mutableListOf(),
 
   val sessionDate: LocalDate,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Attendance.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/Attendance.kt
@@ -62,7 +62,7 @@ data class Attendance(
   val caseNoteText: String? = null,
 
   @Schema(description = "The attendance history records for this attendance")
-  val attendanceHistory: List<AttendanceHistory> = emptyList(),
+  val attendanceHistory: List<AttendanceHistory>? = emptyList(),
 
   @Schema(description = "Flag to show whether this attendance is editable", example = "true")
   val editable: Boolean = true,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ScheduledInstance
 import java.time.LocalDate
 
@@ -38,4 +39,9 @@ interface ScheduledInstanceRepository : JpaRepository<ScheduledInstance, Long> {
       "where si.scheduledInstanceId in :ids",
   )
   fun findByIds(ids: List<Long>): List<ScheduledInstance>
+
+  fun findByActivityScheduleAndSessionDateEquals(
+    activitySchedule: ActivitySchedule,
+    sessionDate: LocalDate,
+  ): List<ScheduledInstance>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
@@ -6,6 +6,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ScheduledInstance
 import java.time.LocalDate
+import java.time.LocalTime
 
 interface ScheduledInstanceRepository : JpaRepository<ScheduledInstance, Long> {
   @Query(
@@ -40,8 +41,9 @@ interface ScheduledInstanceRepository : JpaRepository<ScheduledInstance, Long> {
   )
   fun findByIds(ids: List<Long>): List<ScheduledInstance>
 
-  fun findByActivityScheduleAndSessionDateEquals(
+  fun findByActivityScheduleAndSessionDateEqualsAndStartTimeGreaterThanEqual(
     activitySchedule: ActivitySchedule,
     sessionDate: LocalDate,
+    startTime: LocalTime,
   ): List<ScheduledInstance>
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
@@ -183,12 +183,13 @@ class ManageAttendancesService(
       "Allocation does not belong to same activity schedule as selected instance"
     }
 
-    val scheduledInstances = scheduledInstanceRepository.findByActivityScheduleAndSessionDateEquals(
+    val scheduledInstances = scheduledInstanceRepository.findByActivityScheduleAndSessionDateEqualsAndStartTimeGreaterThanEqual(
       activitySchedule = allocation.activitySchedule,
       sessionDate = LocalDate.now(clock),
+      startTime = nextAvailableInstance.startTime,
     )
 
-    // Need to create attendances for today?
+    // Create any attendances for today
     return scheduledInstances.filter {
       allocation.canAttendOn(date = it.sessionDate, timeSlot = it.timeSlot)
     }.mapNotNull {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
@@ -183,11 +183,14 @@ class ManageAttendancesService(
       "Allocation does not belong to same activity schedule as selected instance"
     }
 
+    val scheduledInstances = scheduledInstanceRepository.findByActivityScheduleAndSessionDateEquals(
+      activitySchedule = allocation.activitySchedule,
+      sessionDate = LocalDate.now(clock),
+    )
+
     // Need to create attendances for today?
-    return allocation.activitySchedule.instances().filter {
-      it.sessionDate == LocalDate.now(clock) &&
-        it.startTime >= nextAvailableInstance.startTime &&
-        allocation.canAttendOn(date = it.sessionDate, timeSlot = it.timeSlot)
+    return scheduledInstances.filter {
+      allocation.canAttendOn(date = it.sessionDate, timeSlot = it.timeSlot)
     }.mapNotNull {
       val prisonerDetails: Prisoner? = prisonerSearchApiClient.findByPrisonerNumber(allocation.prisonerNumber)
       createAttendance(it, allocation, prisonerDetails?.currentIncentive?.level?.code)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -349,7 +349,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
 
   @Test
   @Sql("classpath:test_data/seed-activity-id-7.sql")
-  fun `204 (no content) response when successfully allocate prisoner to an activity schedule that starts today`() {
+  fun `204 (no content) response when successfully allocate prisoner to an activity schedule that starts today (2 sessions, one is earlier, so only one attendance record should be created)`() {
     prisonerSearchApiMockServer.stubSearchByPrisonerNumber(
       PrisonerSearchPrisonerFixture.instance(
         prisonId = MOORLAND_PRISON_CODE,
@@ -367,7 +367,7 @@ class ActivityScheduleIntegrationTest : IntegrationTestBase() {
         prisonerNumber = "G4793VF",
         payBandId = 11,
         startDate = TimeSource.today(),
-        scheduleInstanceId = 1L,
+        scheduleInstanceId = 2L,
       ),
     ).expectStatus().isNoContent
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AttendanceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AttendanceIntegrationTest.kt
@@ -20,6 +20,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAN
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.PENTONVILLE_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.RISLEY_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AttendanceUpdateRequest
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceHistoryRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.AttendanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_ACTIVITY_ADMIN
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_PRISON
@@ -43,6 +44,9 @@ class AttendanceIntegrationTest : ActivitiesIntegrationTestBase() {
 
   @Autowired
   private lateinit var attendanceRepository: AttendanceRepository
+
+  @Autowired
+  private lateinit var attendanceHistoryRepository: AttendanceHistoryRepository
 
   private val eventCaptor = argumentCaptor<OutboundHMPPSDomainEvent>()
 
@@ -161,7 +165,9 @@ class AttendanceIntegrationTest : ActivitiesIntegrationTestBase() {
 
     val updatedAttendances = attendanceRepository.findAll().toList().also { assertThat(it).hasSize(1) }
     assertThat(updatedAttendances.prisonerAttendanceReason("A11111A").code).isEqualTo(AttendanceReasonEnum.SICK)
-    assertThat(updatedAttendances[0].history()).hasSize(1)
+
+    val history = attendanceHistoryRepository.findAll()
+    assertThat(history.filter { it.attendance.attendanceId == updatedAttendances[0].attendanceId }).hasSize(1)
 
     verify(eventsPublisher).send(eventCaptor.capture())
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAttendanceRecordsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAttendanceRecordsJobIntegrationTest.kt
@@ -81,12 +81,14 @@ class ManageAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
 
     assertThat(activitySchedules).hasSize(2)
 
+    var allAttendances = attendanceRepository.findAll()
+    assertThat(allAttendances).hasSize(0)
+
     with(activitySchedules.findByDescription("Maths AM")) {
       assertThat(allocations()).hasSize(2)
       assertThat(instances()).hasSize(1)
       val scheduledInstance = scheduledInstanceRepository.findById(instances().first().scheduledInstanceId)
         .orElseThrow { EntityNotFoundException("ScheduledInstance id ${this.activityScheduleId} not found") }
-      assertThat(scheduledInstance.attendances).isEmpty()
     }
 
     with(activitySchedules.findByDescription("Maths PM")) {
@@ -94,7 +96,6 @@ class ManageAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
       assertThat(instances()).hasSize(1)
       val scheduledInstance = scheduledInstanceRepository.findById(instances().first().scheduledInstanceId)
         .orElseThrow { EntityNotFoundException("ScheduledInstance id ${this.activityScheduleId} not found") }
-      assertThat(scheduledInstance.attendances).isEmpty()
     }
 
     webTestClient.manageAttendanceRecords()
@@ -103,18 +104,18 @@ class ManageAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
     val activitySchedulesAfter = activityScheduleRepository.getAllByActivity(activityAfter)
     log.info("ActivitySchedulesAfter count = ${activitySchedulesAfter.size}")
 
+    allAttendances = attendanceRepository.findAll()
+
     with(activitySchedulesAfter.findByDescription("Maths AM")) {
       val scheduledInstance = scheduledInstanceRepository.findById(instances().first().scheduledInstanceId)
         .orElseThrow { EntityNotFoundException("ScheduledInstance id ${instances().first().scheduledInstanceId} not found") }
-      log.info("ScheduledInstanceId (Maths AM) = ${scheduledInstance.scheduledInstanceId} attendances ${scheduledInstance.attendances.size}")
-      assertThat(scheduledInstance.attendances).hasSize(2)
+      assertThat(allAttendances.filter { it.scheduledInstance.scheduledInstanceId == scheduledInstance.scheduledInstanceId }).hasSize(2)
     }
 
     with(activitySchedulesAfter.findByDescription("Maths PM")) {
       val scheduledInstance = scheduledInstanceRepository.findById(instances().first().scheduledInstanceId)
         .orElseThrow { EntityNotFoundException("ScheduledInstance id ${instances().first().scheduledInstanceId} not found") }
-      log.info("ScheduledInstanceId (Maths PM) = ${scheduledInstance.scheduledInstanceId} attendances ${scheduledInstance.attendances.size}")
-      assertThat(scheduledInstance.attendances).hasSize(2)
+      assertThat(allAttendances.filter { it.scheduledInstance.scheduledInstanceId == scheduledInstance.scheduledInstanceId }).hasSize(2)
     }
 
     assertThat(attendanceRepository.count()).isEqualTo(4)
@@ -153,7 +154,7 @@ class ManageAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
       instances() hasSize 2
       val scheduledInstances = scheduledInstanceRepository.findAll()
       assertThat(scheduledInstances).isNotEmpty
-      scheduledInstances.forEach { assertThat(it.attendances).isEmpty() }
+      assertThat(attendanceRepository.findAll()).hasSize(0)
     }
 
     webTestClient.manageAttendanceRecords()
@@ -162,15 +163,11 @@ class ManageAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
     val activitySchedulesAfter = activityScheduleRepository.getAllByActivity(activityAfter)
     log.info("ActivitySchedulesAfter count = ${activitySchedulesAfter.size}")
 
-    val morningSession = scheduledInstanceRepository.getReferenceById(1)
-    log.info("ScheduledInstanceId (AM) = ${morningSession.scheduledInstanceId} attendances ${morningSession.attendances.size}")
-    assertThat(morningSession.attendances).hasSize(2)
+    val allAttendances = attendanceRepository.findAll()
+    assertThat(allAttendances).hasSize(6)
+    assertThat(attendanceRepository.findAll().filter { it -> it.scheduledInstance.scheduledInstanceId == 1L }).hasSize(2)
 
-    val afternoonSession = scheduledInstanceRepository.getReferenceById(2)
-    log.info("ScheduledInstanceId (PM) = ${afternoonSession.scheduledInstanceId} attendances ${afternoonSession.attendances.size}")
-    assertThat(afternoonSession.attendances).hasSize(4)
-
-    assertThat(attendanceRepository.count()).isEqualTo(6)
+    assertThat(attendanceRepository.findAll().filter { it -> it.scheduledInstance.scheduledInstanceId == 2L }).hasSize(4)
 
     verify(eventsPublisher, times(6)).send(eventCaptor.capture())
 
@@ -214,11 +211,11 @@ class ManageAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
     }
 
     assertThat(activitySchedules).hasSize(1)
+    assertThat(attendanceRepository.findAll()).hasSize(0)
 
     with(activitySchedules.findByDescription("Gym induction AM")) {
       assertThat(allocations()).hasSize(2)
       assertThat(instances()).hasSize(1)
-      assertThat(instances().first().attendances).isEmpty()
     }
 
     webTestClient.manageAttendanceRecords()
@@ -226,9 +223,8 @@ class ManageAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
     val activityAfter = activityRepository.findById(5).orElseThrow()
     val activitySchedulesAfter = activityScheduleRepository.getAllByActivity(activityAfter)
 
-    with(activitySchedulesAfter.findByDescription("Gym induction AM")) {
-      assertThat(instances().first().attendances).isNotEmpty()
-    }
+    val scheduledInstanceId = activitySchedulesAfter.findByDescription("Gym induction AM").instances().first().scheduledInstanceId
+    assertThat(attendanceRepository.findAll().filter { it.scheduledInstance.scheduledInstanceId == scheduledInstanceId }).isNotEmpty
 
     assertThat(attendanceRepository.count()).isEqualTo(2)
   }
@@ -337,13 +333,13 @@ class ManageAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
     }
 
     assertThat(activitySchedules).hasSize(1)
+    assertThat(attendanceRepository.findAll()).hasSize(0)
 
     with(activitySchedules.first()) {
       assertThat(allocations()).hasSize(3)
       assertThat(instances()).hasSize(1)
       val scheduledInstance = scheduledInstanceRepository.findById(instances().first().scheduledInstanceId)
         .orElseThrow { EntityNotFoundException("ScheduledInstance id ${this.activityScheduleId} not found") }
-      assertThat(scheduledInstance.attendances).isEmpty()
     }
 
     webTestClient.manageAttendanceRecords()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
@@ -1099,6 +1099,12 @@ class ManageAttendancesServiceTest {
     @Test
     fun `should create an attendance record`() {
       whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[0]))
+      whenever(
+        scheduledInstanceRepository.findByActivityScheduleAndSessionDateEquals(
+          allocation.activitySchedule,
+          TimeSource.today(),
+        ),
+      ).thenReturn(listOf(allocation.activitySchedule.instances()[0]))
 
       val attendances = service.createAnyAttendancesForToday(1, allocation)
 
@@ -1130,6 +1136,12 @@ class ManageAttendancesServiceTest {
 
       whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[1]))
       whenever(scheduledInstanceRepository.findById(2)).thenReturn(Optional.of(allocation.activitySchedule.instances()[2]))
+      whenever(
+        scheduledInstanceRepository.findByActivityScheduleAndSessionDateEquals(
+          allocation.activitySchedule,
+          TimeSource.today(),
+        ),
+      ).thenReturn(listOf(allocation.activitySchedule.instances()[1], allocation.activitySchedule.instances()[2]))
 
       val attendances = service.createAnyAttendancesForToday(1, allocation)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
@@ -1100,9 +1100,10 @@ class ManageAttendancesServiceTest {
     fun `should create an attendance record`() {
       whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[0]))
       whenever(
-        scheduledInstanceRepository.findByActivityScheduleAndSessionDateEquals(
+        scheduledInstanceRepository.findByActivityScheduleAndSessionDateEqualsAndStartTimeGreaterThanEqual(
           allocation.activitySchedule,
           TimeSource.today(),
+          activitySchedule.slots().first().startTime,
         ),
       ).thenReturn(listOf(allocation.activitySchedule.instances()[0]))
 
@@ -1137,9 +1138,10 @@ class ManageAttendancesServiceTest {
       whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[1]))
       whenever(scheduledInstanceRepository.findById(2)).thenReturn(Optional.of(allocation.activitySchedule.instances()[2]))
       whenever(
-        scheduledInstanceRepository.findByActivityScheduleAndSessionDateEquals(
+        scheduledInstanceRepository.findByActivityScheduleAndSessionDateEqualsAndStartTimeGreaterThanEqual(
           allocation.activitySchedule,
           TimeSource.today(),
+          firstSlot.startTime.plusHours(1),
         ),
       ).thenReturn(listOf(allocation.activitySchedule.instances()[1], allocation.activitySchedule.instances()[2]))
 

--- a/src/test/resources/application-test-local-stack.yml
+++ b/src/test/resources/application-test-local-stack.yml
@@ -15,6 +15,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         generate_statistics: false
+        format_sql: false
 
   datasource:
     url: jdbc:postgresql://localhost:5432/activities

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -15,6 +15,7 @@ spring:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
         generate_statistics: false
+        format_sql: false
 
   datasource:
     url: jdbc:postgresql://localhost:5432/activities

--- a/src/test/resources/test_data/seed-activity-id-7.sql
+++ b/src/test/resources/test_data/seed-activity-id-7.sql
@@ -11,7 +11,10 @@ insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_
 values (1, 1, '09:00:00', '12:00:00', true, 'AM');
 
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
-values (1, current_timestamp, '10:00:00', '11:00:00', false, null, null, null, null, 'AM');
+values (1, current_timestamp, '10:00:00', current_time - interval '1 hour', false, null, null, null, null, 'AM');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_timestamp, current_time, current_time + interval '1 hour', false, null, null, null, null, 'AM');
 
 insert into waiting_list(waiting_list_id, prison_code, prisoner_number, booking_id, application_date, activity_id, activity_schedule_id, requested_by, status, creation_time, created_by)
 values (1, 'MDI', 'G4793VF', 1134676, '2023-08-08', 1, 1, 'Prison staff', 'APPROVED', '2023-08-10', 'SEED USER')


### PR DESCRIPTION
Only add attendance records for the scheduled instances today when allocating a new prisoner. Make attendance history optional