### PR TITLE
BAVL-1341 make extra information/staff notes visible on the appointment search result for use in BVLS.

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/appointment/AppointmentSearch.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/appointment/AppointmentSearch.kt
@@ -121,6 +121,7 @@ data class AppointmentSearch(
     updatedTime = updatedTime,
     cancelledTime = cancelledTime,
     cancelledBy = cancelledBy,
+    extraInformation = extraInformation,
     prisonerExtraInformation = prisonerExtraInformation,
   )
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSeriesCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSeriesCreateRequest.kt
@@ -140,11 +140,10 @@ data class AppointmentSeriesCreateRequest(
   @Schema(
     description =
     """
-    Extra information for the prisoner or prisoners attending the appointment or appointments in the series.
-    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is
-    extra information via the unlock list.
+    This could include details about who will be attending, or other relevant appointment information. This won't 
+    appear on movement slips or the printed unlock list. Unlock lists will just show 'Extra information'.
     """,
-    example = "This appointment will help adjusting to life outside of prison",
+    example = "An interpreter will be attending this appointment",
   )
   val extraInformation: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSetCreateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentSetCreateRequest.kt
@@ -137,10 +137,10 @@ data class AppointmentSetAppointment(
   @Schema(
     description =
     """
-    Extra information for the prisoner or prisoners attending the appointment. Shown only on the appointments details
-    page and on printed movement slips. Wing staff will be notified there is extra information via the unlock list.
+    This could include details about who will be attending, or other relevant appointment information. This won't 
+    appear on movement slips or the printed unlock list. Unlock lists will just show 'Extra information'.
     """,
-    example = "This appointment will help adjusting to life outside of prison",
+    example = "An interpreter will be attending this appointment",
   )
   val extraInformation: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentUpdateRequest.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/request/AppointmentUpdateRequest.kt
@@ -102,11 +102,10 @@ data class AppointmentUpdateRequest(
   @Schema(
     description =
     """
-    Updated extra information for the prisoner or prisoners attending the appointment or appointments.
-    Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is
-    extra information via the unlock list.
+    This could include details about who will be attending, or other relevant appointment information. This won't 
+    appear on movement slips or the printed unlock list. Unlock lists will just show 'Extra information'.
     """,
-    example = "This appointment will help adjusting to life outside of prison",
+    example = "An interpreter will be attending this appointment",
   )
   val extraInformation: String? = null,
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/AppointmentSearchResult.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/response/AppointmentSearchResult.kt
@@ -206,6 +206,16 @@ data class AppointmentSearchResult(
   @Schema(
     description =
     """
+    This could include details about who will be attending, or other relevant appointment information. This won't 
+    appear on movement slips or the printed unlock list. Unlock lists will just show 'Extra information'.
+    """,
+    example = "An interpreter will be attending this appointment",
+  )
+  val extraInformation: String? = null,
+
+  @Schema(
+    description =
+    """
     Prisoner extra information for the prisoner or prisoners attending the appointment or appointments.
     Shown only on the appointments details page and on printed movement slips. Wing staff will be notified there is
     prisoner extra information via the unlock list.

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentEntityFactory.kt
@@ -230,7 +230,7 @@ internal fun appointmentSearchEntity(
   sequenceNumber = 1,
   maxSequenceNumber = 1,
   unlockNotes = null,
-  extraInformation = "Appointment level comment",
+  extraInformation = "Staff level comment",
   createdBy = createdBy,
   isEdited = false,
   isCancelled = false,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/helpers/AppointmentModelFactory.kt
@@ -344,6 +344,7 @@ fun appointmentSearchResultModel(timeSlot: TimeSlot = TimeSlot.AM) = Appointment
   updatedTime = null,
   cancelledTime = null,
   cancelledBy = null,
+  extraInformation = "Staff level comment",
   prisonerExtraInformation = "Prisoner level comment",
 )
 


### PR DESCRIPTION
**What does this PR do?**

This change makes the prisoner staff notes (AKA extra information) readable in the appointment search result model on the back of an appointment search.

This is a non-breaking API change.

**Why is this change being made?**

When an external party requests a video link, perhaps a solicitor, the guidance from OPVCT is to save the name of the external visitor in the custom name of the video link appointment. This means that when a prison user views the daily schedule they can see the details of the external party. The details of the external visitors are also saved in the `staff notes/extra information` field in the appointment for further visibility which includes contact information such as the email address.

The staff notes are to be included in the BVLS Daily Schedule service CSV video link appointments download for the prison users so they have this information to hand.

The associated Jira ticket can be found [here](https://dsdmoj.atlassian.net/browse/BAVL-1341).

**What has changed?**

- AppointmentSearchResult (now includes the staff notes).
- The description for extra information on all other appointment model objects have been updated, the description was not incline with its actual intended use now.
- Unit tests have been updated.

