### PR TITLE
HMAI-643 - Add end date to /appointments/{prisonCode}/search

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSearchRequest.kt
@@ -38,6 +38,15 @@ data class AppointmentSearchRequest(
   val startDate: LocalDate,
 
   @Schema(
+    description = """
+    When an end date is supplied alongside the start date, the search uses a date range and will restrict the search results to
+    appointments that have a start date within the date range.
+    """,
+  )
+  @JsonFormat(pattern = "yyyy-MM-dd")
+  val endDate: LocalDate? = null,
+
+  @Schema(
     description =
     """
     The time slot to match with the appointments. Will restrict the search results to appointments that have a start

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/AppointmentSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/AppointmentSearchService.kt
@@ -1,10 +1,8 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.appointment
 
 import com.microsoft.applicationinsights.TelemetryClient
-import org.springframework.data.jpa.domain.Specification
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.appointment.AppointmentSearch
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.appointment.AppointmentType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.appointment.toResults
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AppointmentSearchRequest

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/AppointmentSearchService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/appointment/AppointmentSearchService.kt
@@ -17,6 +17,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.RolloutPrisonService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.CATEGORY_CODE_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.CREATED_BY_PROPERTY_KEY
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.END_DATE_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.EVENT_TIME_MS_METRIC_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.INTERNAL_LOCATION_ID_PROPERTY_KEY
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.telemetry.PRISONER_NUMBER_PROPERTY_KEY
@@ -149,6 +150,7 @@ class AppointmentSearchService(
       USER_PROPERTY_KEY to principal.name,
       PRISON_CODE_PROPERTY_KEY to prisonCode,
       START_DATE_PROPERTY_KEY to (request.startDate.toString() ?: ""),
+      END_DATE_PROPERTY_KEY to (request.endDate?.toString() ?: ""),
       TIME_SLOT_PROPERTY_KEY to (request.timeSlots?.toString() ?: ""),
       CATEGORY_CODE_PROPERTY_KEY to (request.categoryCode ?: ""),
       INTERNAL_LOCATION_ID_PROPERTY_KEY to (request.internalLocationId?.toString() ?: ""),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSearchIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSearchIntegrationTest.kt
@@ -215,6 +215,9 @@ class AppointmentSearchIntegrationTest : IntegrationTestBase() {
     val results = webTestClient.searchAppointments("MDI", request)!!
 
     assertThat(results.map { it.startDate }.distinct()).containsOnly(request.startDate, request.endDate)
+
+    // Check for single prison code as date range filtering uses ORs which can cause data leaks
+    assertThat(results.map { it.prisonCode }.distinct()).containsOnly("MDI")
   }
 
   @Sql(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSearchIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSearchIntegrationTest.kt
@@ -214,10 +214,10 @@ class AppointmentSearchIntegrationTest : IntegrationTestBase() {
 
     val results = webTestClient.searchAppointments("MDI", request)!!
 
-    assertThat(results.map { it.startDate }.distinct()).containsOnly(request.startDate, request.endDate)
-
     // Check for single prison code as date range filtering uses ORs which can cause data leaks
     assertThat(results.map { it.prisonCode }.distinct()).containsOnly("MDI")
+
+    assertThat(results.map { it.startDate }.distinct()).containsOnly(request.startDate, request.endDate)
   }
 
   @Sql(
@@ -241,6 +241,9 @@ class AppointmentSearchIntegrationTest : IntegrationTestBase() {
     )
 
     val results = webTestClient.searchAppointments("MDI", request)!!
+
+    // Check for single prison code as date range filtering uses ORs which can cause data leaks
+    assertThat(results.map { it.prisonCode }.distinct()).containsOnly("MDI")
 
     results.map { it.startTime }.forEach {
       assertThat(it).isBetween(LocalTime.of(0, 0), LocalTime.of(16, 59))
@@ -272,6 +275,9 @@ class AppointmentSearchIntegrationTest : IntegrationTestBase() {
     )
 
     val results = webTestClient.searchAppointments("MDI", request)!!
+
+    // Check for single prison code as date range filtering uses ORs which can cause data leaks
+    assertThat(results.map { it.prisonCode }.distinct()).containsOnly("MDI")
 
     results.map { it.startTime }.forEach {
       assertThat(it).isBetween(LocalTime.of(0, 0), LocalTime.of(23, 59))

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSearchIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentSearchIntegrationTest.kt
@@ -283,6 +283,30 @@ class AppointmentSearchIntegrationTest : IntegrationTestBase() {
     "classpath:test_data/seed-appointment-search.sql",
   )
   @Test
+  fun `search for next weeks appointments and not find any`() {
+    val request = AppointmentSearchRequest(
+      startDate = LocalDate.now().plusWeeks(1),
+      endDate = LocalDate.now().plusDays(1).plusWeeks(1),
+    )
+
+    prisonApiMockServer.stubGetAppointmentCategoryReferenceCodes()
+    prisonApiMockServer.stubGetLocationsForAppointments(
+      "MDI",
+      listOf(
+        appointmentLocation(123, "MDI", userDescription = "Location 123"),
+        appointmentLocation(456, "MDI", userDescription = "Location 456"),
+      ),
+    )
+
+    val results = webTestClient.searchAppointments("MDI", request)!!
+
+    results.size.isEqualTo(0)
+  }
+
+  @Sql(
+    "classpath:test_data/seed-appointment-search.sql",
+  )
+  @Test
   fun `search for appointments that are part of an appointment with category AC1`() {
     val request = AppointmentSearchRequest(
       startDate = LocalDate.now(),

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSearchServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AppointmentSearchServiceTest.kt
@@ -301,6 +301,110 @@ class AppointmentSearchServiceTest {
   }
 
   @Test
+  fun `search by date range and time slot`() {
+    val request = AppointmentSearchRequest(startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), timeSlots = listOf(TimeSlot.AM))
+    val result = appointmentSearchEntity()
+
+    whenever(prisonRegimeService.getTimeRangeForPrisonAndTimeSlot("TPR", request.timeSlots?.get(0) ?: TimeSlot.PM, request.startDate.dayOfWeek))
+      .thenReturn(LocalTimeRange(LocalTime.of(0, 0), LocalTime.of(13, 0)))
+    whenever(prisonRegimeService.getTimeRangeForPrisonAndTimeSlot("TPR", request.timeSlots?.get(0) ?: TimeSlot.PM, request.endDate!!.dayOfWeek))
+      .thenReturn(LocalTimeRange(LocalTime.of(0, 30), LocalTime.of(12, 30)))
+    whenever(appointmentSearchRepository.findAll(any())).thenReturn(listOf(result))
+    whenever(appointmentAttendeeSearchRepository.findByAppointmentIds(listOf(result.appointmentId))).thenReturn(result.attendees)
+    whenever(referenceCodeService.getReferenceCodesMap(ReferenceCodeDomain.APPOINTMENT_CATEGORY))
+      .thenReturn(mapOf(result.categoryCode to appointmentCategoryReferenceCode(result.categoryCode)))
+    whenever(locationService.getLocationsForAppointmentsMap(result.prisonCode))
+      .thenReturn(mapOf(result.internalLocationId!! to appointmentLocation(result.internalLocationId!!, "TPR")))
+
+    service.searchAppointments("TPR", request, principal)
+
+    verify(appointmentSearchSpecification).prisonCodeEquals("TPR")
+    verify(appointmentSearchSpecification).startDateEquals(request.startDate)
+    verify(appointmentSearchSpecification).startTimeBetween(LocalTime.of(0, 0), LocalTime.of(12, 59))
+    verify(appointmentSearchSpecification).startDateEquals(request.endDate)
+    verify(appointmentSearchSpecification).startTimeBetween(LocalTime.of(0, 30), LocalTime.of(12, 29))
+    verifyNoMoreInteractions(appointmentSearchSpecification)
+
+    verify(telemetryClient).trackEvent(
+      eq(TelemetryEvent.APPOINTMENT_SEARCH.value),
+      telemetryPropertyMap.capture(),
+      telemetryMetricsMap.capture(),
+    )
+
+    with(telemetryPropertyMap) {
+      assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
+      assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
+      assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
+      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo(request.endDate?.toString() ?: "")
+      assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo(request.timeSlots.toString())
+      assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo("")
+      assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo("")
+      assertThat(value[PRISONER_NUMBER_PROPERTY_KEY]).isEqualTo("")
+      assertThat(value[CREATED_BY_PROPERTY_KEY]).isEqualTo("")
+    }
+
+    with(telemetryMetricsMap) {
+      assertThat(value[RESULTS_COUNT_METRIC_KEY]).isEqualTo(1.0)
+      assertThat(value[EVENT_TIME_MS_METRIC_KEY]).isNotNull()
+    }
+  }
+
+  @Test
+  fun `search by date range and multiple time slots`() {
+    val request = AppointmentSearchRequest(startDate = LocalDate.now(), endDate = LocalDate.now().plusDays(1), timeSlots = listOf(TimeSlot.AM, TimeSlot.PM))
+    val result = appointmentSearchEntity()
+
+    whenever(prisonRegimeService.getTimeRangeForPrisonAndTimeSlot("TPR", TimeSlot.AM, request.startDate.dayOfWeek))
+      .thenReturn(LocalTimeRange(LocalTime.of(0, 0), LocalTime.of(13, 0)))
+    whenever(prisonRegimeService.getTimeRangeForPrisonAndTimeSlot("TPR", TimeSlot.PM, request.startDate.dayOfWeek))
+      .thenReturn(LocalTimeRange(LocalTime.of(13, 0), LocalTime.of(18, 0)))
+    whenever(prisonRegimeService.getTimeRangeForPrisonAndTimeSlot("TPR", TimeSlot.AM, request.endDate!!.dayOfWeek))
+      .thenReturn(LocalTimeRange(LocalTime.of(0, 30), LocalTime.of(12, 30)))
+    whenever(prisonRegimeService.getTimeRangeForPrisonAndTimeSlot("TPR", TimeSlot.PM, request.endDate.dayOfWeek))
+      .thenReturn(LocalTimeRange(LocalTime.of(12, 30), LocalTime.of(17, 30)))
+    whenever(appointmentSearchRepository.findAll(any())).thenReturn(listOf(result))
+    whenever(appointmentAttendeeSearchRepository.findByAppointmentIds(listOf(result.appointmentId))).thenReturn(result.attendees)
+    whenever(referenceCodeService.getReferenceCodesMap(ReferenceCodeDomain.APPOINTMENT_CATEGORY))
+      .thenReturn(mapOf(result.categoryCode to appointmentCategoryReferenceCode(result.categoryCode)))
+    whenever(locationService.getLocationsForAppointmentsMap(result.prisonCode))
+      .thenReturn(mapOf(result.internalLocationId!! to appointmentLocation(result.internalLocationId!!, "TPR")))
+
+    service.searchAppointments("TPR", request, principal)
+
+    verify(appointmentSearchSpecification).prisonCodeEquals("TPR")
+    verify(appointmentSearchSpecification).startDateEquals(request.startDate)
+    verify(appointmentSearchSpecification).startTimeBetween(LocalTime.of(0, 0), LocalTime.of(12, 59))
+    verify(appointmentSearchSpecification).startTimeBetween(LocalTime.of(13, 0), LocalTime.of(17, 59))
+    verify(appointmentSearchSpecification).startDateEquals(request.endDate)
+    verify(appointmentSearchSpecification).startTimeBetween(LocalTime.of(0, 30), LocalTime.of(12, 29))
+    verify(appointmentSearchSpecification).startTimeBetween(LocalTime.of(12, 30), LocalTime.of(17, 29))
+    verifyNoMoreInteractions(appointmentSearchSpecification)
+
+    verify(telemetryClient).trackEvent(
+      eq(TelemetryEvent.APPOINTMENT_SEARCH.value),
+      telemetryPropertyMap.capture(),
+      telemetryMetricsMap.capture(),
+    )
+
+    with(telemetryPropertyMap) {
+      assertThat(value[USER_PROPERTY_KEY]).isEqualTo(principal.name)
+      assertThat(value[PRISON_CODE_PROPERTY_KEY]).isEqualTo("TPR")
+      assertThat(value[START_DATE_PROPERTY_KEY]).isEqualTo(request.startDate.toString())
+      assertThat(value[END_DATE_PROPERTY_KEY]).isEqualTo(request.endDate?.toString() ?: "")
+      assertThat(value[TIME_SLOT_PROPERTY_KEY]).isEqualTo(request.timeSlots.toString())
+      assertThat(value[CATEGORY_CODE_PROPERTY_KEY]).isEqualTo("")
+      assertThat(value[INTERNAL_LOCATION_ID_PROPERTY_KEY]).isEqualTo("")
+      assertThat(value[PRISONER_NUMBER_PROPERTY_KEY]).isEqualTo("")
+      assertThat(value[CREATED_BY_PROPERTY_KEY]).isEqualTo("")
+    }
+
+    with(telemetryMetricsMap) {
+      assertThat(value[RESULTS_COUNT_METRIC_KEY]).isEqualTo(1.0)
+      assertThat(value[EVENT_TIME_MS_METRIC_KEY]).isNotNull()
+    }
+  }
+
+  @Test
   fun `search by category code`() {
     val request = AppointmentSearchRequest(startDate = LocalDate.now(), categoryCode = "TEST")
     val result = appointmentSearchEntity()

--- a/src/test/resources/test_data/seed-appointment-search.sql
+++ b/src/test/resources/test_data/seed-appointment-search.sql
@@ -72,3 +72,81 @@ INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, priso
 VALUES (327, 213, 'B2345CD', 457);
 INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (328, 211, 'C3456DE', 458);
+
+-- Appointments for tomorrow
+
+--Individual appointments--
+--Prisoner A1234BC, Category AC1, Location 123, Today 08:30-10:00, Created by TEST.USER
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (111, 'INDIVIDUAL', 'MDI', 'AC1', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (214, 111, 1, 'MDI', 'AC1', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (329, 214, 'A1234BC', 456);
+
+--Prisoner B2345CD, Category AC2, Description Art Class, Location 456, Today 13:00-15:00, Created by DIFFERENT.USER
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, custom_name, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (112, 'INDIVIDUAL', 'MDI', 'AC2', 'Art Class', 1, 456, false, now()::date + 1, '13:00', '15:00', now()::timestamp, 'DIFFERENT.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (215, 112, 1, 'MDI', 'AC2', 1, 456, false, now()::date + 1, '13:00', '15:00', now()::timestamp, 'DIFFERENT.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (330, 215, 'B2345CD', 457);
+
+--Prisoner A1234BC, Category AC3, In cell, One week from now 12:30-14:00, Created by TEST.USER
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (113, 'INDIVIDUAL', 'MDI', 'AC3', 1, null, true, now()::date + 1, '12:30', '14:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (216, 113, 1, 'MDI', 'AC3', 1, null, true, now()::date + 1, '12:30', '14:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (331, 216, 'A1234BC', 456);
+
+--Prison OTH, Prisoner A1234BC, Category AC1, Location 789, Today 09:00-10:30, Created by OTHER.USER
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (114, 'INDIVIDUAL', 'OTH', 'AC1', 1, 789, false, now()::date + 1, '09:00', '10:30', now()::timestamp, 'OTHER.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (217, 114, 1, 'OTH', 'AC1', 1, 789, false, now()::date + 1, '09:00', '10:30', now()::timestamp, 'OTHER.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (332, 217, 'D4567EF', 459);
+
+--Individual appointments--
+--Prisoner A1234BC, Category AC1, Location 123, Today 08:30-10:00, Created by TEST.USER
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (115, 'INDIVIDUAL', 'MDI', 'AC1', 1, 123, false, now()::date + 1, '21:00', '22:30', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (218, 115, 1, 'MDI', 'AC1', 1, 123, false, now()::date + 1, '21:00', '22:30', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (333, 218, 'A1234BC', 456);
+
+--Group appointments--
+--Prisoners A1234BC and B2345CD, Category AC1, Location 123, Started one week ago 09:00-10:30, Repeating weekly 4 times, One edited, One cancelled, One deleted, Created by TEST.USER
+INSERT INTO appointment_series_schedule (appointment_series_schedule_id, frequency, number_of_appointments)
+VALUES (11, 'WEEKLY', 4);
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, appointment_series_schedule_id, created_time, created_by)
+VALUES (116, 'GROUP', 'MDI', 'AC1', 1, 123, false, now()::date + 1, '09:00', '10:30', 10, now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (219, 116, 1, 'MDI', 'AC1', 1, 123, false, now()::date + 1, '09:00', '10:30', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, updated_time, updated_by)
+VALUES (220, 116, 2, 'MDI', 'AC1', 1, 456, false, now()::date + 1, '13:30', '15:00', now()::timestamp, 'TEST.USER', now()::timestamp, 'DIFFERENT.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, cancelled_time, cancellation_reason_id, cancelled_by)
+VALUES (221, 116, 3, 'MDI', 'AC1', 1, 123, false, now()::date + 1, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 2, 'DIFFERENT.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by, cancelled_time, cancellation_reason_id, cancelled_by, is_deleted)
+VALUES (222, 116, 4, 'MDI', 'AC1', 1, 123, false, now()::date + 1, '09:00', '10:30', now()::timestamp, 'TEST.USER', now()::timestamp, 1, 'DIFFERENT.USER', true);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (334, 219, 'A1234BC', 456);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (335, 219, 'B2345CD', 457);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (336, 220, 'A1234BC', 456);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (337, 220, 'B2345CD', 457);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (338, 220, 'C3456DE', 458);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (339, 221, 'A1234BC', 456);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (340, 221, 'B2345CD', 457);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (341, 222, 'A1234BC', 456);
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (342, 222, 'B2345CD', 457);
+

--- a/src/test/resources/test_data/seed-appointment-search.sql
+++ b/src/test/resources/test_data/seed-appointment-search.sql
@@ -154,9 +154,9 @@ VALUES (342, 222, 'B2345CD', 457);
 
 --Prisoner A1234BC, Category AC1, Location 123, Today 08:30-10:00, Created by TEST.USER
 INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
-VALUES (117, 'INDIVIDUAL', 'MDI', 'AC1', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+VALUES (117, 'INDIVIDUAL', 'ABC', 'AC1', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
 INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
-VALUES (223, 117, 1, 'MDI', 'AC1', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+VALUES (223, 117, 1, 'ABC', 'AC1', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
 INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (343, 223, 'A1234BC', 456);
 

--- a/src/test/resources/test_data/seed-appointment-search.sql
+++ b/src/test/resources/test_data/seed-appointment-search.sql
@@ -150,3 +150,13 @@ VALUES (341, 222, 'A1234BC', 456);
 INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (342, 222, 'B2345CD', 457);
 
+-- Alternative prison
+
+--Prisoner A1234BC, Category AC1, Location 123, Today 08:30-10:00, Created by TEST.USER
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (117, 'INDIVIDUAL', 'MDI', 'AC1', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (223, 117, 1, 'MDI', 'AC1', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (343, 223, 'A1234BC', 456);
+


### PR DESCRIPTION
`endDate` is now a field you can supply on an `AppointmentSearchRequest`, doing so will turn the search into a range search on the `startDate` of the appointment.

* `endDate` is optional and defaults to `null` so it shouldn't affect existing integrations
* Due to the number of ORs being added to the search specification, I added an appointment for another prison to the test seed data so my integration tests can check that the date range search doesn't leak data