### PR TITLE
HIA-1269: Remove useReturnTypeSchema from schedules schemas

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ActivityController.kt
@@ -162,7 +162,6 @@ class ActivityController(
       ApiResponse(
         responseCode = "200",
         description = "Activity schedules",
-        useReturnTypeSchema = true,
         content = [
           Content(
             mediaType = "application/json",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/IntegrationApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/IntegrationApiController.kt
@@ -252,7 +252,6 @@ class IntegrationApiController(
       ApiResponse(
         responseCode = "200",
         description = "Activity schedules",
-        useReturnTypeSchema = true,
         content = [
           Content(
             mediaType = "application/json",

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/IntegrationApiController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/IntegrationApiController.kt
@@ -426,7 +426,7 @@ class IntegrationApiController(
         content = [
           Content(
             mediaType = "application/json",
-            array = ArraySchema(schema = Schema(implementation = ActivitySuitabilityCriteria::class)),
+            schema = Schema(implementation = ActivitySuitabilityCriteria::class),
           ),
         ],
       ),


### PR DESCRIPTION
Ive been updating our activities json schema with the latest and had some issues as its generating a duplicate oneOf  discriminator. This means our schema validation is failing the oneOf validation its being validated twice.

Looking at the code this is because for 200s the useReturnTypeSchema is set to true as well as having the content specified.

This is generating the following which is invalid.
```
       "responses": {
          "200": {
            "description": "Activity schedules",
            "content": {
              "application/json": {
                "schema": {
                  "oneOf": [
                    {
                      "type": "array",
                      "items": {
                        "$ref": "#/components/schemas/ActivityScheduleLite"
                      }
                    }, {
                      "type": "array",
                      "items": {
                        "$ref": "#/components/schemas/ActivityScheduleLite"
                      }
                    }
                  ]
                }
              }
            }
          },
```
