### PR TITLE
SAA-3537: Fix job type saved to database for deallocate allocations due to end

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/job/ManageAllocationsJob.kt
@@ -48,7 +48,7 @@ class ManageAllocationsJob(
 
     if (withDeallocateEnding) {
       if (sqsEnabledForDeallocateEnding) {
-        jobRunner.runDistributedJob(JobType.SCHEDULES, manageAllocationsDueToEndService::sendAllocationsDueToEndEvents)
+        jobRunner.runDistributedJob(JobType.DEALLOCATE_ENDING, manageAllocationsDueToEndService::sendAllocationsDueToEndEvents)
       } else {
         jobRunner.runJobWithRetry(
           JobDefinition(jobType = JobType.DEALLOCATE_ENDING) { manageAllocationsDueToEndService.endAllocationsDueToEnd() },

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/WaitingListService.kt
@@ -200,7 +200,7 @@ class WaitingListService(
       "Prisoner ${request.prisonerNumber} has no booking id at prison $prisonCode"
     }
 
-    return prisonerDetails.bookingId.toLong()
+    return prisonerDetails.bookingId!!.toLong()
   }
 
   private fun ActivitySchedule.failIfIsNotInWorkCategory() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AbstractJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AbstractJobIntegrationTest.kt
@@ -1,0 +1,36 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.RolloutPrisonService
+import uk.gov.justice.hmpps.sqs.HmppsQueue
+
+abstract class AbstractJobIntegrationTest : LocalStackTestBase() {
+
+  @Autowired
+  private lateinit var jobRepository: JobRepository
+
+  @Autowired
+  private lateinit var rolloutPrisonService: RolloutPrisonService
+
+  protected val jobsQueue by lazy { hmppsQueueService.findByQueueId("activitiesmanagementjobs") as HmppsQueue }
+  protected val jobsClient by lazy { jobsQueue.sqsClient }
+
+  @BeforeEach
+  fun `clear job queues`() {
+    clearQueues(jobsClient, jobsQueue)
+  }
+
+  protected fun verifyJobComplete(jobType: JobType) {
+    jobRepository.findAll().first().let {
+      assertThat(it.jobType).isEqualTo(jobType)
+      assertThat(it.successful).isTrue()
+      val numPrisons = rolloutPrisonService.getRolloutPrisons().count()
+      assertThat(it.totalSubTasks).isEqualTo(numPrisons)
+      assertThat(it.completedSubTasks).isEqualTo(numPrisons)
+    }
+  }
+}

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/CreateScheduledInstancesJobSqsIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/CreateScheduledInstancesJobSqsIntegrationTest.kt
@@ -11,13 +11,12 @@ import org.springframework.test.context.TestPropertySource
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.JobType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.JobRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ScheduledInstanceRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
-import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.refdata.RolloutPrisonService
 import java.time.DayOfWeek
 import java.time.LocalDate
 
@@ -28,19 +27,13 @@ import java.time.LocalDate
     "feature.jobs.sqs.schedules.enabled=true",
   ],
 )
-class CreateScheduledInstancesJobSqsIntegrationTest : LocalStackTestBase() {
+class CreateScheduledInstancesJobSqsIntegrationTest : AbstractJobIntegrationTest() {
 
   @MockitoBean
   private lateinit var outboundEventsService: OutboundEventsService
 
   @Autowired
   private lateinit var scheduleInstancesRepository: ScheduledInstanceRepository
-
-  @Autowired
-  private lateinit var jobRepository: JobRepository
-
-  @Autowired
-  private lateinit var rolloutPrisonService: RolloutPrisonService
 
   private val today: LocalDate = TimeSource.today()
 
@@ -66,12 +59,7 @@ class CreateScheduledInstancesJobSqsIntegrationTest : LocalStackTestBase() {
     verify(outboundEventsService).send(OutboundEvent.ACTIVITY_SCHEDULE_UPDATED, 2L)
     verifyNoMoreInteractions(outboundEventsService)
 
-    jobRepository.findAll().first().let {
-      assertThat(it.successful).isTrue()
-      val numPrisons = rolloutPrisonService.getRolloutPrisons().count()
-      assertThat(it.totalSubTasks).isEqualTo(numPrisons)
-      assertThat(it.completedSubTasks).isEqualTo(numPrisons)
-    }
+    verifyJobComplete(JobType.SCHEDULES)
   }
 
   @Sql("classpath:test_data/seed-activity-with-old-instances.sql")


### PR DESCRIPTION
- Job type fixed to use `DEALLOCATE_ENDING` instead of `SCHEDULES`
- Refactoring and improving tests