### PR TITLE
Revert "Update dependency gradle to v9"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -155,7 +155,7 @@ tasks.register("listrepos") {
 tasks.register("copyPreCommitHook", Copy::class) {
   from(project.file("pre-commit"))
   into(project.file(".git/hooks"))
-  filePermissions { unix("755") }
+  setFileMode(0b111101101)
   dependsOn("generateGitProperties")
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-activities-management-api#1666

`integrationTest` does not run any tests