### PR TITLE
Use jars built in host in Dockerfile

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,6 +29,15 @@ jobs:
     secrets: inherit
     with:
       environment: ${{ matrix.environments }}
+  app_version:
+    name: Calculate application version
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.app_version.outputs.version }}
+    steps:
+      - id: app_version
+        name: Application version creators
+        uses: ministryofjustice/hmpps-github-actions/.github/actions/build-test-and-deploy/create_app_version@v2 # WORKFLOW_VERSION
   gradle_validate:
     name: Build the app and run the unit tests
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_verify.yml@v2 # WORKFLOW_VERSION
@@ -36,6 +45,9 @@ jobs:
     with:
       upload-build-artifacts: ${{ github.ref == 'refs/heads/main' }}
       artifact-name: unit-test-results
+      gradle-command: 'BUILD_NUMBER=${{ needs.app_version.outputs.version}} ./gradlew assemble check -x test'
+    needs:
+      - app_version
   gradle_integration_tests:
     name: Run the integration tests
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/gradle_localstack_postgres_verify.yml@v2 # WORKFLOW_VERSION
@@ -61,7 +73,8 @@ jobs:
       registry_org: 'ministryofjustice'
       additional_docker_tag: ${{ inputs.additional_docker_tag }}
       push: ${{ inputs.push || true }}
-      docker_multiplatform: true
+      docker_multiplatform: false
+      download_build_artifacts: true
   deploy_dev:
     name: Deploy to the dev environment
     if: github.ref == 'refs/heads/main'

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -5,8 +5,9 @@ ENV BUILD_NUMBER ${BUILD_NUMBER:-1_0_0}
 
 WORKDIR /app
 ADD . .
+RUN ./gradlew -Dorg.gradle.jvmargs="-Xmx2g" --no-daemon assemble
 
-RUN cp hmpps-activities-management-api*.jar app.jar
+RUN cp /app/build/libs/hmpps-activities-management-api*.jar app.jar
 RUN java -Djarmode=tools -jar app.jar extract --layers --destination extracted
 
 # Grab AWS RDS Root cert
@@ -36,7 +37,7 @@ COPY --from=builder --chown=appuser:appgroup /app/root.crt /home/appuser/.postgr
 WORKDIR /app
 COPY --chown=appuser:appgroup ./applicationinsights.json /app
 COPY --chown=appuser:appgroup ./applicationinsights.dev.json /app
-COPY --from=builder --chown=appuser:appgroup ./app/applicationinsights-agent*.jar /app/agent.jar
+COPY --from=builder --chown=appuser:appgroup /app/build/libs/applicationinsights-agent*.jar /app/agent.jar
 
 COPY --from=builder --chown=appuser:appgroup /app/extracted/spring-boot-loader/ /app
 COPY --from=builder --chown=appuser:appgroup /app/extracted/snapshot-dependencies/ /app

--- a/README.md
+++ b/README.md
@@ -212,8 +212,8 @@ If for example the attendance creation failed it can be re-run as follows:
 
 In a terminal window port forward to one of the API pods.
 
-```
-kubectl -n hmpps-activities-management-<dev|preprod|prod> get pods | grep api
+```shell
+  kubectl -n hmpps-activities-management-<dev|preprod|prod> get pods | grep api
 ```
 Using one of the API pods listed from the command above do the following
 ```
@@ -222,8 +222,8 @@ kubectl -n hmpps-activities-management-<dev|preprod|prod> port-forward hmpps-act
 
 In another terminal window a curl command to run the job (the one below is running attendance creation)
 
-```
-curl -XPOST "http://localhost:8080/job/manage-attendance-records?date=2023-11-18&prisonCode=XYZ"
+```shell
+  curl -XPOST "http://localhost:8080/job/manage-attendance-records?date=2023-11-18&prisonCode=XYZ"
 ```
 
 ### Manually raising events
@@ -234,8 +234,8 @@ There may be times we need to manually raise an event in production e.g. on the 
 
 In a terminal window port forward to one of the API pods
 
-```
-kubectl -n hmpps-activities-management-<dev|preprod|prod> get pods | grep api
+```shell
+  kubectl -n hmpps-activities-management-<dev|preprod|prod> get pods | grep api
 ```
 Using one of the API pods listed from the command above do the following
 ```
@@ -277,4 +277,12 @@ union *
 | where operation_Id ==‘<INSERT OPERATION ID HERE>’
 |project timestamp, message, itemType, name, operation_Name, cloud_RoleName, resultCode, customDimensions, duration, url, data, innermostMessage
 |sort by timestamp asc
+```
+
+### Docker files
+
+There are two Docker files. `Dockerfile` is used by GitHuba Actions to build the API Docker image for deployment to the enviroments. `Dockerfile.local` is used by developers to build the API Docker image locally.
+
+```shell
+  docker build -f Dockerfile.local .
 ```


### PR DESCRIPTION
Updated GitHub actions to re-use the jars from Gradle build instead of rebuilding again as part of Docker build.