### PR TITLE
SAA-4401: New endpoint for movements for a single location

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventController.kt
@@ -88,8 +88,7 @@ class ScheduledEventController(
   )
   @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN')")
   fun getScheduledEventsForMultiplePrisoners(
-    @PathVariable("prisonCode")
-    @Parameter(description = "The 3-character prison code.")
+    @PathVariable @Parameter(description = "The 3-character prison code.")
     prisonCode: String,
     @RequestParam(value = "date", required = true)
     @Parameter(description = "The exact date to return events for (required) in format YYYY-MM-DD")
@@ -165,8 +164,7 @@ class ScheduledEventController(
   @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN')")
   @Deprecated(message = "Will be replaced by getScheduledEventsForMultipleLocationsByDPSLocationsIds")
   fun getScheduledEventsForMultipleLocations(
-    @PathVariable("prisonCode")
-    @Parameter(description = "The 3-character prison code.")
+    @PathVariable @Parameter(description = "The 3-character prison code.")
     prisonCode: String,
     @RequestParam(value = "date", required = true)
     @Parameter(description = "The exact date to return events for (required) in format YYYY-MM-DD")
@@ -185,6 +183,7 @@ class ScheduledEventController(
     timeSlot,
   )
 
+  @Deprecated("Use the GET /prison/{prisonCode}/location-events endpoint")
   @PostMapping(
     value = ["/prison/{prisonCode}/location-events"],
     consumes = [MediaType.APPLICATION_JSON_VALUE],
@@ -236,8 +235,7 @@ class ScheduledEventController(
   )
   @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN')")
   fun getScheduledEventsForMultipleLocationsByDPSLocationsIds(
-    @PathVariable("prisonCode")
-    @Parameter(description = "The 3-character prison code.")
+    @PathVariable @Parameter(description = "The 3-character prison code.")
     prisonCode: String,
     @RequestParam(value = "date", required = true)
     @Parameter(description = "The exact date to return events for (required) in format YYYY-MM-DD")
@@ -255,6 +253,70 @@ class ScheduledEventController(
     date,
     timeSlot,
   )
+
+  @GetMapping(
+    value = ["/prison/{prisonCode}/location-events"],
+    produces = [MediaType.APPLICATION_JSON_VALUE],
+  )
+  @ResponseBody
+  @Operation(
+    summary = "Get a list of scheduled events for a DPS location, a date and optional time slot",
+    description = """
+      Returns scheduled events for the DPS location, date and optional time slot.
+      This endpoint only returns activities and appointments from the local database.
+      This endpoint supports the creation of movement lists.
+      Activities are only scheduled 60 days in advance. Appointments may be scheduled for any date in the future.
+    """,
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Successful call - zero or more scheduled events found",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = InternalLocationEvents::class)),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "400",
+        description = "Invalid request",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "Requested resource not found",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN')")
+  fun getScheduledEventsByDPSLocationsId(
+    @PathVariable @Parameter(description = "The 3-character prison code.")
+    prisonCode: String,
+    @RequestParam(value = "date", required = true)
+    @Parameter(description = "The exact date to return events for (required) in format YYYY-MM-DD")
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    date: LocalDate,
+    @RequestParam(value = "dpsLocationId", required = true)
+    @Parameter(description = "The internal DPS Location UUID. Example b7602cc8-e769-4cbb-8194-62d8e655992a")
+    dpsLocationId: UUID,
+    @RequestParam(value = "timeSlot", required = false)
+    @Parameter(description = "Time slot of the events (optional). If supplied, one of AM, PM or ED.")
+    timeSlot: TimeSlot?,
+  ): InternalLocationEvents = internalLocationService.getLocationEvents(prisonCode, dpsLocationId, date, timeSlot)
 
   @GetMapping(
     value = ["/prison/{prisonCode}/external-movements"],
@@ -299,8 +361,7 @@ class ScheduledEventController(
   )
   @PreAuthorize("hasAnyRole('PRISON', 'ACTIVITY_ADMIN')")
   fun getExternalMovements(
-    @PathVariable("prisonCode")
-    @Parameter(description = "The 3-character prison code.")
+    @PathVariable @Parameter(description = "The 3-character prison code.")
     prisonCode: String,
     @RequestParam(value = "date", required = true)
     @Parameter(description = "The exact date to return movements for (required) in format YYYY-MM-DD")

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/InternalLocationService.kt
@@ -194,6 +194,12 @@ class InternalLocationService(
     getLocationEvents(prisonCode, dpsLocationIds, date, timeSlot)
   }
 
+  fun getLocationEvents(prisonCode: String, dpsLocationId: UUID, date: LocalDate, timeSlot: TimeSlot?) = runBlocking {
+    locationsInsidePrisonAPIClient.getLocationById(dpsLocationId)
+    getLocationEvents(prisonCode, setOf(dpsLocationId), date, timeSlot).first()
+  }
+
+  @Deprecated("Will be removed in favour of getLocationEvents for one location")
   fun getLocationEvents(prisonCode: String, dpsLocationIds: Set<UUID>, date: LocalDate, timeSlot: TimeSlot?) = runBlocking {
     checkCaseloadAccess(prisonCode)
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -2187,6 +2187,8 @@ class ActivityIntegrationTest : LocalStackTestBase() {
       ),
     )
 
+    locationsInsidePrisonApiMockServer.stubLocationFromDpsUuid()
+
     val createdActivity = webTestClient.createActivity(newActivityRequest)!!
 
     val updatedActivity = webTestClient.updateActivity(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityScheduleIntegrationTest.kt
@@ -686,6 +686,8 @@ class ActivityScheduleIntegrationTest : LocalStackTestBase() {
   )
   @Test
   fun `attempting to fetch candidates without specifying a caseload succeeds if admin role present`() {
+    prisonerSearchApiMockServer.stubGetAllPrisonersInPrison("PVI")
+
     webTestClient.get()
       .uri("/schedules/1/candidates")
       .accept(MediaType.APPLICATION_JSON)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentAttendanceIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AppointmentAttendanceIntegrationTest.kt
@@ -3,6 +3,7 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.within
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -439,6 +440,11 @@ class AppointmentAttendanceIntegrationTest : AppointmentsIntegrationTestBase() {
     val prisonerC3456DE = prisonerA1234BC.copy(prisonerNumber = "C3456DE")
     val prisonerXX1111X = prisonerA1234BC.copy(prisonerNumber = "XX1111X")
     val prisonerYY1111Y = prisonerA1234BC.copy(prisonerNumber = "YY1111Y")
+
+    @BeforeEach
+    fun beforeEach() {
+      stubForAttendanceSummaries(RISLEY_PRISON_CODE)
+    }
 
     @AfterEach
     fun afterEach() {

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/IntegrationTestBase.kt
@@ -125,29 +125,29 @@ abstract class IntegrationTestBase {
       locationsInsidePrisonApiMockServer.stop()
       externalMovementsApiMockServer.stop()
     }
+  }
 
-    @BeforeEach
-    fun initMocks() {
-      prisonApiMockServer.resetAll()
-      prisonerSearchApiMockServer.resetAll()
-      incentivesApiMockServer.resetAll()
-      nomisMappingApiMockServer.resetAll()
-      locationsInsidePrisonApiMockServer.resetAll()
-      externalMovementsApiMockServer.resetAll()
-    }
+  @BeforeEach
+  fun initAllMockServices() {
+    prisonApiMockServer.resetAll()
+    prisonerSearchApiMockServer.resetAll()
+    incentivesApiMockServer.resetAll()
+    nomisMappingApiMockServer.resetAll()
+    locationsInsidePrisonApiMockServer.resetAll()
+    externalMovementsApiMockServer.resetAll()
+  }
 
-    @AfterEach
-    fun afterEach() {
-      prisonApiMockServer.resetAll()
-      prisonerSearchApiMockServer.resetAll()
-      nonAssociationsApiMockServer.resetAll()
-      caseNotesApiMockServer.resetAll()
-      incentivesApiMockServer.resetAll()
-      manageAdjudicationsApiMockServer.resetAll()
-      nomisMappingApiMockServer.resetAll()
-      locationsInsidePrisonApiMockServer.resetAll()
-      externalMovementsApiMockServer.resetAll()
-    }
+  @AfterEach
+  fun resetAllMockServices() {
+    prisonApiMockServer.resetAll()
+    prisonerSearchApiMockServer.resetAll()
+    nonAssociationsApiMockServer.resetAll()
+    caseNotesApiMockServer.resetAll()
+    incentivesApiMockServer.resetAll()
+    manageAdjudicationsApiMockServer.resetAll()
+    nomisMappingApiMockServer.resetAll()
+    locationsInsidePrisonApiMockServer.resetAll()
+    externalMovementsApiMockServer.resetAll()
   }
 
   internal fun setAuthorisationAsClient(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAttendanceRecordsJobIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ManageAttendanceRecordsJobIntegrationTest.kt
@@ -213,6 +213,14 @@ class ManageAttendanceRecordsJobIntegrationTest : LocalStackTestBase() {
       assertThat(instances()).hasSize(1)
     }
 
+    val prisonerNumbers = listOf("A22222A", "A11111A")
+    prisonerSearchApiMockServer.stubSearchByPrisonerNumbers(
+      prisonerNumbers = prisonerNumbers,
+      prisoners = prisonerNumbers.map { prisonNumber ->
+        PrisonerSearchPrisonerFixture.instance(prisonerNumber = prisonNumber, prisonId = "PVI")
+      },
+    )
+
     waitForJobs({ webTestClient.manageAttendanceRecords() })
 
     val activityAfter = activityRepository.findById(5).orElseThrow()

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ScheduledEventIntegrationTest.kt
@@ -42,7 +42,7 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
   val locationUuid: UUID = UUID.fromString("88888888-8888-8888-8888-888888888888")
 
   @BeforeEach
-  fun setupAppointmentStubs() {
+  fun setUp() {
     // Stubs used to find category and location descriptions for appointments
     prisonApiMockServer.stubGetLocationsForTypeUnrestricted(
       "MDI",
@@ -685,6 +685,58 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
 
     @Test
     @Sql("classpath:test_data/seed-activity-id-3.sql")
+    @Sql("classpath:test_data/seed-appointment-single-id-3.sql")
+    fun `get location events for single location with activities, appointments and visits - 200 success`() {
+      val date = LocalDate.of(2022, 10, 1)
+
+      prisonApiMockServer.stubScheduledVisitsForLocation(
+        prisonCode,
+        activityLocation1.locationId,
+        date,
+        null,
+        emptyList(),
+      )
+      manageAdjudicationsApiMockServer.stubHearingsForDate(
+        agencyId = prisonCode,
+        date = date,
+        body = mapper.writeValueAsString(HearingSummaryResponse(hearings = emptyList())),
+      )
+      nomisMappingApiMockServer.stubMappingsFromNomisIds(
+        listOf(
+          NomisDpsLocationMapping(dpsLocationId1, activityLocation1.locationId),
+        ),
+      )
+
+      nomisMappingApiMockServer.stubMappingsFromDpsIds(
+        listOf(
+          NomisDpsLocationMapping(dpsLocationId1, activityLocation1.locationId),
+        ),
+      )
+
+      locationsInsidePrisonApiMockServer.stubLocationFromDpsUuid(dpsLocationId1)
+
+      val result = webTestClient.getLocationEvents(prisonCode, activityDpsLocation1.id, date)!!
+
+      with(result) {
+        size isEqualTo 1
+        with(this.single { it.id == activityLocation1.locationId }) {
+          prisonCode isEqualTo prisonCode
+          code isEqualTo activityDpsLocation1.code
+          description isEqualTo activityDpsLocation1.localName
+          events.filter { it.scheduledInstanceId == 1L && it.eventType == "ACTIVITY" } hasSize 2
+        }
+      }
+    }
+
+    @Test
+    fun `get location events for single invalid location - 404 not found`() {
+      val date = LocalDate.of(2022, 10, 1)
+
+      webTestClient.getLocationEventsLocationDoesNotExist(prisonCode, activityDpsLocation1.id, date)
+    }
+
+    @Test
+    @Sql("classpath:test_data/seed-activity-id-3.sql")
     @Sql("classpath:test_data/seed-activity-id-3-on-wing.sql")
     @Sql("classpath:test_data/seed-appointment-single-id-3.sql")
     fun `get locations ignores activities with location id and on-wing is true`() {
@@ -1112,7 +1164,44 @@ class ScheduledEventIntegrationTest : IntegrationTestBase() {
       .expectHeader().contentType(MediaType.APPLICATION_JSON)
       .expectBodyList<InternalLocationEvents>()
       .returnResult().responseBody
+
+    private fun WebTestClient.getLocationEvents(
+      prisonCode: String,
+      dpsLocationId: UUID,
+      date: LocalDate,
+      timeSlot: TimeSlot? = null,
+    ) = get()
+      .uri(
+        "/scheduled-events/prison/$prisonCode/location-events?dpsLocationId=$dpsLocationId&date=$date" + (
+          timeSlot?.let { "&timeSlot=$timeSlot" }
+            ?: ""
+          ),
+      )
+      .accept(MediaType.APPLICATION_JSON)
+      .headers(setAuthorisationAsClient(roles = listOf(ROLE_PRISON)))
+      .exchange()
+      .expectStatus().isOk
+      .expectHeader().contentType(MediaType.APPLICATION_JSON)
+      .expectBodyList<InternalLocationEvents>()
+      .returnResult().responseBody
   }
+
+  fun WebTestClient.getLocationEventsLocationDoesNotExist(
+    prisonCode: String,
+    dpsLocationId: UUID,
+    date: LocalDate,
+    timeSlot: TimeSlot? = null,
+  ) = get()
+    .uri(
+      "/scheduled-events/prison/$prisonCode/location-events?dpsLocationId=$dpsLocationId&date=$date" + (
+        timeSlot?.let { "&timeSlot=$timeSlot" }
+          ?: ""
+        ),
+    )
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisationAsClient(roles = listOf(ROLE_PRISON)))
+    .exchange()
+    .expectStatus().isNotFound
 
   private fun adjudicationsMock(
     agencyId: String,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/WaitingListApplicationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/WaitingListApplicationIntegrationTest.kt
@@ -92,6 +92,8 @@ class WaitingListApplicationIntegrationTest : IntegrationTestBase() {
       status isEqualTo WaitingListStatus.PENDING
     }
 
+    stubPrisoners(listOf("ABCDEF"))
+
     val response = update(
       1,
       WaitingListApplicationUpdateRequest(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/ScheduledEventControllerTest.kt
@@ -324,7 +324,7 @@ class ScheduledEventControllerTest : ControllerTestBase() {
   }
 
   @Test
-  fun `getScheduledEventsForMultipleLocationsByDPSLocationsIds - 200 response when internal locations with events found`() {
+  fun `getScheduledEventsByDPSLocationIds - 200 response when internal locations with events found`() {
     val prisonCode = "MDI"
     val date = LocalDate.now()
     val timeSlot = TimeSlot.AM
@@ -333,7 +333,7 @@ class ScheduledEventControllerTest : ControllerTestBase() {
 
     whenever(internalLocationService.getLocationEvents(prisonCode, dpsLocationsIds, date, timeSlot)).thenReturn(locations)
 
-    val response = mockMvc.getScheduledEventsForMultipleLocationsByDPSLocationsIds(prisonCode, dpsLocationsIds, date, timeSlot)
+    val response = mockMvc.getScheduledEventsByDPSLocationIds(prisonCode, dpsLocationsIds, date, timeSlot)
       .andExpect { status { isOk() } }
       .andReturn().response
 
@@ -341,7 +341,7 @@ class ScheduledEventControllerTest : ControllerTestBase() {
   }
 
   @Test
-  fun `getScheduledEventsForMultipleLocationsByDPSLocationsIds - 200 response when no time slot supplied`() {
+  fun `getScheduledEventsByDPSLocationIds - 200 response when no time slot supplied`() {
     val prisonCode = "MDI"
     val date = LocalDate.now()
     val locations = setOf(internalLocationEvents())
@@ -349,7 +349,7 @@ class ScheduledEventControllerTest : ControllerTestBase() {
 
     whenever(internalLocationService.getLocationEvents(prisonCode, dpsLocationsIds, date, null)).thenReturn(locations)
 
-    val response = mockMvc.getScheduledEventsForMultipleLocationsByDPSLocationsIds(prisonCode, dpsLocationsIds, date, null)
+    val response = mockMvc.getScheduledEventsByDPSLocationIds(prisonCode, dpsLocationsIds, date, null)
       .andExpect { status { isOk() } }
       .andReturn().response
 
@@ -357,7 +357,38 @@ class ScheduledEventControllerTest : ControllerTestBase() {
   }
 
   @Test
-  fun `getScheduledEventsForMultipleLocationsByDPSLocationsIds - 400 response when no date supplied`() {
+  fun `getScheduledEventsByDPSLocationId - 200 response when internal location with events found`() {
+    val prisonCode = "MDI"
+    val date = LocalDate.now()
+    val timeSlot = TimeSlot.AM
+    val location = internalLocationEvents()
+
+    whenever(internalLocationService.getLocationEvents(prisonCode, location.dpsLocationId, date, timeSlot)).thenReturn(location)
+
+    val response = mockMvc.getScheduledEventsByDPSLocationId(prisonCode, location.dpsLocationId, date, timeSlot)
+      .andExpect { status { isOk() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).isEqualTo(mapper.writeValueAsString(location))
+  }
+
+  @Test
+  fun `getScheduledEventsByDPSLocationId - 200 response when no time slot supplied`() {
+    val prisonCode = "MDI"
+    val date = LocalDate.now()
+    val location = internalLocationEvents()
+
+    whenever(internalLocationService.getLocationEvents(prisonCode, location.dpsLocationId, date, null)).thenReturn(location)
+
+    val response = mockMvc.getScheduledEventsByDPSLocationId(prisonCode, location.dpsLocationId, date, null)
+      .andExpect { status { isOk() } }
+      .andReturn().response
+
+    assertThat(response.contentAsString).isEqualTo(mapper.writeValueAsString(location))
+  }
+
+  @Test
+  fun `getScheduledEventsByDPSLocationIds - 400 response when no date supplied`() {
     mockMvc.post("/scheduled-events/prison/MDI/location-events") {
       accept = MediaType.APPLICATION_JSON
       contentType = MediaType.APPLICATION_JSON
@@ -378,7 +409,7 @@ class ScheduledEventControllerTest : ControllerTestBase() {
   }
 
   @Test
-  fun `getScheduledEventsForMultipleLocationsByDPSLocationsIds - 400 response when invalid date supplied`() {
+  fun `getScheduledEventsByDPSLocationIds - 400 response when invalid date supplied`() {
     mockMvc.post("/scheduled-events/prison/MDI/location-events?date=invalid") {
       accept = MediaType.APPLICATION_JSON
       contentType = MediaType.APPLICATION_JSON
@@ -399,7 +430,7 @@ class ScheduledEventControllerTest : ControllerTestBase() {
   }
 
   @Test
-  fun `getScheduledEventsForMultipleLocationsByDPSLocationsIds - 400 response when invalid time slot supplied`() {
+  fun `getScheduledEventsByDPSLocationIds - 400 response when invalid time slot supplied`() {
     val date = LocalDate.now()
     mockMvc.post("/scheduled-events/prison/MDI/location-events?date=$date&timeSlot=no") {
       accept = MediaType.APPLICATION_JSON
@@ -421,14 +452,14 @@ class ScheduledEventControllerTest : ControllerTestBase() {
   }
 
   @Test
-  fun `getScheduledEventsForMultipleLocationsByDPSLocationsIds - 500 response when service throws exception`() {
+  fun `getScheduledEventsByDPSLocationIds - 500 response when service throws exception`() {
     val prisonCode = "MDI"
     val date = LocalDate.now()
     val dpsLocationsIds = setOf(UUID.randomUUID())
 
     whenever(internalLocationService.getLocationEvents(prisonCode, dpsLocationsIds, date, null)).thenThrow(RuntimeException("Error"))
 
-    val response = mockMvc.getScheduledEventsForMultipleLocationsByDPSLocationsIds(prisonCode, dpsLocationsIds, date, null)
+    val response = mockMvc.getScheduledEventsByDPSLocationIds(prisonCode, dpsLocationsIds, date, null)
       .andExpect { status { isInternalServerError() } }
       .andReturn().response
 
@@ -518,13 +549,6 @@ class ScheduledEventControllerTest : ControllerTestBase() {
     verifyNoInteractions(scheduledEventService)
   }
 
-  private fun MockMvc.getScheduledEventsForSinglePrisoner(
-    prisonCode: String,
-    prisonerNumber: String,
-    startDate: LocalDate,
-    endDate: LocalDate,
-  ) = get("/scheduled-events/prison/$prisonCode?prisonerNumber=$prisonerNumber&startDate=$startDate&endDate=$endDate")
-
   private fun MockMvc.getScheduledEventsForMultiplePrisoners(
     prisonCode: String,
     prisonerNumbers: Set<String>,
@@ -551,7 +575,7 @@ class ScheduledEventControllerTest : ControllerTestBase() {
     )
   }.andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
 
-  private fun MockMvc.getScheduledEventsForMultipleLocationsByDPSLocationsIds(
+  private fun MockMvc.getScheduledEventsByDPSLocationIds(
     prisonCode: String,
     dpsLocationIds: Set<UUID>,
     date: LocalDate,
@@ -562,6 +586,15 @@ class ScheduledEventControllerTest : ControllerTestBase() {
     content = mapper.writeValueAsBytes(
       dpsLocationIds,
     )
+  }.andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
+
+  private fun MockMvc.getScheduledEventsByDPSLocationId(
+    prisonCode: String,
+    dpsLocationId: UUID,
+    date: LocalDate,
+    timeSlot: TimeSlot? = null,
+  ) = get("/scheduled-events/prison/$prisonCode/location-events?dpsLocationId=$dpsLocationId&date=$date" + (timeSlot?.let { "&timeSlot=$timeSlot" } ?: "")) {
+    accept = MediaType.APPLICATION_JSON
   }.andExpect { content { contentType(MediaType.APPLICATION_JSON_VALUE) } }
 
   private fun MockMvc.getExternalMovements(


### PR DESCRIPTION
- Add an endpoint to get scheduled events for a single DPS location id
- Fixing wiremock resets in integration tests