### PR TITLE
SAA-4314: Fix allocation, planned suspension and attendance payment during suspend

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSuspensionsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSuspensionsService.kt
@@ -43,11 +43,9 @@ class PrisonerSuspensionsService(
       require(it.onOrAfter(LocalDate.now())) { "Suspension start date must be on or after today's date" }
     }
 
-    require(listOf(PrisonerStatus.SUSPENDED, PrisonerStatus.SUSPENDED_WITH_PAY).contains(request.status)) {
+    require(request.status in setOf(PrisonerStatus.SUSPENDED, PrisonerStatus.SUSPENDED_WITH_PAY)) {
       "Only 'SUSPENDED' or 'SUSPENDED_WITH_PAY' are allowed for status"
     }
-
-    val issuePayment = request.status == PrisonerStatus.SUSPENDED_WITH_PAY
 
     val impactedAttendanceIds = transactionHandler.newSpringTransaction {
       val allocations = allocationRepository.findAllById(allocationIds)
@@ -62,28 +60,7 @@ class PrisonerSuspensionsService(
         request.suspensionCaseNote?.let { createCaseNote(prisonCode, prisonerNumber, suspendFrom, it, allocations) }
       val now = LocalDateTime.now()
       val attendanceIds = allocations.flatMap { allocation ->
-        allocation.plannedSuspension().let { plannedSuspension ->
-          plannedSuspension?.plan(suspendFrom, now, byWhom, mayBeCaseNoteId)
-            ?: allocation.addPlannedSuspension(
-              PlannedSuspension(
-                allocation = allocation,
-                plannedStartDate = maxOf(suspendFrom, allocation.startDate),
-                plannedBy = byWhom,
-                plannedAt = now,
-                dpsCaseNoteId = mayBeCaseNoteId,
-                paid = issuePayment,
-              ),
-            )
-        }
-
-        allocation.takeIf { it.status(PrisonerStatus.ACTIVE) && it.isCurrentlySuspended() }?.let { alloc ->
-          alloc.activatePlannedSuspension(request.status)
-          attendanceSuspensionDomainService.suspendFutureAttendancesForAllocation(
-            dateTime = LocalDateTime.now(),
-            allocation = alloc,
-            issuePayment = issuePayment,
-          ).map(Attendance::attendanceId)
-        } ?: emptyList()
+        planSuspension(allocation, suspendFrom, now, byWhom, mayBeCaseNoteId, request.status)
       }
 
       allocationRepository.saveAllAndFlush(allocations)
@@ -91,6 +68,39 @@ class PrisonerSuspensionsService(
     }
 
     publishChangesFor(allocationIds, impactedAttendanceIds)
+  }
+
+  private fun planSuspension(
+    allocation: Allocation,
+    suspendFrom: LocalDate,
+    now: LocalDateTime,
+    byWhom: String,
+    caseNoteId: UUID?,
+    requestedStatus: PrisonerStatus,
+  ): List<Long> {
+    val status = if (allocation.activitySchedule.isPaid()) requestedStatus else PrisonerStatus.SUSPENDED
+    val issuePayment = status == PrisonerStatus.SUSPENDED_WITH_PAY && allocation.activitySchedule.isPaid()
+
+    allocation.plannedSuspension()?.plan(suspendFrom, now, byWhom, caseNoteId)
+      ?: allocation.addPlannedSuspension(
+        PlannedSuspension(
+          allocation = allocation,
+          plannedStartDate = maxOf(suspendFrom, allocation.startDate),
+          plannedBy = byWhom,
+          plannedAt = now,
+          dpsCaseNoteId = caseNoteId,
+          paid = issuePayment,
+        ),
+      )
+
+    return allocation.takeIf { it.status(PrisonerStatus.ACTIVE) && it.isCurrentlySuspended() }?.let { alloc ->
+      alloc.activatePlannedSuspension(status)
+      attendanceSuspensionDomainService.suspendFutureAttendancesForAllocation(
+        dateTime = now,
+        allocation = alloc,
+        issuePayment = issuePayment,
+      ).map(Attendance::attendanceId)
+    } ?: emptyList()
   }
 
   private fun Collection<Allocation>.checkAllSuspensionStartDates(suspendStartDate: LocalDate) {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationApiIntegrationTest.kt
@@ -79,11 +79,13 @@ class IntegrationApiIntegrationTest : ActivitiesIntegrationTestBase() {
       )
 
       with(attendanceList!!) {
-        assertThat(size).isEqualTo(5)
-        assertThat(first().prisonerNumber).isEqualTo(prisonerNumber)
-        assertThat(first().scheduleInstanceId).isEqualTo(1)
-        assertThat(first().attendanceReason).isNull()
-        assertThat(first().comment).isNull()
+        assertThat(this.map { it.scheduleInstanceId }.toSet()).isEqualTo(setOf(1L, 2L, 3L, 4L , 5L))
+
+        this.forEach {
+          assertThat(it.prisonerNumber).isEqualTo(prisonerNumber)
+          assertThat(it.attendanceReason).isNull()
+          assertThat(it.comment).isNull()
+        }
       }
     }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationApiIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationApiIntegrationTest.kt
@@ -79,7 +79,7 @@ class IntegrationApiIntegrationTest : ActivitiesIntegrationTestBase() {
       )
 
       with(attendanceList!!) {
-        assertThat(this.map { it.scheduleInstanceId }.toSet()).isEqualTo(setOf(1L, 2L, 3L, 4L , 5L))
+        assertThat(this.map { it.scheduleInstanceId }.toSet()).isEqualTo(setOf(1L, 2L, 3L, 4L, 5L))
 
         this.forEach {
           assertThat(it.prisonerNumber).isEqualTo(prisonerNumber)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSuspensionsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/PrisonerSuspensionsServiceTest.kt
@@ -26,6 +26,8 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PlannedS
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.PrisonerStatus
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activityEntity
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.activitySchedule
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.attendance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
@@ -40,7 +42,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.addCaseloa
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.clearCaseloadIdFromRequestHeader
 import java.time.LocalDate
 import java.time.LocalDateTime
-import java.util.UUID
+import java.util.*
 
 class PrisonerSuspensionsServiceTest {
   private val caseLoad = MOORLAND_PRISON_CODE
@@ -83,7 +85,7 @@ class PrisonerSuspensionsServiceTest {
   }
 
   @Test
-  fun `suspension start date must be on or after todays date`() {
+  fun `suspension start date must be on or after today's date`() {
     val allocation = allocation()
     val prisonCode = allocation.activitySchedule.activity.prisonCode
 
@@ -152,6 +154,7 @@ class PrisonerSuspensionsServiceTest {
       startDate() isEqualTo allocation.startDate.plusWeeks(1)
       caseNoteId() isEqualTo null
       dpsCaseNoteId() isEqualTo UUID.fromString("c94f5885-9036-409e-9743-10ce07088748")
+      paid() isEqualTo false
     }
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
     verifyNoMoreInteractions(outboundEventsService)
@@ -192,6 +195,7 @@ class PrisonerSuspensionsServiceTest {
       startDate() isEqualTo allocation.startDate.plusWeeks(1)
       caseNoteId() isEqualTo null
       dpsCaseNoteId() isEqualTo UUID.fromString("c94f5885-9036-409e-9743-10ce07088748")
+      paid() isEqualTo false
     }
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
     verifyNoMoreInteractions(outboundEventsService)
@@ -232,6 +236,7 @@ class PrisonerSuspensionsServiceTest {
       startDate() isEqualTo allocation.startDate.plusWeeks(1)
       caseNoteId() isEqualTo null
       dpsCaseNoteId() isEqualTo UUID.fromString("c94f5885-9036-409e-9743-10ce07088748")
+      paid() isEqualTo false
     }
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
     verifyNoMoreInteractions(outboundEventsService)
@@ -269,6 +274,7 @@ class PrisonerSuspensionsServiceTest {
     assertThat(allocationCaptor.firstValue.first().plannedSuspension()).isNotNull
     with(allocationCaptor.firstValue.first().plannedSuspension()!!) {
       startDate() isEqualTo allocation.startDate.plusWeeks(1)
+      paid() isEqualTo false
     }
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
     verifyNoMoreInteractions(outboundEventsService)
@@ -276,7 +282,7 @@ class PrisonerSuspensionsServiceTest {
   }
 
   @Test
-  fun `an existing planned suspension is updated if it hasnt started yet`() {
+  fun `an existing planned suspension is updated if it hasn't started yet`() {
     val allocation = allocation().apply {
       addPlannedSuspension(
         PlannedSuspension(
@@ -311,6 +317,7 @@ class PrisonerSuspensionsServiceTest {
       newSuspension isEqualTo originalSuspension
       startDate() isEqualTo allocation.startDate
       endDate() isEqualTo null
+      paid() isEqualTo false
     }
 
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
@@ -369,7 +376,10 @@ class PrisonerSuspensionsServiceTest {
 
     with(allocationCaptor.firstValue.first()) {
       status(PrisonerStatus.PENDING) isBool true
-      plannedSuspension()!!.startDate() isEqualTo LocalDate.now().plusDays(1)
+      with(plannedSuspension()!!) {
+        startDate() isEqualTo LocalDate.now().plusDays(1)
+        paid() isEqualTo false
+      }
     }
 
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
@@ -574,8 +584,11 @@ class PrisonerSuspensionsServiceTest {
 
     assertThat(allocationCaptor.firstValue.first().plannedSuspension()).isNotNull
     with(allocationCaptor.firstValue.first()) {
-      prisonerStatus == PrisonerStatus.SUSPENDED
-      plannedSuspension()!!.paid() isEqualTo false
+      prisonerStatus isEqualTo PrisonerStatus.ACTIVE
+      with(plannedSuspension()!!) {
+        startDate() isEqualTo suspendPrisonerRequest.suspendFrom
+        paid() isEqualTo false
+      }
     }
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
     verifyNoMoreInteractions(outboundEventsService)
@@ -583,7 +596,7 @@ class PrisonerSuspensionsServiceTest {
   }
 
   @Test
-  fun `suspension with prisoner status SUSPENDED_WITH_PAY gets set`() {
+  fun `suspension with prisoner status SUSPENDED_WITH_PAY gets set when activity is paid`() {
     val allocation = allocation()
     val allocationId = allocation.allocationId
     val prisonCode = allocation.activitySchedule.activity.prisonCode
@@ -603,8 +616,11 @@ class PrisonerSuspensionsServiceTest {
 
     assertThat(allocationCaptor.firstValue.first().plannedSuspension()).isNotNull
     with(allocationCaptor.firstValue.first()) {
-      prisonerStatus == PrisonerStatus.SUSPENDED_WITH_PAY
-      plannedSuspension()!!.paid() isEqualTo true
+      prisonerStatus isEqualTo PrisonerStatus.ACTIVE
+      with(plannedSuspension()!!) {
+        startDate() isEqualTo suspendPrisonerRequest.suspendFrom
+        paid() isEqualTo true
+      }
     }
 
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
@@ -613,7 +629,41 @@ class PrisonerSuspensionsServiceTest {
   }
 
   @Test
-  fun `unsuspension of a paid suspenson is successful`() {
+  fun `suspension with prisoner status SUSPENDED_WITH_PAY gets set when activity is unpaid and suspension starts today`() {
+    val allocation = activitySchedule(activityEntity(paid = false, noPayBands = true), paid = false, noExclusions = true).allocations().first()
+    val allocationId = allocation.allocationId
+    val prisonCode = allocation.activitySchedule.activity.prisonCode
+
+    val suspendPrisonerRequest = SuspendPrisonerRequest(
+      prisonerNumber = "A1234AA",
+      allocationIds = listOf(allocation.allocationId),
+      suspendFrom = allocation.startDate,
+      status = PrisonerStatus.SUSPENDED_WITH_PAY,
+    )
+
+    whenever(allocationRepository.findAllById(setOf(allocationId))).thenReturn(listOf(allocation))
+
+    service.suspend(prisonCode, suspendPrisonerRequest, "user")
+
+    verify(allocationRepository).saveAllAndFlush(allocationCaptor.capture())
+
+    assertThat(allocationCaptor.firstValue.first().plannedSuspension()).isNotNull
+    with(allocationCaptor.firstValue.first()) {
+      prisonerStatus isEqualTo PrisonerStatus.SUSPENDED
+      with(plannedSuspension()!!) {
+        startDate() isEqualTo suspendPrisonerRequest.suspendFrom
+        paid() isEqualTo false
+      }
+    }
+
+    verify(attendanceSuspensionDomainService).suspendFutureAttendancesForAllocation(any(), eq(allocation), eq(false))
+    verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
+    verifyNoMoreInteractions(outboundEventsService)
+    verifyNoInteractions(caseNotesApiClient)
+  }
+
+  @Test
+  fun `unsuspension of a paid suspension is successful`() {
     val allocation = allocation(withPlannedSuspensions = true, withPaidSuspension = true)
     val allocationId = allocation.allocationId
     val prisonCode = allocation.activitySchedule.activity.prisonCode


### PR DESCRIPTION
When suspending multiple allocations for a prisoner with suspend with pay set to true for unpaid activities:
- Allocation statuses cannot be SUSPEND_WITH_PAY
- Completed attendances are unpaid
- Planned suspension should be unpaid
