### PR TITLE
Correct activity schedules OpenAPI schema

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleLite.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ActivityScheduleLite.kt
@@ -22,7 +22,7 @@ data class ActivityScheduleLite(
   @Schema(description = "The description of this activity schedule", example = "Monday AM Houseblock 3")
   val description: String,
 
-  @Schema(description = "The NOMIS internal location for this schedule", example = "98877667")
+  @Schema(description = "The NOMIS internal location for this schedule")
   var internalLocation: InternalLocation? = null,
 
   @Schema(description = "The maximum number of prisoners allowed for a scheduled instance of this schedule", example = "10")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
@@ -162,7 +162,7 @@ class ActivityController(
         content = [
           Content(
             mediaType = "application/json",
-            array = ArraySchema(schema = Schema(implementation = ActivityScheduleLite::class))
+            array = ArraySchema(schema = Schema(implementation = ActivityScheduleLite::class)),
           ),
         ],
       ),

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
@@ -2,6 +2,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource
 
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
+import io.swagger.v3.oas.annotations.media.ArraySchema
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
 import io.swagger.v3.oas.annotations.responses.ApiResponse
@@ -157,10 +158,11 @@ class ActivityController(
       ApiResponse(
         responseCode = "200",
         description = "Activity schedules",
+        useReturnTypeSchema = true,
         content = [
           Content(
             mediaType = "application/json",
-            schema = Schema(implementation = ActivityScheduleLite::class),
+            array = ArraySchema(schema = Schema(implementation = ActivityScheduleLite::class))
           ),
         ],
       ),


### PR DESCRIPTION
Contains some corrections to the OpenAPI schema annotations for the `/activities/{activityId}/schedules` endpoint.