### PR TITLE
SAA-3333: Ignore activity prisoners from unlock list deallocated from sessions later today

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ScheduledEventService.kt
@@ -468,6 +468,7 @@ class ScheduledEventService(
     date = date,
     timeSlot = slot,
   )
+    .filter { activity -> activity.sessionDate != LocalDate.now() || activity.attendanceStatus != null }
 
   private fun getMultiplePrisonersAppointments(
     prisonCode: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAttendanceRecordsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAttendanceRecordsJobIntegrationTest.kt
@@ -133,7 +133,7 @@ class ManageAttendanceRecordsJobIntegrationTest : IntegrationTestBase() {
     }
   }
 
-  @Sql("classpath:test_data/seed-activity-with-active-exclusions.sql")
+  @Sql("classpath:test_data/seed-activity-for-attendance-job.sql")
   @Test
   fun `Attendance records are not created for where there are exclusions`() {
     val allocatedPrisoners = listOf(listOf("G4793VF", "H4793VF"), listOf("A5193DY"))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
@@ -566,6 +566,26 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
         assertThat(activities!!.first().date).isEqualTo(date)
       }
     }
+
+    @Test
+    @Sql("classpath:test_data/seed-activity-with-planned-deallocation-date.sql")
+    fun `POST - multiple prisoners - scheduled events should npt return any activity events for today where attendance does not exist`() {
+      val prisonCode = "MDI"
+      val prisonerNumbers = listOf("G0459PP", "AA1111A")
+      val date = LocalDate.now()
+
+      prisonApiMockServer.stubGetScheduledVisitsForPrisonerNumbers(prisonCode, date)
+      prisonApiMockServer.stubGetExternalTransfersOnDate(prisonCode, prisonerNumbers.toSet(), date)
+      prisonApiMockServer.stubGetCourtEventsForPrisonerNumbers(prisonCode, date)
+      adjudicationsMock(prisonCode, date, prisonerNumbers)
+
+      val scheduledEvents = webTestClient.getScheduledEventsForMultiplePrisoners(prisonCode, prisonerNumbers.toSet(), date)
+
+      with(scheduledEvents!!) {
+        assertThat(activities).hasSize(1)
+        assertThat(activities!!.first().date).isEqualTo(date)
+      }
+    }
   }
 
   @Nested

--- a/src/test/resources/test_data/seed-activity-for-attendance-job.sql
+++ b/src/test/resources/test_data/seed-activity-for-attendance-job.sql
@@ -39,9 +39,3 @@ values (1000, 'MONDAY'), (1000, 'TUESDAY'), (1000, 'WEDNESDAY'), (1000, 'THURSDA
 
 insert into exclusion_days_of_week(exclusion_id, day_of_week)
 values (1001, 'MONDAY'), (1001, 'TUESDAY'), (1001, 'WEDNESDAY'), (1001, 'THURSDAY'), (1001, 'FRIDAY'), (1001, 'SATURDAY'), (1001, 'SUNDAY');
-
-insert into attendance(scheduled_instance_id, prisoner_number, status)
-values (1, 'A5193DY', 'WAITING');
-
-insert into attendance(scheduled_instance_id, prisoner_number, status)
-values (2, 'A5193DY', 'WAITING');

--- a/src/test/resources/test_data/seed-activity-with-planned-deallocation-date.sql
+++ b/src/test/resources/test_data/seed-activity-with-planned-deallocation-date.sql
@@ -41,6 +41,9 @@ update allocation set planned_deallocation_id = 2 where allocation_id = 2;
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (3, 3, 'G0459PP', 10001, 1, '2022-10-10', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
 
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (4, 3, 'AA1111A', 10003, 1, '2022-10-10', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
 values (1, current_date, '10:00:00', '11:00:00', false, null, null, null, null, 'AM');
 
@@ -55,3 +58,15 @@ values (2, current_date, '10:00:00', '11:00:00', false, null, null, null, null, 
 
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
 values (3, current_date, '10:00:00', '11:00:00', false, null, null, null, null, 'AM');
+
+insert into attendance(scheduled_instance_id, prisoner_number, status)
+values (1, 'G0459MM', 'WAITING');
+
+insert into attendance(scheduled_instance_id, prisoner_number, status)
+values (4, 'G0459NN', 'WAITING');
+
+insert into attendance(scheduled_instance_id, prisoner_number, status)
+values (5, 'G0459PP', 'WAITING');
+
+-- insert into attendance(scheduled_instance_id, prisoner_number, status)
+-- values (5, 'AA1111A', 'WAITING');


### PR DESCRIPTION
If a prisoner is deallocated from today and there are sessions later today then they will appear on the unlock list for today.

As part of deallocation the API will remove the relevant attendance records for today.

Use the fact that there are no attendance records and that unlock list is for today to filter out those prisoners.

NB: Attendance records are only create for one day.