### PR TITLE
SAA-2444: Create not required attendance records

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceCreationData.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AttendanceCreationData.kt
@@ -55,5 +55,7 @@ data class AttendanceCreationData(
 
   val possibleExclusion: Boolean,
 
+  val possibleAdvanceAttendance: Boolean,
+
   val plannedDeallocationDate: LocalDate?,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/util/TransformFunctions.kt
@@ -312,7 +312,7 @@ fun transform(attendance: EntityAttendance, caseNotesApiClient: CaseNotesApiClie
 
   if (includeHistory) {
     history = attendance.history()
-      .sortedWith(compareBy { attendance.recordedTime })
+      .sortedWith(compareBy { it.recordedTime })
       .reversed()
       .map { attendanceHistory: EntityAttendanceHistory ->
         transform(

--- a/src/main/resources/migrations/common/R__v_attendance_creation_data.sql
+++ b/src/main/resources/migrations/common/R__v_attendance_creation_data.sql
@@ -1,46 +1,41 @@
-CREATE OR REPLACE VIEW v_attendance_creation_data
-AS SELECT gen_random_uuid() as id, data.*
-   FROM (SELECT DISTINCT si.scheduled_instance_id,
-                         si.session_date,
-                         si.time_slot,
-                         alloc.allocation_id,
-                         alloc.prisoner_number,
-                         alloc.prisoner_status,
-                         alloc.prison_pay_band_id,
-                         alloc.start_date as alloc_start,
-                         alloc.end_date   as alloc_end,
-                         as1.start_date   as schedule_start,
-                         as1.end_date     as schedule_end,
-                         as1.schedule_weeks,
-                         si.cancelled_reason,
-                         si.cancelled_by,
-                         case
-                             when e.exclusion_id is not null then true
-                             else false
-                             end          as possible_exclusion,
-                         a.prison_code,
-                         a.paid,
-                         a.activity_id,
-                        pd.planned_date as planned_deallocation_date
-         FROM scheduled_instance si
-                  join
-              activity_schedule as1
-              on as1.activity_schedule_id = si.activity_schedule_id
-                  join
-              activity a
-              on a.activity_id = as1.activity_id
-                  join
-              allocation alloc
-              on as1.activity_schedule_id = alloc.activity_schedule_id
-                  left join
-              exclusion e
-              on alloc.allocation_id = e.allocation_id
-                  left join
-              planned_deallocation pd
-              on alloc.planned_deallocation_id = pd.planned_deallocation_id
-         WHERE alloc.prisoner_status <> 'ENDED'
-         AND NOT EXISTS (select 1
-                         from attendance a2
-                         where a2.scheduled_instance_id = si.scheduled_instance_id
-                           and a2.prisoner_number = alloc.prisoner_number)
-         ) as data
+create or replace view v_attendance_creation_data as
+    select
+        gen_random_uuid() as id,
+        data.*
+    from (
+        select distinct
+            si.scheduled_instance_id,
+            si.session_date,
+            si.time_slot,
+            alloc.allocation_id,
+            alloc.prisoner_number,
+            alloc.prisoner_status,
+            alloc.prison_pay_band_id,
+            alloc.start_date                                                as alloc_start,
+            alloc.end_date                                                  as alloc_end,
+            as1.start_date                                                  as schedule_start,
+            as1.end_date                                                    as schedule_end,
+            as1.schedule_weeks,
+            si.cancelled_reason,
+            si.cancelled_by,
+            case when e.exclusion_id is not null then true
+                else false
+            end                                                             as possible_exclusion,
+            a.prison_code,
+            a.paid,
+            a.activity_id,
+            pd.planned_date                                                 as planned_deallocation_date,
+            case when adv_att.advance_attendance_id is not null then true
+               else false
+            end                                                             as possible_advance_attendance
+
+            from scheduled_instance si
+                join activity_schedule as1 on as1.activity_schedule_id = si.activity_schedule_id
+                join activity a on a.activity_id = as1.activity_id
+                join allocation alloc on as1.activity_schedule_id = alloc.activity_schedule_id
+                left join exclusion e on alloc.allocation_id = e.allocation_id
+                left join planned_deallocation pd on alloc.planned_deallocation_id = pd.planned_deallocation_id
+                left join advance_attendance adv_att on si.scheduled_instance_id = adv_att.scheduled_instance_id and alloc.prisoner_number = adv_att.prisoner_number
+             where alloc.prisoner_status <> 'ENDED'
+                and not exists (select 1 from attendance a2 where a2.scheduled_instance_id = si.scheduled_instance_id and a2.prisoner_number = alloc.prisoner_number)
+     ) as data

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
@@ -146,6 +146,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -208,6 +209,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -280,6 +282,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -325,6 +328,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -387,6 +391,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = true,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -446,6 +451,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -521,6 +527,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -604,6 +611,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -687,6 +695,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -760,6 +769,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -843,6 +853,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -932,6 +943,7 @@ class ManageAttendancesServiceTest {
           scheduleWeeks = 1,
           possibleExclusion = false,
           plannedDeallocationDate = null,
+          possibleAdvanceAttendance = false,
         ),
       ),
     )
@@ -970,6 +982,94 @@ class ManageAttendancesServiceTest {
       assertThat(status()).isEqualTo(AttendanceStatus.WAITING)
       assertThat(prisonerNumber).isEqualTo(instance.activitySchedule.allocations().first().prisonerNumber)
       assertThat(payAmount).isEqualTo(30)
+    }
+
+    verify(outboundEventsService).send(OutboundEvent.PRISONER_ATTENDANCE_CREATED, 1L)
+  }
+
+  @Test
+  fun `attendance is created when advance attendance for not required exists`() {
+    whenever(attendanceCreationDataRepository.findBy(MOORLAND_PRISON_CODE, LocalDate.now())).thenReturn(
+      listOf(
+        AttendanceCreationData(
+          id = UUID.randomUUID(),
+          scheduledInstanceId = 0L,
+          sessionDate = LocalDate.now(),
+          timeSlot = TimeSlot.AM,
+          prisonerNumber = "A1234AA",
+          paid = true,
+          prisonPayBandId = 1L,
+          prisonCode = MOORLAND_PRISON_CODE,
+          activityId = 1L,
+          prisonerStatus = PrisonerStatus.ACTIVE,
+          allocationId = 1L,
+          allocStart = LocalDate.now(),
+          allocEnd = null,
+          scheduleStart = LocalDate.now(),
+          scheduleEnd = null,
+          scheduleWeeks = 1,
+          possibleExclusion = false,
+          plannedDeallocationDate = null,
+          possibleAdvanceAttendance = true,
+        ),
+      ),
+    )
+
+    val notRequiredReason = attendanceReasons()["NOT_REQUIRED"]
+
+    whenever(attendanceReasonRepository.findByCode(AttendanceReasonEnum.NOT_REQUIRED)).thenReturn(notRequiredReason)
+
+    whenever(scheduledInstanceRepository.findAllById(listOf(0L))).thenReturn(listOf(instance))
+
+    whenever(activityRepository.findAllById(listOf(1L))).thenReturn(listOf(activity))
+
+    whenever(prisonPayBandRepository.findAllById(listOf(1L))).thenReturn(listOf(lowPayBand))
+    whenever(allocationRepository.findById(1L)).thenReturn(Optional.of(allocation))
+
+    whenever(attendanceRepository.saveAllAndFlush(anyList()))
+      .thenReturn(
+        listOf(
+          Attendance(
+            attendanceId = 1L,
+            scheduledInstance = instance,
+            prisonerNumber = instance.activitySchedule.allocations().first().prisonerNumber,
+            status = AttendanceStatus.WAITING,
+            initialIssuePayment = true,
+            payAmount = 30,
+          ),
+        ),
+      )
+
+    whenever(prisonerSearchApiClient.findByPrisonerNumbersMap(listOf("A1234AA")))
+      .thenReturn(listOf(PrisonerSearchPrisonerFixture.instance(prisonerNumber = "A1234AA")).associateBy { it.prisonerNumber })
+
+    instance.advanceAttendances.first().updatePayment(false, "Sally Baker")
+
+    service.createAttendances(today, MOORLAND_PRISON_CODE)
+
+    verify(attendanceRepository).saveAllAndFlush(attendanceListCaptor.capture())
+
+    with(attendanceListCaptor.firstValue.first()) {
+      assertThat(attendanceId).isEqualTo(0L) // Not set when called
+      assertThat(status()).isEqualTo(AttendanceStatus.COMPLETED)
+      assertThat(attendanceReason).isEqualTo(notRequiredReason)
+      assertThat(prisonerNumber).isEqualTo(instance.activitySchedule.allocations().first().prisonerNumber)
+      assertThat(payAmount).isEqualTo(30)
+      assertThat(history()).hasSize(2)
+      with(history().first()) {
+        val matchingAdvanceAttendanceHistory = instance.advanceAttendances.first().history().first()
+        assertThat(attendanceReason).isEqualTo(notRequiredReason)
+        assertThat(issuePayment).isEqualTo(matchingAdvanceAttendanceHistory.issuePayment)
+        assertThat(recordedTime).isEqualTo(matchingAdvanceAttendanceHistory.recordedTime)
+        assertThat(recordedBy).isEqualTo(matchingAdvanceAttendanceHistory.recordedBy)
+      }
+      with(history().last()) {
+        val matchingAdvanceAttendance = instance.advanceAttendances.first()
+        assertThat(attendanceReason).isEqualTo(notRequiredReason)
+        assertThat(issuePayment).isEqualTo(matchingAdvanceAttendance.issuePayment)
+        assertThat(recordedTime).isEqualTo(matchingAdvanceAttendance.recordedTime)
+        assertThat(recordedBy).isEqualTo(matchingAdvanceAttendance.recordedBy)
+      }
     }
 
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ATTENDANCE_CREATED, 1L)

--- a/src/test/resources/test_data/seed-activity-with-advance-attendances-1.sql
+++ b/src/test/resources/test_data/seed-activity-with-advance-attendances-1.sql
@@ -1,0 +1,21 @@
+insert into activity(prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values ('PVI', 1, 1, true, false, false, false, 'H', 'Gym', 'Gym induction', current_date, null, 'high', current_timestamp, 'SEED USER', true);
+
+insert into activity_schedule(activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 'Gym induction AM', 1, 'L1', 'Location 1', 10, current_date);
+
+insert into activity_schedule_slot(activity_schedule_id, start_time, end_time, monday_flag, time_slot)
+values ( 1, '10:00:00', '11:00:00', true, 'AM');
+
+insert into allocation(activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values ( 1, 'A11111A', 10001, 1, '2022-10-10', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_date, '10:00:00', '11:00:00', false, null, null, null, null, 'AM');
+
+insert into advance_attendance(scheduled_instance_id, prisoner_number, issue_payment, recorded_time, recorded_by)
+values (1, 'A11111A', true, '2022-10-15 10:00:00', 'FRED SMITH');
+
+insert into advance_attendance_history(advance_attendance_id, recorded_time, recorded_by, issue_payment)
+values (1, '2022-10-14 11:00:00', 'ALICE JONES', false),
+       (1, '2022-10-13 11:00:00', 'SARAH WILLIAMS', true);


### PR DESCRIPTION
A user can create advance attendances to say that a prisoner is not required for a future activity.

On the morning of that day the attendance job needs to check for any advance attendances for that prisoner and that session and create the not required attendance record.

Example UI:
<img width="802" alt="image" src="https://github.com/user-attachments/assets/20ec3ebf-46c8-4a8d-a67c-8d6486b46327" />


<img width="714" alt="image" src="https://github.com/user-attachments/assets/c92a3910-94bf-419d-8877-33913f6727d9" />
