### PR TITLE
SAA-2331: Set appointment start date limit to 5 years

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -139,6 +139,7 @@ online:
 applications:
   max-appointment-instances: ${MAX_APPOINTMENT_INSTANCES}
   max-sync-appointment-instance-actions: ${MAX_SYNC_APPOINTMENT_INSTANCE_ACTIONS}
+  max-appointment-start-date-from-today: 1784
 
 hmpps:
   sqs:

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/MigrateAppointmentIntegrationTest.kt
@@ -171,8 +171,8 @@ class MigrateAppointmentIntegrationTest : AppointmentsIntegrationTestBase() {
   }
 
   @Test
-  fun `migrate appointment rejected if start date is too far into the future and is not a BVLS code`() {
-    val request = appointmentMigrateRequest(categoryCode = "TEST2343", startDate = LocalDate.now().plusDays(371))
+  fun `migrate appointment rejected if start date over 5 years into the future and is not a BVLS category code`() {
+    val request = appointmentMigrateRequest(categoryCode = "TEST2343", startDate = LocalDate.now().plusDays(1785))
 
     prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
       listOf(request.prisonerNumber!!),


### PR DESCRIPTION
Increasing the limit from 1 year to 5 years to allow some more consideration of what is correct.