### PR TITLE
SAA-2344: Allocation start date migration

### DIFF
--- a/src/test/resources/test_data/seed-activity-id-23-2.sql
+++ b/src/test/resources/test_data/seed-activity-id-23-2.sql
@@ -1,0 +1,12 @@
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values (1, 'MDI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date + 2, null, 'high', current_timestamp, 'SEED USER', true);
+
+insert into activity_pay(activity_pay_id, activity_id, incentive_nomis_code, incentive_level, prison_pay_band_id, rate, piece_rate, piece_rate_items)
+values (1, 1, 'BAS', 'Basic', 11, 125, 150, 1);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date + 2);
+
+insert into public.activity_schedule_slot (activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, week_number, time_slot) values (1, 1, '09:25:00', '11:35:00', true, true, true, true, false, false, false, 1, 'AM');
+insert into public.activity_schedule_slot (activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, week_number, time_slot) values (2, 1, '13:40:00', '16:50:00', true, true, true, true, false, false, false, 1, 'PM');
+insert into public.activity_schedule_slot (activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, week_number, time_slot) values (3, 1, '08:25:00', '11:35:00', false, false, false, false, true, false, false, 1, 'AM');


### PR DESCRIPTION
For migrating allocations start dates use the activity start date or allocation start date. Whichever is further in the future