### PR TITLE
SAA-3333: Ignore activity prisoners from movement list de-allocated from sessions later today

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
@@ -211,6 +211,7 @@ class InternalLocationService(
       date,
       timeSlot,
     )
+      .filter { activity -> activity.sessionDate != LocalDate.now() || activity.attendanceStatus != null }
 
     val timeRange = getTimeRange(
       prisonCode = prisonCode,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/ActivityFactory.kt
@@ -583,8 +583,8 @@ internal fun activityFromDbInstance(
   suspended: Boolean = false,
   paidActivity: Boolean = false,
   issuePayment: Boolean = false,
-  attendanceStatus: AttendanceStatus = AttendanceStatus.COMPLETED,
-  attendanceReasonCode: AttendanceReasonEnum = AttendanceReasonEnum.ATTENDED,
+  attendanceStatus: AttendanceStatus? = AttendanceStatus.COMPLETED,
+  attendanceReasonCode: AttendanceReasonEnum? = AttendanceReasonEnum.ATTENDED,
 ) = PrisonerScheduledActivity(
   scheduledInstanceId = scheduledInstanceId,
   allocationId = allocationId,


### PR DESCRIPTION
If a prisoner is deallocated from today and there are sessions later today then they will appear on the movement list for today.

As part of deallocation the API will remove the relevant attendance records for today.

Use the fact that there are no attendance records and that movement list is for today to filter out those prisoners.

NB: Attendance records are only create for one day.