### PR TITLE
SAA-2427: Add endpoint to list activities with invalid locations

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/UtilityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/UtilityController.kt
@@ -5,6 +5,7 @@ import jakarta.validation.Valid
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
 import org.springframework.validation.annotation.Validated
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.ResponseBody
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.PublishEventUtilityModel
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ActivityLocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
 
 // These endpoints are secured in the ingress rather than the app so that they can be called from
@@ -23,6 +25,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.
 @RequestMapping("/utility", produces = [MediaType.TEXT_PLAIN_VALUE])
 class UtilityController(
   private val outboundEventsService: OutboundEventsService,
+  private val activityLocationService: ActivityLocationService,
 ) {
 
   @PostMapping(value = ["/publish-events"])
@@ -42,5 +45,20 @@ class UtilityController(
     }
 
     return "Domain event ${publishEventUtilityModel.outboundEvent} published"
+  }
+
+  @GetMapping(value = ["invalid-activity-locations"], produces = [MediaType.TEXT_PLAIN_VALUE])
+  @ResponseBody
+  @Operation(
+    summary = "Get any activities with invalid locations",
+    description = "Return any activities with invalid locations.",
+  )
+  fun getInvalidActivityLocations(): String {
+    val builder = StringBuilder()
+    builder.appendLine("Prison Code,Activity ID,Activity Description,Internal Location ID,Internal Location Code,Internal Location Description,DPS Location ID")
+    activityLocationService.getInvalidActivityLocations().forEach {
+      builder.appendLine("${it.getPrisonCode()},${it.getActivityId()},${it.getActivityDescription()},${it.getInternalLocationId()},${it.getInternalLocationCode()},${it.getInternalLocationDescription()},${it.getDpsLocationId()}")
+    }
+    return builder.toString()
   }
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityLocationService.kt
@@ -1,0 +1,40 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import kotlinx.coroutines.runBlocking
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.locationsinsideprison.api.LocationsInsidePrisonAPIClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.RolloutPrisonService
+
+@Service
+@Transactional(readOnly = true)
+class ActivityLocationService(
+  private val locationsInsidePrisonAPIClient: LocationsInsidePrisonAPIClient,
+  private val rolloutService: RolloutPrisonService,
+  private val activityScheduleRepository: ActivityScheduleRepository,
+) {
+  companion object {
+    private val log = LoggerFactory.getLogger(this::class.java)
+  }
+
+  fun getInvalidActivityLocations() = runBlocking {
+    rolloutService.getRolloutPrisons()
+      .map { it.prisonCode }
+      .sortedBy { it }
+      .flatMap {
+        log.info("Checking for invalid activities for location $it")
+
+        val validUuids = locationsInsidePrisonAPIClient.getLocationsWithUsageTypes(it).map { it.id }.toSet()
+
+        activityScheduleRepository.findInvalidLocationUuids(it)
+          .filter { validUuids.contains(it).not() }
+          .flatMap {
+            log.info("Finding invalid activities for location $it")
+
+            activityScheduleRepository.findByInvalidLocationUuids(it)
+          }
+      }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/UtilityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/UtilityIntegrationTest.kt
@@ -60,7 +60,6 @@ class UtilityIntegrationTest : IntegrationTestBase() {
       dpsLocationIds = setOf(UUID.fromString("99999999-9999-9999-9999-999999999999")),
     )
 
-
     locationsInsidePrisonApiMockServer.stubLocationsWithUsageTypes(
       prisonCode = "RSI",
       dpsLocationIds = setOf(UUID.fromString("11111111-1111-1111-1111-111111111111")),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/UtilityControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/UtilityControllerTest.kt
@@ -1,20 +1,26 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.context.ContextConfiguration
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.PublishEventUtilityModel
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ActivityScheduleRepository.ActivityScheduleWithInvalidLocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.ActivityLocationService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
+import java.util.*
 
 @WebMvcTest(controllers = [UtilityController::class])
 @ContextConfiguration(classes = [UtilityController::class])
@@ -23,9 +29,12 @@ class UtilityControllerTest : ControllerTestBase<UtilityController>() {
   @MockitoBean
   private lateinit var outboundEventsService: OutboundEventsService
 
+  @MockitoBean
+  private lateinit var activityLocationService: ActivityLocationService
+
   private val identifierCaptor = argumentCaptor<Long>()
 
-  override fun controller() = UtilityController(outboundEventsService)
+  override fun controller() = UtilityController(outboundEventsService, activityLocationService)
 
   @Test
   fun `201 response when outbound event is published`() {
@@ -39,6 +48,26 @@ class UtilityControllerTest : ControllerTestBase<UtilityController>() {
     identifierCaptor.secondValue isEqualTo 2
   }
 
+  @Test
+  fun `returns a list of activities with invalid location`() {
+    val act1 = TestData("RSI", 111, "Activity 1", 333, "LOC-1", "Location 1", UUID.fromString("11111111-1111-1111-1111-111111111111"))
+    val act2 = TestData("LEI", 222, "Activity 2", 444, "LOC-2", "Location 2", UUID.fromString("22222222-2222-2222-2222-222222222222"))
+    whenever(activityLocationService.getInvalidActivityLocations()).thenReturn(listOf(act1, act2))
+
+    val expectedResult = """
+      Prison Code,Activity ID,Activity Description,Internal Location ID,Internal Location Code,Internal Location Description,DPS Location ID
+      RSI,111,Activity 1,333,LOC-1,Location 1,11111111-1111-1111-1111-111111111111
+      LEI,222,Activity 2,444,LOC-2,Location 2,22222222-2222-2222-2222-222222222222
+      
+    """.trimIndent()
+
+    val response = mockMvc.getInvalidActivityLocations()
+      .andExpect { status { isOk() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).isEqualTo(expectedResult)
+  }
+
   private fun MockMvc.publishEvents(event: OutboundEvent, identifiers: List<Long>) = post("/utility/publish-events") {
     contentType = MediaType.APPLICATION_JSON
     content = mapper.writeValueAsBytes(
@@ -47,5 +76,25 @@ class UtilityControllerTest : ControllerTestBase<UtilityController>() {
         identifiers = identifiers,
       ),
     )
+  }
+
+  private fun MockMvc.getInvalidActivityLocations() = get("/utility/invalid-activity-locations") {}
+
+  inner class TestData(
+    private val prisonCode: String,
+    private val activityId: Long,
+    private val activityDescription: String,
+    private val internalLocationId: Int,
+    private val internalLocationCode: String,
+    private val internalLocationDescription: String,
+    private val dpsLocationId: UUID,
+  ) : ActivityScheduleWithInvalidLocation {
+    override fun getPrisonCode() = this.prisonCode
+    override fun getActivityId() = this.activityId
+    override fun getActivityDescription() = this.activityDescription
+    override fun getInternalLocationId() = this.internalLocationId
+    override fun getInternalLocationCode() = this.internalLocationCode
+    override fun getInternalLocationDescription() = this.internalLocationDescription
+    override fun getDpsLocationId() = this.dpsLocationId
   }
 }

--- a/src/test/resources/test_data/seed-activity-id-34.sql
+++ b/src/test/resources/test_data/seed-activity-id-34.sql
@@ -1,0 +1,24 @@
+--
+-- Test data for find activities with invalid locations --
+
+-- Ignore because dps_location_id is valid
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values (1, 'RSI', 1, 1, true, false, false, false, 'H', 'Activity 1', 'Activity 1', current_timestamp, null, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date, dps_location_id)
+values (1, 1, 'Activity 1', 1, 'L1', 'Location 1', 10, current_timestamp, null, '11111111-1111-1111-1111-111111111111');
+
+-- Ignore because activity has ended
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values (2, 'RSI', 1, 1, true, false, false, false, 'H', 'Activity 2', 'Activity 2', current_timestamp - interval '2 day', current_timestamp - interval '1 day', 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date, dps_location_id)
+values (2, 2, 'Activity 2', 2, 'L2', 'Location 2', 10, current_timestamp, null, '22222222-2222-2222-2222-222222222222');
+
+-- Error because dps_location_id is invalid and activity has not ended
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values (3, 'RSI', 1, 1, true, false, false, false, 'H', 'Activity 3', 'Activity 3', current_timestamp - interval '1 day', current_timestamp, 'high', '2022-9-21 00:00:00', 'SEED USER', true);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, end_date, dps_location_id)
+values (3, 3, 'Activity 3', 2, 'L2', 'Location 2', 10, current_timestamp, null, '22222222-2222-2222-2222-222222222222');
+


### PR DESCRIPTION
Utlity endpoint to list activities with invalid locations:

```
Prison Code,Activity ID,Activity Description,Internal Location ID,Internal Location Code,Internal Location Description,DPS Location ID
LEI,79,C Wing cleaning,14444,CWING,C Wing,84852b74-7d91-4267-97f7-476befc73776
LEI,78,C/D Wing laundry,14444,CWING,C Wing,84852b74-7d91-4267-97f7-476befc73776
LEI,80,C Wing - Orderly,14444,CWING,C Wing,84852b74-7d91-4267-97f7-476befc73776
LEI,1110,RECEPTION CLEANERS,14528,RECEP,Reception,7bfef4ed-c58b-4fbf-809d-bf62040fd00a
LEI,678,RECEPTION CLEANERS,14528,RECEP,Reception,7bfef4ed-c58b-4fbf-809d-bf62040fd00a
```

