### PR TITLE
SAA-2331: Prevent appointments for having start date too far in future

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/MigrateAppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/MigrateAppointmentService.kt
@@ -52,7 +52,7 @@ class MigrateAppointmentService(
       "$prisonCode $categoryCode $startDate $startTime-$endTime"
     }
 
-    if (LocalDate.now().plusDays(maxStartDateOffsetDays.toLong()) < request.startDate) {
+    if (ignoreCategoryCode(request.categoryCode!!).not() && LocalDate.now().plusDays(maxStartDateOffsetDays.toLong()) < request.startDate) {
       log.warn("Appointment dropped as start date is more than $maxStartDateOffsetDays days in the future: $appointmentDescription")
       return null
     }
@@ -75,7 +75,7 @@ class MigrateAppointmentService(
                 log.warn("Null end time set to start time plus one hour: $appointmentDescription")
                 newEndTime
               }
-            }.takeIf { ignoreCategoryCode(request.categoryCode).not() },
+            },
             extraInformation = request.comment?.trim()?.takeIf { it.isNotEmpty() },
             createdTime = request.created!!,
             createdBy = request.createdBy!!,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/MigrateAppointmentService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/MigrateAppointmentService.kt
@@ -43,7 +43,7 @@ class MigrateAppointmentService(
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
   }
 
-  val videoBookingCategories = listOf("VLLA", "VLB", "VLOO", "VLPA", "VLPM", "VLAP")
+  val videoBookingCategories = listOf("VLB", "VLPM")
 
   private fun ignoreCategoryCode(categoryCode: String) = videoBookingCategories.contains(categoryCode)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
@@ -148,31 +148,8 @@ class MigrateAppointmentIntegrationTest : AppointmentsIntegrationTestBase() {
     verifyNoInteractions(eventsPublisher, telemetryClient, auditService)
   }
 
-  @ParameterizedTest(name = "null end time is left as null when category code is {0}")
-  @ValueSource(strings = ["VLLA", "VLB", "VLOO", "VLPA", "VLPM", "VLAP"])
-  fun `appointment with null end time is left as null when category code is excluded`(categoryCode: String) {
-    val request = appointmentMigrateRequest(endTime = null, categoryCode = categoryCode)
-
-    prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
-      listOf(request.prisonerNumber!!),
-      listOf(
-        PrisonerSearchPrisonerFixture.instance(
-          prisonerNumber = request.prisonerNumber!!,
-          bookingId = 1,
-          prisonId = request.prisonCode!!,
-        ),
-      ),
-    )
-
-    val response = webTestClient.migrateAppointment(request)!!
-
-    verifyAppointmentInstance(response = response, setCustomName = false)
-
-    verifyNoInteractions(eventsPublisher, telemetryClient, auditService)
-  }
-
   @Test
-  fun `appointment with null end time set to start time plus one hour when category code is not excluded`() {
+  fun `migrate appointment with null end time`() {
     val request = appointmentMigrateRequest(endTime = null)
 
     prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
@@ -194,8 +171,8 @@ class MigrateAppointmentIntegrationTest : AppointmentsIntegrationTestBase() {
   }
 
   @Test
-  fun `rejected if start date is too far into the future`() {
-    val request = appointmentMigrateRequest(startDate = LocalDate.now().plusDays(371))
+  fun `migrate appointment rejected if start date is too far into the future and is not a BVLS code`() {
+    val request = appointmentMigrateRequest(categoryCode = "TEST2343", startDate = LocalDate.now().plusDays(371))
 
     prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
       listOf(request.prisonerNumber!!),
@@ -211,8 +188,31 @@ class MigrateAppointmentIntegrationTest : AppointmentsIntegrationTestBase() {
     assertThat(webTestClient.migrateRejectedAppointment(request)).isNull()
   }
 
+  @ParameterizedTest(name = "migrate appointment is not rejected if start date is too far into the future but is BVLS code {0}")
+  @ValueSource(strings = ["VLLA", "VLB", "VLOO", "VLPA", "VLPM", "VLAP"])
+  fun `migrate appointment success if start date is too far into the future but is a BVLS code`(categoryCode: String) {
+    val request = appointmentMigrateRequest(categoryCode = categoryCode, startDate = LocalDate.now().plusDays(371))
+
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
+      listOf(request.prisonerNumber!!),
+      listOf(
+        PrisonerSearchPrisonerFixture.instance(
+          prisonerNumber = request.prisonerNumber!!,
+          bookingId = 1,
+          prisonId = request.prisonCode!!,
+        ),
+      ),
+    )
+
+    val response = webTestClient.migrateAppointment(request)!!
+
+    verifyAppointmentInstance(response = response, appointmentDate = request.startDate, setCustomName = false)
+
+    verifyNoInteractions(eventsPublisher, telemetryClient, auditService)
+  }
+
   @Test
-  fun `not rejected if start date is the maximum allowed`() {
+  fun `migrate appointment success if start date is the maximum allowed`() {
     val request = appointmentMigrateRequest(startDate = LocalDate.now().plusDays(370))
 
     prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
@@ -189,7 +189,7 @@ class MigrateAppointmentIntegrationTest : AppointmentsIntegrationTestBase() {
   }
 
   @ParameterizedTest(name = "migrate appointment is not rejected if start date is too far into the future but is BVLS code {0}")
-  @ValueSource(strings = ["VLLA", "VLB", "VLOO", "VLPA", "VLPM", "VLAP"])
+  @ValueSource(strings = ["VLB", "VLPM"])
   fun `migrate appointment success if start date is too far into the future but is a BVLS code`(categoryCode: String) {
     val request = appointmentMigrateRequest(categoryCode = categoryCode, startDate = LocalDate.now().plusDays(371))
 
@@ -234,7 +234,7 @@ class MigrateAppointmentIntegrationTest : AppointmentsIntegrationTestBase() {
   }
 
   @ParameterizedTest
-  @ValueSource(strings = ["VLLA", "VLB", "VLOO", "VLPA", "VLPM", "VLAP"])
+  @ValueSource(strings = ["VLB", "VLPM"])
   fun `migrate appointment success with BVLS category custom name is blank`(categoryCode: String) {
     val request = appointmentMigrateRequest(categoryCode = categoryCode)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateAppointmentServiceTest.kt
@@ -207,7 +207,7 @@ class MigrateAppointmentServiceTest {
     }
 
     @ParameterizedTest(name = "do not reject if start date is too far into the future and is BVLS category code {0}")
-    @ValueSource(strings = ["VLLA", "VLB", "VLOO", "VLPA", "VLPM", "VLAP"])
+    @ValueSource(strings = ["VLB", "VLPM"])
     fun `do not reject if start date is too far into the future and is a BVLS category code`(categoryCode: String) {
       val request = appointmentMigrateRequest(categoryCode = categoryCode, startDate = LocalDate.now().plusDays(3))
 
@@ -280,7 +280,7 @@ class MigrateAppointmentServiceTest {
     }
 
     @ParameterizedTest
-    @ValueSource(strings = ["VLLA", "VLB", "VLOO", "VLPA", "VLPM", "VLAP"])
+    @ValueSource(strings = ["VLB", "VLPM"])
     fun `custom name is empty for BVLS categoryCodes`(categoryCode: String) {
       val request = appointmentMigrateRequest(comment = "appointment comment", categoryCode = categoryCode)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateAppointmentServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/MigrateAppointmentServiceTest.kt
@@ -186,21 +186,9 @@ class MigrateAppointmentServiceTest {
       }
     }
 
-    @ParameterizedTest(name = "null end time is left as null when category code is {0}")
-    @ValueSource(strings = ["VLLA", "VLB", "VLOO", "VLPA", "VLPM", "VLAP"])
-    fun `null end time is left as null category code is excluded`(categoryCode: String) {
-      val request = appointmentMigrateRequest(endTime = null, categoryCode = categoryCode)
-
-      service.migrateAppointment(request)
-
-      with(appointmentSeriesCaptor.firstValue) {
-        endTime isEqualTo null
-      }
-    }
-
     @Test
-    fun `null end time is replaced by start time plus one hour when category code is not excluded`() {
-      val request = appointmentMigrateRequest(endTime = null, categoryCode = "CANT")
+    fun `null end time is replaced by start time plus one hour`() {
+      val request = appointmentMigrateRequest(endTime = null)
 
       service.migrateAppointment(request)
 
@@ -210,16 +198,29 @@ class MigrateAppointmentServiceTest {
     }
 
     @Test
-    fun `rejected if start date is too far into the future`() {
-      val request = appointmentMigrateRequest(startDate = LocalDate.now().plusDays(3))
+    fun `rejected if start date is too far into the future and is not a BVLS category code`() {
+      val request = appointmentMigrateRequest(categoryCode = "ANYTHING", startDate = LocalDate.now().plusDays(3))
 
       assertThat(service.migrateAppointment(request)).isNull()
 
       verifyNoInteractions(appointmentSeriesRepository, appointmentInstanceRepository, appointmentCreateDomainService)
     }
 
+    @ParameterizedTest(name = "do not reject if start date is too far into the future and is BVLS category code {0}")
+    @ValueSource(strings = ["VLLA", "VLB", "VLOO", "VLPA", "VLPM", "VLAP"])
+    fun `do not reject if start date is too far into the future and is a BVLS category code`(categoryCode: String) {
+      val request = appointmentMigrateRequest(categoryCode = categoryCode, startDate = LocalDate.now().plusDays(3))
+
+      assertThat(service.migrateAppointment(request)).isNotNull()
+
+      with(appointmentSeriesCaptor.firstValue) {
+        categoryCode isEqualTo categoryCode
+        startDate isEqualTo request.startDate
+      }
+    }
+
     @Test
-    fun `not rejected if start date is the maximum allowed`() {
+    fun `do not rejected if start date is the maximum allowed`() {
       val request = appointmentMigrateRequest(startDate = LocalDate.now().plusDays(2))
 
       assertThat(service.migrateAppointment(request)).isNotNull()


### PR DESCRIPTION
- Prevent new and updated appts from having start date more than 370 days in future
- Fix migration to reject any appointments which start over 370 days in future **but not if category code is BVLS**