### PR TITLE
SAA-2444: Exclude future not required prisoners from unlock list

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/PrisonerScheduledActivityRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/PrisonerScheduledActivityRepository.kt
@@ -44,6 +44,7 @@ interface PrisonerScheduledActivityRepository : JpaRepository<PrisonerScheduledA
     AND sa.sessionDate = :date
     AND sa.prisonerNumber in :prisonerNumbers
     AND (:timeSlot IS NULL OR sa.timeSlot = :timeSlot)
+    AND sa.possibleAdvanceAttendance = false
     """,
   )
   fun getScheduledActivitiesForPrisonerListAndDate(


### PR DESCRIPTION
Remove any prisoner events from unlock list if the prisoner is not required for the future.