### PR TITLE
Opt into param site target for annotations

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,7 @@ tasks {
     dependsOn("buildPrisonApiModel", "buildNonAssociationsApiModel", "buildIncentivesApiModel", "buildLocationsInsidePrisonApiModel", "copyPreCommitHook")
     compilerOptions {
       jvmTarget.set(JvmTarget.JVM_21)
+      freeCompilerArgs.add("-Xannotation-default-target=param-property")
     }
   }
 }


### PR DESCRIPTION
Remove compiler warnings as done elsewhere:

```
This annotation is currently applied to the value parameter only, but in the future it will also be applied to field.
- To opt in to applying to both value parameter and field, add '-Xannotation-default-target=param-property' to your compiler arguments.
- To keep applying to the value parameter only, use the '@param:' annotation target.
```