### PR TITLE
SAA-4207: Allow update to a prisoners schedule today when removing exclusions

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Allocation.kt
@@ -176,6 +176,12 @@ data class Allocation(
     exclusionsToEnd.forEach { it.endNow() }
   }
 
+  fun endExclusionsYesterday(exclusionsToEnd: Set<Exclusion>) = run {
+    require(exclusionsToEnd.all { it.allocation == this }) { "Cannot end the given exclusions because some of them do not belong to the allocation with id $allocationId" }
+    require(exclusionsToEnd.all { it.startDate < LocalDate.now() }) { "Can only end exclusions for yesterday if exclusions started in the past" }
+    exclusionsToEnd.forEach { it.endYesterday() }
+  }
+
   fun prisonCode() = activitySchedule.activity.prisonCode
 
   private fun activitySummary() = activitySchedule.activity.summary

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Exclusion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Exclusion.kt
@@ -48,6 +48,11 @@ data class Exclusion(
 
   fun endNow() = run { endDate = LocalDate.now() }
 
+  fun endYesterday() {
+    require(startDate.isBefore(LocalDate.now()), { "Can only end an exclusion for yesterday if exclusion started in the past" })
+    endDate = LocalDate.now().minusDays(1)
+  }
+
   fun getDaysOfWeek() = this.exclusionDaysOfWeek.map { it.dayOfWeek }.toSet()
 
   fun setDaysOfWeek(daysOfWeek: Set<DayOfWeek>) {

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AllocationUpdateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AllocationUpdateRequest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request
 import com.fasterxml.jackson.annotation.JsonFormat
 import io.swagger.v3.oas.annotations.media.Schema
 import jakarta.validation.constraints.FutureOrPresent
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Slot
 import java.time.LocalDate
 
@@ -39,6 +40,10 @@ data class AllocationUpdateRequest(
   )
   val exclusions: List<Slot>? = null,
 
+  @Deprecated(message = "Superseded by todayTimeSlot")
   @Schema(description = "The scheduled instance id required when allocation starts today")
   val scheduleInstanceId: Long? = null,
+
+  @Schema(description = "The scheduled instances time slot for any allocations or exclusions changes that should apply today")
+  var firstTimeSlotForToday: TimeSlot? = null,
 )

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ScheduledInstanceRepository.kt
@@ -30,34 +30,6 @@ interface ScheduledInstanceRepository : JpaRepository<ScheduledInstance, Long> {
   ): List<ScheduledInstance>
 
   @Query(
-    """
-    SELECT si FROM ScheduledInstance si
-    WHERE si.activitySchedule.activity.prisonCode = :prisonCode
-    AND si.sessionDate >= :startDate
-    AND si.sessionDate <= :endDate
-    AND (:cancelled is null or si.cancelled = :cancelled)
-    AND (:timeSlot is null or si.timeSlot = :timeSlot)
-    AND (
-      EXISTS (
-        SELECT 1 FROM si.attendances a WHERE a.prisonerNumber = :prisonerNumber
-      )
-      OR
-      EXISTS (
-        SELECT 1 FROM si.advanceAttendances aa WHERE aa.prisonerNumber = :prisonerNumber
-      )
-    )
-    """,
-  )
-  fun getActivityScheduleInstancesForPrisonerByPrisonCodeAndDateRange(
-    prisonCode: String,
-    prisonerNumber: String,
-    startDate: LocalDate,
-    endDate: LocalDate,
-    cancelled: Boolean? = null,
-    timeSlot: TimeSlot? = null,
-  ): List<ScheduledInstance>
-
-  @Query(
     "select si " +
       "from ScheduledInstance si " +
       "join fetch si.activitySchedule asch " +

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleService.kt
@@ -178,7 +178,10 @@ class ActivityScheduleService(
           .singleOrNull()?.allocated(allocation)
 
         // if allocation is for instance(s) later today then need to create attendance records
-        val newAttendances = manageAttendancesService.createAnyAttendancesForToday(request.scheduleInstanceId, allocation)
+        val newAttendances = manageAttendancesService.createAnyAttendancesForToday(
+          allocation = allocation,
+          scheduleInstanceId = request.scheduleInstanceId,
+        )
 
         repository.saveAndFlush(schedule)
 
@@ -290,7 +293,10 @@ class ActivityScheduleService(
             .singleOrNull()
 
           // if allocations are for instance(s) later today then need to create attendance records
-          val newAttendances = manageAttendancesService.createAnyAttendancesForToday(request.scheduleInstanceId, allocation)
+          val newAttendances = manageAttendancesService.createAnyAttendancesForToday(
+            allocation = allocation,
+            scheduleInstanceId = request.scheduleInstanceId,
+          )
           allocationsWithAttendances.add(Triple(allocation, newAttendances, maybeWaitingList))
         }
       }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
@@ -71,7 +71,12 @@ class AllocationsService(
 
       allocationRepository.saveAndFlush(allocation)
 
-      val newAttendances = manageAttendancesService.createAnyAttendancesForToday(request.scheduleInstanceId, allocation)
+      val newAttendances = manageAttendancesService.createAnyAttendancesForToday(
+        allocation = allocation,
+
+        scheduleInstanceId = request.scheduleInstanceId,
+        firstTimeSlot = request.firstTimeSlotForToday,
+      )
 
       val savedAttendances = manageAttendancesService.saveAttendances(newAttendances, allocation.activitySchedule.description)
 
@@ -99,32 +104,57 @@ class AllocationsService(
   }
 
   private fun applyExclusionsUpdate(request: AllocationUpdateRequest, allocation: Allocation) {
-    request.exclusions?.apply {
+    val todayScheduledInstance = request.firstTimeSlotForToday?.let { timeSlot ->
+      allocation.activitySchedule.instances().first { it.sessionDate == LocalDate.now() && it.timeSlot == timeSlot }
+    }
+
+    val today = LocalDate.now()
+
+    request.exclusions?.let { exclusions ->
       /*
-       End any exclusions tha have started and not ended.
+       End any exclusions that have started and not ended.
 
        Although Nomis does not have the concept of exclusion date ranges the old exclusions are needed for historical
        reasons such as unlock and attendance lists (SAA-1379)
        */
+      val newExclusionSlots = exclusions.map { it.weekNumber to it.timeSlot }.toSet()
+
+      // Remove exclusions staring in the future that are not in the request
+      allocation.removeExclusions(
+        allocation.exclusions(ExclusionsFilter.FUTURE)
+          .filter { (it.weekNumber to it.timeSlot) !in newExclusionSlots }
+          .toSet(),
+      )
+
+      // When the update request includes a scheduled instance for today, then end as yesterday or remove
+      if (todayScheduledInstance != null) {
+        val (toRemove, toEnd) = allocation.exclusions(ExclusionsFilter.PRESENT)
+          .filter { it.timeSlot >= todayScheduledInstance.timeSlot }
+          .partition { it.startDate == today }
+
+        allocation.removeExclusions(toRemove.toSet())
+        allocation.endExclusionsYesterday(toEnd.toSet())
+      }
+
+      // End any remaining exclusions that are current
       allocation.endExclusions(allocation.exclusions(ExclusionsFilter.PRESENT))
 
-      val newExclusions = this.map { ex -> ex.weekNumber to ex.timeSlot }
-      val exclusionsToRemove = allocation.exclusions(ExclusionsFilter.FUTURE).mapNotNull {
-        val oldExclusion = it.weekNumber to it.timeSlot
-        it.takeIf { oldExclusion !in newExclusions }
-      }.toSet()
-      allocation.removeExclusions(exclusionsToRemove)
-    }
+      exclusions.forEach { exclusion ->
+        require(!allocation.activitySchedule.noMatchingSlots(exclusion)) {
+          "Updating allocation with id ${allocation.allocationId}: No ${exclusion.timeSlot} slots in week number ${exclusion.weekNumber}"
+        }
 
-    request.exclusions?.onEach { exclusion ->
+        val startDate = todayScheduledInstance
+          ?.takeIf { it.timeSlot <= exclusion.timeSlot && exclusion.daysOfWeek.contains(today.dayOfWeek) }
+          ?.let { today }
+          ?: today.plusDays(1)
 
-      if (allocation.activitySchedule.noMatchingSlots(exclusion)) throw IllegalArgumentException("Updating allocation with id ${allocation.allocationId}: No ${exclusion.timeSlot} slots in week number ${exclusion.weekNumber}")
-
-      // exclusion updates always apply tomorrow, if the allocation date is in the past (as per the UI content)
-      allocation.updateExclusion(
-        exclusionSlot = exclusion,
-        startDate = maxOf(allocation.startDate, LocalDate.now().plusDays(1)),
-      )
+        // exclusion updates always apply tomorrow if the allocation date is in the past (as per the UI content)
+        allocation.updateExclusion(
+          exclusionSlot = exclusion,
+          startDate = maxOf(allocation.startDate, startDate),
+        )
+      }
     }
   }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesService.kt
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.api.PrisonerSearchApiClient
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.client.prisonersearchapi.model.Prisoner
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.between
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.ifNotEmpty
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Activity
@@ -178,22 +179,26 @@ class ManageAttendancesService(
     return attendanceRepository.saveAllAndFlush(attendances)
   }
 
-  fun createAnyAttendancesForToday(scheduleInstanceId: Long?, allocation: Allocation): List<Attendance> {
-    if (scheduleInstanceId == null) {
+  fun createAnyAttendancesForToday(allocation: Allocation, scheduleInstanceId: Long? = null, firstTimeSlot: TimeSlot? = null): List<Attendance> {
+    if (scheduleInstanceId == null && firstTimeSlot == null) {
       return emptyList()
     }
 
-    val nextAvailableInstance = scheduledInstanceRepository.findOrThrowNotFound(scheduleInstanceId)
+    val scheduledInstances = if (firstTimeSlot != null) {
+      allocation.activitySchedule.instances().filter { it.sessionDate == LocalDate.now(clock) && it.timeSlot >= firstTimeSlot }
+    } else {
+      val nextAvailableInstance = scheduledInstanceRepository.findOrThrowNotFound(scheduleInstanceId!!)
 
-    require(nextAvailableInstance.activitySchedule == allocation.activitySchedule) {
-      "Allocation does not belong to same activity schedule as selected instance"
+      require(nextAvailableInstance.activitySchedule == allocation.activitySchedule) {
+        "Allocation does not belong to same activity schedule as selected instance"
+      }
+
+      scheduledInstanceRepository.findByActivityScheduleAndSessionDateEqualsAndStartTimeGreaterThanEqual(
+        activitySchedule = allocation.activitySchedule,
+        sessionDate = LocalDate.now(clock),
+        startTime = nextAvailableInstance.startTime,
+      )
     }
-
-    val scheduledInstances = scheduledInstanceRepository.findByActivityScheduleAndSessionDateEqualsAndStartTimeGreaterThanEqual(
-      activitySchedule = allocation.activitySchedule,
-      sessionDate = LocalDate.now(clock),
-      startTime = nextAvailableInstance.startTime,
-    )
 
     // Create any attendances for today
     return scheduledInstances.filter {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/AllocationTest.kt
@@ -1170,5 +1170,41 @@ class AllocationTest {
       assertThat(instance1.advanceAttendances).hasSize(1)
       assertThat(instance2.advanceAttendances).hasSize(1)
     }
+
+    @Test
+    fun `endExclusionsYesterday should fail if any exclusions do not belong to the allocation`() {
+      val allocation1 = allocation(startDate = LocalDate.now(), withExclusions = true)
+      val allocation2 = allocation(startDate = LocalDate.now(), withExclusions = true)
+
+      assertThatThrownBy { allocation1.endExclusionsYesterday(allocation2.exclusions(ExclusionsFilter.PRESENT)) }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessage("Cannot end the given exclusions because some of them do not belong to the allocation with id 0")
+    }
+
+    @Test
+    fun `endExclusionsYesterday - should fail if any exclusion starts today`() {
+      val allocation = allocation(startDate = LocalDate.now(), withExclusions = true)
+
+      assertThatThrownBy { allocation.endExclusionsYesterday(allocation.exclusions(ExclusionsFilter.PRESENT)) }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessage("Can only end exclusions for yesterday if exclusions started in the past")
+    }
+
+    @Test
+    fun `endExclusionsYesterday - should fail if any exclusion starts in the future`() {
+      val allocation = allocation(startDate = LocalDate.now().plusDays(1), withExclusions = true)
+
+      assertThatThrownBy { allocation.endExclusionsYesterday(allocation.exclusions(ExclusionsFilter.FUTURE)) }
+        .isInstanceOf(IllegalArgumentException::class.java)
+        .hasMessage("Can only end exclusions for yesterday if exclusions started in the past")
+    }
+
+    @Test
+    fun `endExclusionsYesterday - will set exclusion end dates to yesterday if starts date are in the past`() {
+      val allocation = allocation(startDate = LocalDate.now().minusDays(1), withExclusions = true)
+      assertThat(allocation.exclusions(ExclusionsFilter.PRESENT)).hasSize(1)
+      allocation.endExclusionsYesterday(allocation.exclusions(ExclusionsFilter.PRESENT))
+      assertThat(allocation.exclusions(ExclusionsFilter.PRESENT)).isEmpty()
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ExclusionTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ExclusionTest.kt
@@ -1,9 +1,11 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity
 
+import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isEqualTo
 import java.time.DayOfWeek
+import java.time.LocalDate
 
 class ExclusionTest {
 
@@ -15,6 +17,36 @@ class ExclusionTest {
 
     with(exclusion) {
       getDaysOfWeek() isEqualTo setOf(DayOfWeek.TUESDAY, DayOfWeek.WEDNESDAY)
+    }
+  }
+
+  @Test
+  fun `endYesterday - will fail if start date is today`() {
+    val exclusion = allocation(startDate = LocalDate.now(), withExclusions = true).exclusions(ExclusionsFilter.ACTIVE).first()
+
+    assertThatThrownBy { exclusion.endYesterday() }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Can only end an exclusion for yesterday if exclusion started in the past")
+  }
+
+  @Test
+  fun `endYesterday - will fail if start date is in future`() {
+    val exclusion = allocation(startDate = LocalDate.now().plusDays(1), withExclusions = true).exclusions(ExclusionsFilter.ACTIVE).first()
+
+    assertThatThrownBy { exclusion.endYesterday() }
+      .isInstanceOf(IllegalArgumentException::class.java)
+      .hasMessage("Can only end an exclusion for yesterday if exclusion started in the past")
+  }
+
+  @Test
+  fun `endYesterday - will set end date to yesterday if start date is in the past`() {
+    val yesterday = LocalDate.now().minusDays(1)
+    val exclusion = allocation(startDate = yesterday, withExclusions = true).exclusions(ExclusionsFilter.ACTIVE).first()
+
+    exclusion.endYesterday()
+
+    with(exclusion) {
+      endDate isEqualTo yesterday
     }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -281,6 +281,96 @@ class AllocationIntegrationTest : LocalStackTestBase() {
     )
   }
 
+  @Sql("classpath:test_data/seed-allocation-with-exclusions-1.sql")
+  @Test
+  fun `update allocation exclusions for today session with new attendances created`() {
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumber("A1234BC")
+
+    with(webTestClient.getAllocationBy(1)!!) {
+      exclusions hasSize 3
+    }
+
+    val today = LocalDate.now()
+    val dayOfWeek = today.dayOfWeek
+
+    webTestClient.updateAllocation(
+      PENTONVILLE_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        firstTimeSlotForToday = TimeSlot.PM,
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.PM,
+            monday = dayOfWeek == DayOfWeek.MONDAY,
+            tuesday = dayOfWeek == DayOfWeek.TUESDAY,
+            wednesday = dayOfWeek == DayOfWeek.WEDNESDAY,
+            thursday = dayOfWeek == DayOfWeek.THURSDAY,
+            friday = dayOfWeek == DayOfWeek.FRIDAY,
+            saturday = dayOfWeek == DayOfWeek.SATURDAY,
+            sunday = dayOfWeek == DayOfWeek.SUNDAY,
+          ),
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            tuesday = true,
+            wednesday = true,
+            thursday = true,
+            friday = true,
+            saturday = true,
+            sunday = true,
+          ),
+        ),
+      ),
+    )
+
+    with(webTestClient.getAllocationBy(1)!!) {
+      exclusions hasSize 2
+      with(exclusions.first { it.timeSlot == TimeSlot.AM }) {
+        timeSlot isEqualTo TimeSlot.AM
+        daysOfWeek isEqualTo setOf(
+          DayOfWeek.MONDAY,
+          DayOfWeek.TUESDAY,
+          DayOfWeek.WEDNESDAY,
+          DayOfWeek.THURSDAY,
+          DayOfWeek.FRIDAY,
+          DayOfWeek.SATURDAY,
+          DayOfWeek.SUNDAY,
+        )
+      }
+      with(exclusions.first { it.timeSlot == TimeSlot.PM }) {
+        timeSlot isEqualTo TimeSlot.PM
+        daysOfWeek isEqualTo setOf(dayOfWeek)
+      }
+    }
+
+    with(webTestClient.getScheduledInstancesByIds(1, 2, 3)!!) {
+      this hasSize 3
+      // No attendances for existing and retained AM exclusion
+      with(first { it.timeSlot == TimeSlot.AM }) {
+        attendances hasSize 0
+      }
+      // No attendances for existing and retained PM exclusion
+      with(first { it.timeSlot == TimeSlot.PM }) {
+        attendances hasSize 0
+      }
+      // New attendance for existing but removed ED exclusion
+      with(first { it.timeSlot == TimeSlot.ED }) {
+        attendances hasSize 1
+        with(attendances.first()) {
+          prisonerNumber isEqualTo "A1234BC"
+        }
+      }
+    }
+
+    validateOutboundEvents(
+      ExpectedOutboundEvent(PRISONER_ALLOCATION_AMENDED, 1),
+      // AM and PM exclusions are kept so ED attendances is created
+      ExpectedOutboundEvent(PRISONER_ATTENDANCE_CREATED, 1),
+    )
+  }
+
   @Sql("classpath:test_data/seed-activity-id-1.sql")
   @Test
   fun `suspend allocations - add planned suspension for the future`() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -281,9 +281,9 @@ class AllocationIntegrationTest : LocalStackTestBase() {
     )
   }
 
-  @Sql("classpath:test_data/seed-allocation-with-exclusions-1.sql")
+  @Sql("classpath:test_data/allocation-with-exclusions-one-week.sql")
   @Test
-  fun `update allocation exclusions for today session with new attendances created`() {
+  fun `update allocation exclusions for today session with new attendances created for one week schedule`() {
     prisonerSearchApiMockServer.stubSearchByPrisonerNumber("A1234BC")
 
     with(webTestClient.getAllocationBy(1)!!) {
@@ -361,6 +361,78 @@ class AllocationIntegrationTest : LocalStackTestBase() {
         with(attendances.first()) {
           prisonerNumber isEqualTo "A1234BC"
         }
+      }
+    }
+
+    validateOutboundEvents(
+      ExpectedOutboundEvent(PRISONER_ALLOCATION_AMENDED, 1),
+      // AM and PM exclusions are kept so ED attendances is created
+      ExpectedOutboundEvent(PRISONER_ATTENDANCE_CREATED, 1),
+    )
+  }
+
+  @Sql("classpath:test_data/allocation-with-exclusions-two-week.sql")
+  @Test
+  fun `update allocation exclusions for today session with new attendances created for two week schedule`() {
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumber("A1234BC")
+
+    with(webTestClient.getAllocationBy(1)!!) {
+      exclusions hasSize 4
+    }
+
+    val today = LocalDate.now()
+    val dayOfWeek = today.dayOfWeek
+
+    webTestClient.updateAllocation(
+      PENTONVILLE_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        firstTimeSlotForToday = TimeSlot.PM,
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.PM,
+            monday = dayOfWeek == DayOfWeek.MONDAY,
+            tuesday = dayOfWeek == DayOfWeek.TUESDAY,
+            wednesday = dayOfWeek == DayOfWeek.WEDNESDAY,
+            thursday = dayOfWeek == DayOfWeek.THURSDAY,
+            friday = dayOfWeek == DayOfWeek.FRIDAY,
+            saturday = dayOfWeek == DayOfWeek.SATURDAY,
+            sunday = dayOfWeek == DayOfWeek.SUNDAY,
+          ),
+        ),
+      ),
+    )
+
+    with(webTestClient.getAllocationBy(1)!!.exclusions) {
+      this hasSize 1
+      with(this.first()) {
+        weekNumber isEqualTo 1
+        timeSlot isEqualTo TimeSlot.PM
+        daysOfWeek isEqualTo setOf(dayOfWeek)
+      }
+    }
+
+    with(webTestClient.getScheduledInstancesByIds(1, 2, 3, 4)!!) {
+      this hasSize 4
+      // No attendances for existing but removed week 1 AM exclusion
+      with(first { it.timeSlot == TimeSlot.AM }) {
+        attendances hasSize 0
+      }
+      // No attendances for existing and retained week 1 PM exclusion
+      with(first { it.timeSlot == TimeSlot.PM }) {
+        attendances hasSize 0
+      }
+      // New attendance for existing but removed week 1 ED exclusion
+      with(first { it.date == today && it.timeSlot == TimeSlot.ED }) {
+        attendances hasSize 1
+        with(attendances.first()) {
+          prisonerNumber isEqualTo "A1234BC"
+        }
+      }
+      // No attendances for existing but removed week 2 ED exclusion
+      with(first { it.date == today.plusDays(7) && it.timeSlot == TimeSlot.ED }) {
+        attendances hasSize 0
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ActivityScheduleServiceTest.kt
@@ -76,6 +76,7 @@ import java.time.LocalDate
 import java.time.LocalDateTime
 import java.time.temporal.ChronoUnit
 import java.util.*
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation as AllocationEntity
 
 @ExtendWith(FakeSecurityContext::class, FakeCaseLoad::class)
 class ActivityScheduleServiceTest {
@@ -819,7 +820,7 @@ class ActivityScheduleServiceTest {
     val attendance1: Attendance = mock()
     val attendance2: Attendance = mock()
     val newAttendances: List<Attendance> = listOf(attendance1, attendance2)
-    whenever(manageAttendancesService.createAnyAttendancesForToday(eq(123L), any())) doReturn newAttendances
+    whenever(manageAttendancesService.createAnyAttendancesForToday(any(), eq(123L), eq(null))) doReturn newAttendances
     whenever(manageAttendancesService.saveAttendances(newAttendances, schedule.description)) doReturn newAttendances
 
     service.allocatePrisoner(
@@ -838,7 +839,7 @@ class ActivityScheduleServiceTest {
     verify(auditService).logEvent(any())
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATED, 0)
     inOrder(manageAttendancesService) {
-      verify(manageAttendancesService).createAnyAttendancesForToday(eq(123L), any())
+      verify(manageAttendancesService).createAnyAttendancesForToday(any(), eq(123L), eq(null))
       verify(manageAttendancesService).saveAttendances(newAttendances, schedule.description)
       verify(manageAttendancesService).sendCreatedEvent(attendance1)
       verify(manageAttendancesService).sendCreatedEvent(attendance2)
@@ -1111,7 +1112,7 @@ class ActivityScheduleServiceTest {
     whenever(prisonPayBandRepository.findByPrisonCode(PENTONVILLE_PRISON_CODE)).thenReturn(prisonPayBandsLowMediumHigh(PENTONVILLE_PRISON_CODE))
     whenever(waitingListRepository.findByPrisonCodeAndPrisonerNumberAndActivitySchedule(any(), any(), any())) doReturn emptyList()
     manageAttendancesService.stub {
-      on { createAnyAttendancesForToday(any(), any()) }.doReturn(emptyList())
+      on { createAnyAttendancesForToday(any<AllocationEntity>(), any<Long>(), eq(null)) }.doReturn(emptyList())
     }
 
     service.allocatePrisonersToSchedule(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsServiceTest.kt
@@ -21,6 +21,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.toPrison
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Attendance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Exclusion
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ExclusionsFilter
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
@@ -45,7 +46,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPri
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalTime
-import java.util.Optional
+import java.util.*
 
 class AllocationsServiceTest {
   private val allocationRepository: AllocationRepository = mock()
@@ -135,7 +136,7 @@ class AllocationsServiceTest {
     assertThat(savedAllocation.prisonerStatus).isEqualTo(PrisonerStatus.PENDING)
 
     inOrder(manageAttendancesService) {
-      verify(manageAttendancesService).createAnyAttendancesForToday(eq(null), any())
+      verify(manageAttendancesService).createAnyAttendancesForToday(any(), eq(null), eq(null))
       verify(manageAttendancesService).saveAttendances(eq(emptyList()), any())
       verifyNoMoreInteractions()
     }
@@ -157,7 +158,13 @@ class AllocationsServiceTest {
     val attendance1: Attendance = mock()
     val attendance2: Attendance = mock()
     val newAttendances: List<Attendance> = listOf(attendance1, attendance2)
-    whenever(manageAttendancesService.createAnyAttendancesForToday(ArgumentMatchers.eq(123L), any())) doReturn newAttendances
+    whenever(
+      manageAttendancesService.createAnyAttendancesForToday(
+        any(),
+        ArgumentMatchers.eq(123L),
+        eq(null),
+      ),
+    ) doReturn newAttendances
     whenever(manageAttendancesService.saveAttendances(eq(newAttendances), any())) doReturn newAttendances
 
     allocation.startDate = LocalDate.now().plusDays(1)
@@ -176,7 +183,11 @@ class AllocationsServiceTest {
     assertThat(allocation.exclusions(ExclusionsFilter.ACTIVE).first().startDate).isEqualTo(TimeSource.today())
 
     inOrder(manageAttendancesService) {
-      verify(manageAttendancesService).createAnyAttendancesForToday(eq(123L), allocationCaptor.capture())
+      verify(manageAttendancesService).createAnyAttendancesForToday(
+        allocationCaptor.capture(),
+        eq(123L),
+        eq(null),
+      )
       assertThat(allocationCaptor.firstValue.startDate).isEqualTo(TimeSource.today())
       verify(manageAttendancesService).saveAttendances(eq(newAttendances), eq("schedule description"))
       verify(manageAttendancesService).sendCreatedEvent(eq(attendance1))
@@ -646,5 +657,103 @@ class AllocationsServiceTest {
       .hasMessage("Updating allocation with id 0: No AM slots in week number 3")
 
     verifyNoInteractions(outboundEventsService)
+  }
+
+  @Test
+  fun `updateAllocation - remove exclusions starting today where old exclusion starts today`() {
+    val today = LocalDate.now()
+    val yesterday = today.minusDays(1)
+    val todayDaysOfWeek = setOf(today.dayOfWeek)
+
+    val allocation = activitySchedule(activityEntity(startDate = today), daysOfWeek = todayDaysOfWeek)
+      // Activity runs today for AM, PM and ED
+      .also {
+        it.addSlot(1, LocalTime.of(12, 0) to LocalTime.of(13, 0), setOf(today.dayOfWeek), TimeSlot.PM).also { slot -> it.addInstance(today, slot) }
+        it.addSlot(1, LocalTime.of(19, 0) to LocalTime.of(20, 0), setOf(today.dayOfWeek), TimeSlot.ED).also { slot -> it.addInstance(today, slot) }
+        it.addSlot(1, LocalTime.of(12, 0) to LocalTime.of(13, 0), setOf(yesterday.dayOfWeek), TimeSlot.PM).also { slot -> it.addInstance(yesterday, slot) }
+      }
+      .let {
+        val allocation = it.allocations().first()
+        // Prisoner is excluded from today's AM and PM
+        allocation.apply {
+          addExclusion(
+            Exclusion.valueOf(
+              allocation = this,
+              weekNumber = 1,
+              daysOfWeek = setOf(today.dayOfWeek),
+              startDate = today,
+              timeSlot = TimeSlot.AM,
+            ),
+          )
+          addExclusion(
+            Exclusion.valueOf(
+              allocation = this,
+              weekNumber = 1,
+              daysOfWeek = setOf(today.dayOfWeek),
+              startDate = today,
+              timeSlot = TimeSlot.PM,
+            ),
+          )
+        }
+        allocation
+      }
+
+    val allocationId = allocation.allocationId
+    val prisonCode = allocation.activitySchedule.activity.prisonCode
+
+    val updateAllocationRequest = AllocationUpdateRequest(
+      firstTimeSlotForToday = TimeSlot.PM,
+      exclusions = listOf(
+        // Prisoner is now excluded from today AM and ED
+        Slot(
+          weekNumber = 1,
+          timeSlot = TimeSlot.AM,
+          monday = today.dayOfWeek == DayOfWeek.MONDAY,
+          tuesday = today.dayOfWeek == DayOfWeek.TUESDAY,
+          wednesday = today.dayOfWeek == DayOfWeek.WEDNESDAY,
+          thursday = today.dayOfWeek == DayOfWeek.THURSDAY,
+          friday = today.dayOfWeek == DayOfWeek.FRIDAY,
+          saturday = today.dayOfWeek == DayOfWeek.SATURDAY,
+          sunday = today.dayOfWeek == DayOfWeek.SUNDAY,
+        ),
+        Slot(
+          weekNumber = 1,
+          timeSlot = TimeSlot.ED,
+          monday = today.dayOfWeek == DayOfWeek.MONDAY,
+          tuesday = today.dayOfWeek == DayOfWeek.TUESDAY,
+          wednesday = today.dayOfWeek == DayOfWeek.WEDNESDAY,
+          thursday = today.dayOfWeek == DayOfWeek.THURSDAY,
+          friday = today.dayOfWeek == DayOfWeek.FRIDAY,
+          saturday = today.dayOfWeek == DayOfWeek.SATURDAY,
+          sunday = today.dayOfWeek == DayOfWeek.SUNDAY,
+        ),
+      ),
+    )
+
+    whenever(allocationRepository.findByAllocationIdAndPrisonCode(allocationId, prisonCode)).thenReturn(allocation)
+    whenever(allocationRepository.saveAndFlush(any<Allocation>())).thenReturn(allocation)
+
+    val newAttendances: List<Attendance> = emptyList()
+    whenever(
+      manageAttendancesService.createAnyAttendancesForToday(
+        any(),
+        eq(null),
+        eq(TimeSlot.AM),
+      ),
+    ) doReturn newAttendances
+
+    service.updateAllocation(allocationId, updateAllocationRequest, prisonCode, "user")
+
+    verify(allocationRepository).saveAndFlush(allocationCaptor.capture())
+
+    val exclusions = allocationCaptor.firstValue.exclusions(ExclusionsFilter.ACTIVE)
+
+    exclusions hasSize 2
+    exclusions.first().getDaysOfWeek() isEqualTo setOf(today.dayOfWeek)
+    exclusions.all { it.startDate == LocalDate.now() }
+    assertThat(exclusions).extracting("timeSlot").containsExactlyInAnyOrder(TimeSlot.AM, TimeSlot.ED)
+
+    verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
+    verify(manageAttendancesService).saveAttendances(newAttendances, allocation.activitySchedule.description)
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ManageAttendancesServiceTest.kt
@@ -1118,8 +1118,8 @@ class ManageAttendancesServiceTest {
     }
 
     @Test
-    fun `should do nothing if no schedule instance id was provided`() {
-      assertThat(service.createAnyAttendancesForToday(null, allocation)).isEmpty()
+    fun `should do nothing if scheduleInstanceId and firstTimeSlot are null`() {
+      assertThat(service.createAnyAttendancesForToday(allocation, null, null)).isEmpty()
     }
 
     @Test
@@ -1127,13 +1127,23 @@ class ManageAttendancesServiceTest {
       whenever(scheduledInstanceRepository.findById(123)).thenReturn(Optional.of(instance.copy(123)))
 
       assertThatThrownBy {
-        service.createAnyAttendancesForToday(123, allocation)
+        service.createAnyAttendancesForToday(allocation, 123)
       }.isInstanceOf(IllegalArgumentException::class.java)
         .hasMessage("Allocation does not belong to same activity schedule as selected instance")
     }
 
     @Test
-    fun `should create an attendance record`() {
+    fun `should create an attendance record when firstTimeSlot is provided and exists today`() {
+      allocation(startDate = LocalDate.now())
+
+      val attendances = service.createAnyAttendancesForToday(allocation, null, TimeSlot.AM)
+
+      assertThat(attendances).hasSize(1)
+      assertThat(attendances.first().scheduledInstance).isEqualTo(allocation.activitySchedule.instances().first())
+    }
+
+    @Test
+    fun `should create an attendance record when scheduleInstanceId is provided and is today`() {
       whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[0]))
       whenever(
         scheduledInstanceRepository.findByActivityScheduleAndSessionDateEqualsAndStartTimeGreaterThanEqual(
@@ -1143,7 +1153,7 @@ class ManageAttendancesServiceTest {
         ),
       ).thenReturn(listOf(allocation.activitySchedule.instances()[0]))
 
-      val attendances = service.createAnyAttendancesForToday(1, allocation)
+      val attendances = service.createAnyAttendancesForToday(allocation, 1)
 
       assertThat(attendances).hasSize(1)
       assertThat(attendances.first().scheduledInstance).isEqualTo(allocation.activitySchedule.instances().first())
@@ -1156,7 +1166,7 @@ class ManageAttendancesServiceTest {
 
       whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[0]))
 
-      val attendances = service.createAnyAttendancesForToday(1, allocation)
+      val attendances = service.createAnyAttendancesForToday(allocation, 1)
 
       assertThat(attendances).isEmpty()
     }
@@ -1181,7 +1191,7 @@ class ManageAttendancesServiceTest {
         ),
       ).thenReturn(listOf(allocation.activitySchedule.instances()[1], allocation.activitySchedule.instances()[2]))
 
-      val attendances = service.createAnyAttendancesForToday(1, allocation)
+      val attendances = service.createAnyAttendancesForToday(allocation, 1)
 
       // Should not contain first instance as it is before the second instance that is selected
       assertThat(attendances).hasSize(2)
@@ -1195,7 +1205,7 @@ class ManageAttendancesServiceTest {
 
       whenever(scheduledInstanceRepository.findById(1)).thenReturn(Optional.of(allocation.activitySchedule.instances()[0]))
 
-      val attendances = service.createAnyAttendancesForToday(1, allocation)
+      val attendances = service.createAnyAttendancesForToday(allocation, 1)
 
       assertThat(attendances).isEmpty()
     }

--- a/src/test/resources/test_data/allocation-with-exclusions-one-week.sql
+++ b/src/test/resources/test_data/allocation-with-exclusions-one-week.sql
@@ -1,0 +1,71 @@
+INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
+VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', '2022-9-21 00:00:00', 'SEED USER', false);
+
+insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
+values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot)
+values (1, 1, '10:00:00', '11:00:00', true, true, true, true, true, true, true, 'AM');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot)
+values (2, 1, '12:00:00', '13:00:00', true, true, true, true, true, true, true, 'PM');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot)
+values (3, 1, '18:00:00', '19:00:00', true, true, true, true, true, true, true, 'ED');
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (1, 1, 'A1234BC', 10001, null, '2022-10-10', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+insert into exclusion(allocation_id, time_slot, week_number, start_date, end_date)
+values (1, 'AM', 1, current_date, null);
+
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'MONDAY' where extract(isodow from current_date) = 1;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'TUESDAY' where extract(isodow from current_date) = 2;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'WEDNESDAY' where extract(isodow from current_date) = 3;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'THURSDAY' where extract(isodow from current_date) = 4;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'FRIDAY' where extract(isodow from current_date) = 5;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'SATURDAY' where extract(isodow from current_date) = 6;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'SUNDAY' where extract(isodow from current_date) = 7;
+
+insert into exclusion(allocation_id, time_slot, week_number, start_date, end_date)
+values (1, 'PM', 1, current_date, null);
+
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'MONDAY' where extract(isodow from current_date) = 1;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'TUESDAY' where extract(isodow from current_date) = 2;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'WEDNESDAY' where extract(isodow from current_date) = 3;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'THURSDAY' where extract(isodow from current_date) = 4;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'FRIDAY' where extract(isodow from current_date) = 5;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'SATURDAY' where extract(isodow from current_date) = 6;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'SUNDAY' where extract(isodow from current_date) = 7;
+
+
+insert into exclusion(allocation_id, time_slot, week_number, start_date, end_date)
+values (1, 'ED', 1, current_date - interval '7 day' , null);
+
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'MONDAY' where extract(isodow from current_date) = 1;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'TUESDAY' where extract(isodow from current_date) = 2;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'WEDNESDAY' where extract(isodow from current_date) = 3;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'THURSDAY' where extract(isodow from current_date) = 4;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'FRIDAY' where extract(isodow from current_date) = 5;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'SATURDAY' where extract(isodow from current_date) = 6;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'SUNDAY' where extract(isodow from current_date) = 7;
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_date, '10:00:00', '10:00:00', false, null, null, null, null, 'AM');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_date, '12:00:00', '13:00:00', false, null, null, null, null, 'PM');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_date, '18:00:00', '19:00:00', false, null, null, null, null, 'ED');
+
+
+
+
+

--- a/src/test/resources/test_data/allocation-with-exclusions-two-week.sql
+++ b/src/test/resources/test_data/allocation-with-exclusions-two-week.sql
@@ -2,22 +2,21 @@ INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, p
 VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
 
 insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
-values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', '2022-9-21 00:00:00', 'SEED USER', false);
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', current_date, null, 'high', '2022-9-21 00:00:00', 'SEED USER', false);
 
 insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
 values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
 
-insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
-values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date, schedule_weeks)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, current_date, 2);
 
-insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot)
-values (1, 1, '10:00:00', '11:00:00', true, true, true, true, true, true, true, 'AM');
-
-insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot)
-values (2, 1, '12:00:00', '13:00:00', true, true, true, true, true, true, true, 'PM');
-
-insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot)
-values (3, 1, '18:00:00', '19:00:00', true, true, true, true, true, true, true, 'ED');
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot, week_number) values
+     (1, 1, '10:00:00', '11:00:00', true, true, true, true, true, true, true, 'AM', 1),
+     (2, 1, '12:00:00', '13:00:00', true, true, true, true, true, true, true, 'PM', 1),
+     (3, 1, '18:00:00', '19:00:00', true, true, true, true, true, true, true, 'ED', 1),
+     (4, 1, '10:00:00', '11:00:00', true, true, true, true, true, true, true, 'AM', 2),
+     (5, 1, '12:00:00', '13:00:00', true, true, true, true, true, true, true, 'PM', 2),
+     (6, 1, '18:00:00', '19:00:00', true, true, true, true, true, true, true, 'ED', 2);
 
 insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
 values (1, 1, 'A1234BC', 10001, null, '2022-10-10', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
@@ -44,7 +43,6 @@ insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'FRIDAY'
 insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'SATURDAY' where extract(isodow from current_date) = 6;
 insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'SUNDAY' where extract(isodow from current_date) = 7;
 
-
 insert into exclusion(allocation_id, time_slot, week_number, start_date, end_date)
 values (1, 'ED', 1, current_date - interval '7 day' , null);
 
@@ -56,14 +54,29 @@ insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'FRIDAY'
 insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'SATURDAY' where extract(isodow from current_date) = 6;
 insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'SUNDAY' where extract(isodow from current_date) = 7;
 
-insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
-values (1, current_timestamp, '10:00:00', '10:00:00', false, null, null, null, null, 'AM');
+insert into exclusion(allocation_id, time_slot, week_number, start_date, end_date)
+values (1, 'ED', 2, current_date, null);
+
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'MONDAY' where extract(isodow from current_date) = 1;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'TUESDAY' where extract(isodow from current_date) = 2;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'WEDNESDAY' where extract(isodow from current_date) = 3;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'THURSDAY' where extract(isodow from current_date) = 4;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'FRIDAY' where extract(isodow from current_date) = 5;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'SATURDAY' where extract(isodow from current_date) = 6;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'SUNDAY' where extract(isodow from current_date) = 7;
 
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
-values (1, current_timestamp, '12:00:00', '13:00:00', false, null, null, null, null, 'PM');
+values (1, current_date, '10:00:00', '10:00:00', false, null, null, null, null, 'AM');
 
 insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
-values (1, current_timestamp, '18:00:00', '19:00:00', false, null, null, null, null, 'ED');
+values (1, current_date, '12:00:00', '13:00:00', false, null, null, null, null, 'PM');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_date, '18:00:00', '19:00:00', false, null, null, null, null, 'ED');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_date + interval '7 days', '18:00:00', '19:00:00', false, null, null, null, null, 'ED');
+
 
 
 

--- a/src/test/resources/test_data/seed-allocation-with-exclusions-1.sql
+++ b/src/test/resources/test_data/seed-allocation-with-exclusions-1.sql
@@ -1,0 +1,71 @@
+INSERT INTO prison_regime (prison_regime_id, prison_code, am_start, am_finish, pm_start, pm_finish, ed_start, ed_finish)
+VALUES(3, 'PVI', '10:00:00', '11:00:00', '13:00:00', '16:30:00', '18:00:00', '20:00:00');
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, attendance_required, in_cell, piece_work, outside_work, pay_per_session, summary, description, start_date, end_date, risk_level, created_time, created_by, paid)
+values (1, 'PVI', 1, 1, true, false, false, false, 'H', 'Maths', 'Maths Level 1', '2022-10-10', null, 'high', '2022-9-21 00:00:00', 'SEED USER', false);
+
+insert into activity_minimum_education_level(activity_minimum_education_level_id, activity_id, education_level_code, education_level_description, study_area_code, study_area_description)
+values (1, 1, '1', 'Reading Measure 1.0', 'ENGLA', 'English Language');
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, internal_location_id, internal_location_code, internal_location_description, capacity, start_date)
+values (1, 1, 'Maths AM', 1, 'L1', 'Location 1', 10, '2022-10-10');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot)
+values (1, 1, '10:00:00', '11:00:00', true, true, true, true, true, true, true, 'AM');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot)
+values (2, 1, '12:00:00', '13:00:00', true, true, true, true, true, true, true, 'PM');
+
+insert into activity_schedule_slot(activity_schedule_slot_id, activity_schedule_id, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag, saturday_flag, sunday_flag, time_slot)
+values (3, 1, '18:00:00', '19:00:00', true, true, true, true, true, true, true, 'ED');
+
+insert into allocation(allocation_id, activity_schedule_id, prisoner_number, booking_id, prison_pay_band_id, start_date, end_date, allocated_time, allocated_by, deallocated_time, deallocated_by, deallocated_reason, suspended_time, suspended_by, suspended_reason, prisoner_status)
+values (1, 1, 'A1234BC', 10001, null, '2022-10-10', null, '2022-10-10 09:00:00', 'MR BLOGS', null, null, null, null, null, null, 'ACTIVE');
+
+insert into exclusion(allocation_id, time_slot, week_number, start_date, end_date)
+values (1, 'AM', 1, current_date, null);
+
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'MONDAY' where extract(isodow from current_date) = 1;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'TUESDAY' where extract(isodow from current_date) = 2;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'WEDNESDAY' where extract(isodow from current_date) = 3;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'THURSDAY' where extract(isodow from current_date) = 4;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'FRIDAY' where extract(isodow from current_date) = 5;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'SATURDAY' where extract(isodow from current_date) = 6;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 1, 'SUNDAY' where extract(isodow from current_date) = 7;
+
+insert into exclusion(allocation_id, time_slot, week_number, start_date, end_date)
+values (1, 'PM', 1, current_date, null);
+
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'MONDAY' where extract(isodow from current_date) = 1;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'TUESDAY' where extract(isodow from current_date) = 2;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'WEDNESDAY' where extract(isodow from current_date) = 3;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'THURSDAY' where extract(isodow from current_date) = 4;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'FRIDAY' where extract(isodow from current_date) = 5;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'SATURDAY' where extract(isodow from current_date) = 6;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 2, 'SUNDAY' where extract(isodow from current_date) = 7;
+
+
+insert into exclusion(allocation_id, time_slot, week_number, start_date, end_date)
+values (1, 'ED', 1, current_date - interval '7 day' , null);
+
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'MONDAY' where extract(isodow from current_date) = 1;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'TUESDAY' where extract(isodow from current_date) = 2;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'WEDNESDAY' where extract(isodow from current_date) = 3;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'THURSDAY' where extract(isodow from current_date) = 4;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'FRIDAY' where extract(isodow from current_date) = 5;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'SATURDAY' where extract(isodow from current_date) = 6;
+insert into exclusion_days_of_week(exclusion_id, day_of_week) select 3, 'SUNDAY' where extract(isodow from current_date) = 7;
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_timestamp, '10:00:00', '10:00:00', false, null, null, null, null, 'AM');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_timestamp, '12:00:00', '13:00:00', false, null, null, null, null, 'PM');
+
+insert into scheduled_instance(activity_schedule_id, session_date, start_time, end_time, cancelled, cancelled_time, cancelled_by, cancelled_reason, comment, time_slot)
+values (1, current_timestamp, '18:00:00', '19:00:00', false, null, null, null, null, 'ED');
+
+
+
+
+


### PR DESCRIPTION
Allow a user to select a time slot for today schedule in which to start removing exclusions so allowing the attendances to also be created for those session(s).

If a user passes PM time slot and there is PM and ED session today then attendances records for that prisoner should be created for those sessions.