### PR TITLE
BAVL-1030 attendees should not be removed from court and probation video appointments

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/appointment/AppointmentManagement.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/appointment/AppointmentManagement.kt
@@ -1,0 +1,17 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.appointment
+
+private const val VIDEO_LINK_COURT_APPOINTMENT_CATEGORY_CODE = "VLB"
+private const val VIDEO_LINK_PROBATION_APPOINTMENT_CATEGORY_CODE = "VLPM"
+
+object AppointmentManagement {
+  fun isManagedByTheService(appointmentInstance: AppointmentInstance) = isManagedByTheService(appointmentInstance.categoryCode)
+
+  /*
+   * Court and probation video link appointments are not managed by the Activities and Appointments service. These types of
+   * appointment are managed and owned by the book a video link service.
+   */
+  private fun isManagedByTheService(value: String) = value !in listOf(
+    VIDEO_LINK_COURT_APPOINTMENT_CATEGORY_CODE,
+    VIDEO_LINK_PROBATION_APPOINTMENT_CATEGORY_CODE,
+  )
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/appointment/AppointmentManagementTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/appointment/AppointmentManagementTest.kt
@@ -1,0 +1,29 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.appointment
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
+
+class AppointmentManagementTest {
+  private val appointmentInstance: AppointmentInstance = mock()
+
+  @Test
+  fun `should not manage video link court appointment`() {
+    whenever(appointmentInstance.categoryCode) doReturn "VLB"
+    AppointmentManagement.isManagedByTheService(appointmentInstance) isBool false
+  }
+
+  @Test
+  fun `should not manage video link probation appointment`() {
+    whenever(appointmentInstance.categoryCode) doReturn "VLPM"
+    AppointmentManagement.isManagedByTheService(appointmentInstance) isBool false
+  }
+
+  @Test
+  fun `should manage chaplaincy appointment`() {
+    whenever(appointmentInstance.categoryCode) doReturn "CHAP"
+    AppointmentManagement.isManagedByTheService(appointmentInstance) isBool true
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/InboundEventsIntegrationTest.kt
@@ -395,7 +395,7 @@ class InboundEventsIntegrationTest : LocalStackTestBase() {
   @Test
   @Sql("classpath:test_data/seed-appointments-changed-event.sql")
   fun `appointments deleted when offender released event received`() {
-    val appointmentIds = listOf(200L, 201L, 202L, 203L, 210L, 211L, 212L)
+    val appointmentIds = listOf(200L, 201L, 202L, 203L, 204L, 210L, 211L, 212L)
 
     stubPrisonerForInterestingEvent(activeInMoorlandInmate.copy(offenderNo = "A1234BC"))
 
@@ -411,6 +411,7 @@ class InboundEventsIntegrationTest : LocalStackTestBase() {
     assertThat(allocationsMap[201]).hasSize(1)
     assertThat(allocationsMap[202]).hasSize(1)
     assertThat(allocationsMap[203]).hasSize(1)
+    assertThat(allocationsMap[204]).hasSize(1)
     assertThat(allocationsMap[210]).hasSize(2)
     assertThat(allocationsMap[211]).hasSize(3)
     assertThat(allocationsMap[212]).hasSize(2)
@@ -428,6 +429,7 @@ class InboundEventsIntegrationTest : LocalStackTestBase() {
       assertThat(allocationsMap[201]).hasSize(1)
       assertThat(allocationsMap[202]).isNull()
       assertThat(allocationsMap[203]).hasSize(1)
+      assertThat(allocationsMap[204]).hasSize(1)
       assertThat(allocationsMap[210]).hasSize(2)
       assertThat(allocationsMap[211]).hasSize(2)
       assertThat(allocationsMap[212]).hasSize(1)
@@ -439,6 +441,7 @@ class InboundEventsIntegrationTest : LocalStackTestBase() {
 
       assertThat(appointmentAttendeeRepository.existsById(301)).isTrue()
       assertThat(appointmentAttendeeRepository.existsById(303)).isTrue()
+      assertThat(appointmentAttendeeRepository.existsById(304)).isTrue()
       assertThat(appointmentAttendeeRepository.existsById(320)).isTrue()
       assertThat(appointmentAttendeeRepository.existsById(321)).isTrue()
       assertThat(appointmentAttendeeRepository.existsById(323)).isTrue()
@@ -449,6 +452,8 @@ class InboundEventsIntegrationTest : LocalStackTestBase() {
 
       verify(outboundEventsService).send(APPOINTMENT_INSTANCE_DELETED, 300L)
       verify(outboundEventsService).send(APPOINTMENT_INSTANCE_DELETED, 302L)
+      // This is a court video link appointment and should not be touched on release
+      verify(outboundEventsService, never()).send(APPOINTMENT_INSTANCE_DELETED, 304L)
       verify(outboundEventsService).send(APPOINTMENT_INSTANCE_DELETED, 322L)
       verify(outboundEventsService).send(APPOINTMENT_INSTANCE_DELETED, 324L)
       verifyNoMoreInteractions(outboundEventsService)

--- a/src/test/resources/test_data/seed-appointments-changed-event.sql
+++ b/src/test/resources/test_data/seed-appointments-changed-event.sql
@@ -31,6 +31,14 @@ VALUES (203, 103, 1, 'OTH', 'AC1', 1, 789, false, now()::date + 1, '09:00', '10:
 INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
 VALUES (303, 203, 'D4567EF', 459);
 
+--Prisoner A1234BC, Category VLB, Location 123, Today 08:30-10:00, Created by TEST.USER
+INSERT INTO appointment_series (appointment_series_id, appointment_type, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (104, 'INDIVIDUAL', 'MDI', 'VLB', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment (appointment_id, appointment_series_id, sequence_number, prison_code, category_code, appointment_tier_id, internal_location_id, in_cell, start_date, start_time, end_time, created_time, created_by)
+VALUES (204, 104, 1, 'MDI', 'VLB', 1, 123, false, now()::date + 1, '08:30', '10:00', now()::timestamp, 'TEST.USER');
+INSERT INTO appointment_attendee (appointment_attendee_id, appointment_id, prisoner_number, booking_id)
+VALUES (304, 204, 'A1234BC', 456);
+
 --Group appointments--
 --Prisoners A1234BC and B2345CD, Category AC1, Location 123, Started one week ago 09:00-10:30, Repeating weekly 4 times, One edited, One cancelled, One deleted, Created by TEST.USER
 INSERT INTO appointment_series_schedule (appointment_series_schedule_id, frequency, number_of_appointments)


### PR DESCRIPTION
Related [Jira](https://dsdmoj.atlassian.net/browse/BAVL-1030) ticket.

This change stops attendees from being removed from video link court and probation appointments. These appointment types are (now) managed outside of A&A via the book a video link service.

For example, when a prisoner is released the appointment is cancelled by the book a video link service making a call the A&A API.  A&A should not take any further action for these appointment types on the release of prisoners.