### PR TITLE
SAA-4486: Return exclusions change history

### DIFF
--- a/HTTP/Activities API.http
+++ b/HTTP/Activities API.http
@@ -1,0 +1,22 @@
+Activities API.http:
+
+### Retrieve an activity
+
+< {%
+    request.variables.set("activityId", "1")
+%}
+
+GET {{ baseUrl }}/activities/{{activityId}}/filtered?includeScheduledInstances=false
+Authorization: Bearer {{$auth.token("auth-token")}}
+
+
+### Retrieve exclusions history for an allocation
+
+< {%
+    request.variables.set("allocationId", "20")
+%}
+
+GET {{ baseUrl }}/allocations/id/{{ allocationId }}/exclusions/history
+Authorization: Bearer {{$auth.token("auth-token")}}
+
+###

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Exclusion.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/Exclusion.kt
@@ -12,6 +12,8 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.Table
+import org.hibernate.envers.Audited
+import org.hibernate.envers.RelationTargetAuditMode
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Slot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.consolidateMatchingSlots
@@ -19,6 +21,7 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 
 @Entity
+@Audited
 @Table(name = "exclusion")
 data class Exclusion(
   @Id
@@ -27,6 +30,7 @@ data class Exclusion(
 
   @ManyToOne
   @JoinColumn(name = "allocation_id", nullable = false)
+  @Audited(targetAuditMode = RelationTargetAuditMode.NOT_AUDITED)
   val allocation: Allocation,
 
   var startDate: LocalDate,
@@ -36,8 +40,7 @@ data class Exclusion(
   @Enumerated(EnumType.STRING)
   var timeSlot: TimeSlot,
 
-  @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
-  @JoinColumn(name = "exclusion_id")
+  @OneToMany(mappedBy = "exclusion", cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
   private var exclusionDaysOfWeek: MutableList<ExclusionDaysOfWeek> = mutableListOf(),
 
 ) {
@@ -59,7 +62,7 @@ data class Exclusion(
     this.exclusionDaysOfWeek.clear()
     this.exclusionDaysOfWeek.addAll(
       daysOfWeek.map {
-        ExclusionDaysOfWeek(dayOfWeek = it)
+        ExclusionDaysOfWeek(exclusion = this, dayOfWeek = it)
       },
     )
   }
@@ -92,10 +95,11 @@ data class Exclusion(
       weekNumber = weekNumber,
       startDate = startDate,
       timeSlot = timeSlot,
-      exclusionDaysOfWeek = daysOfWeek.map {
-        ExclusionDaysOfWeek(dayOfWeek = it)
-      }.toMutableList(),
-    )
+    ).also { exclusion ->
+      exclusion.exclusionDaysOfWeek = daysOfWeek.map {
+        ExclusionDaysOfWeek(exclusion = exclusion, dayOfWeek = it)
+      }.toMutableList()
+    }
   }
 }
 

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ExclusionDaysOfWeek.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/entity/ExclusionDaysOfWeek.kt
@@ -6,15 +6,25 @@ import jakarta.persistence.Enumerated
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import org.hibernate.envers.AuditTable
+import org.hibernate.envers.Audited
 import java.time.DayOfWeek
 
 @Entity
+@Audited
+@AuditTable(value = "exclusion_days_of_week_aud")
 @Table(name = "exclusion_days_of_week")
 data class ExclusionDaysOfWeek(
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   val id: Long = 0,
+
+  @ManyToOne
+  @JoinColumn(name = "exclusion_id", nullable = false)
+  val exclusion: Exclusion,
 
   @Enumerated(EnumType.STRING)
   val dayOfWeek: DayOfWeek,

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ExclusionRevision.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ExclusionRevision.kt
@@ -1,0 +1,34 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model
+
+import com.fasterxml.jackson.annotation.JsonFormat
+import io.swagger.v3.oas.annotations.media.Schema
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+
+@Schema(description = "Represents a historical snapshot for an exclusion change.")
+data class ExclusionRevision(
+  @Schema(description = "The week number", example = "1")
+  val weekNumber: Int,
+
+  @Schema(description = "The time slots that were affected")
+  val timeSlots: List<TimeSlot>,
+
+  @Schema(description = "The day of the week", example = "MONDAY")
+  val dayOfWeek: DayOfWeek,
+
+  @Schema(description = "The type of revision", example = "ADDED")
+  val revisionType: RevisionType? = null,
+
+  @Schema(description = "The revision number", example = "12345")
+  val revision: Long? = null,
+
+  @Schema(description = "The username of the user that made the change", example = "BLOGGSJ")
+  val updatedBy: String? = null,
+
+  @Schema(description = "The local date and time", example = "2026-06-25T10:15:30")
+  @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
+  val updatedDateTime: LocalDateTime? = null,
+)
+
+enum class RevisionType { ADDED, REMOVED }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ExclusionRevision.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/model/ExclusionRevision.kt
@@ -18,17 +18,17 @@ data class ExclusionRevision(
   val dayOfWeek: DayOfWeek,
 
   @Schema(description = "The type of revision", example = "ADDED")
-  val revisionType: RevisionType? = null,
+  val revisionType: RevisionType,
 
   @Schema(description = "The revision number", example = "12345")
-  val revision: Long? = null,
+  val revision: Long,
 
   @Schema(description = "The username of the user that made the change", example = "BLOGGSJ")
-  val updatedBy: String? = null,
+  val updatedBy: String,
 
   @Schema(description = "The local date and time", example = "2026-06-25T10:15:30")
   @JsonFormat(pattern = "yyyy-MM-dd'T'HH:mm:ss")
-  val updatedDateTime: LocalDateTime? = null,
+  val updatedDateTime: LocalDateTime,
 )
 
 enum class RevisionType { ADDED, REMOVED }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ExclusionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ExclusionRepository.kt
@@ -1,0 +1,52 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository
+
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.history.RevisionRepository
+import org.springframework.data.repository.query.Param
+import org.springframework.stereotype.Repository
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Exclusion
+import java.time.DayOfWeek
+import java.time.LocalDateTime
+
+interface ExclusionHistoryAuditRow {
+  val weekNumber: Int
+  val timeSlot: TimeSlot
+  val dayOfWeek: DayOfWeek
+  val revision: Long
+  val exclusionRevisionType: Int
+  val exclusionDaysOfWeekRevisionType: Int
+  val username: String
+  val revisionDateTime: LocalDateTime?
+}
+
+@Repository
+interface ExclusionRepository :
+  ReadOnlyRepository<Exclusion, Long>,
+  RevisionRepository<Exclusion, Long, Int> {
+
+  @Query(
+    value = """
+      select
+        ea.allocation_id,
+        ea.week_number,
+        ea.time_slot,
+        eaw.day_of_week,
+        ea.rev as revision,
+        ea.revtype as exclusion_revision_type,
+        eaw.revtype as exclusion_days_of_week_revision_type,
+        eaw.id as exclusion_days_of_week_id,
+        r.username,
+        r.revision_date_time
+        
+      from exclusion_aud ea
+      join exclusion_days_of_week_aud eaw on ea.rev=eaw.rev and ea.exclusion_id=eaw.exclusion_id
+      join revision r on r.id = ea.rev
+      where ea.allocation_id = :allocationId
+    """,
+    nativeQuery = true,
+  )
+  fun findHistoryByAllocationId(
+    @Param("allocationId") allocationId: Long,
+  ): List<ExclusionHistoryAuditRow>
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ExclusionRepository.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/repository/ExclusionRepository.kt
@@ -17,7 +17,7 @@ interface ExclusionHistoryAuditRow {
   val exclusionRevisionType: Int
   val exclusionDaysOfWeekRevisionType: Int
   val username: String
-  val revisionDateTime: LocalDateTime?
+  val revisionDateTime: LocalDateTime
 }
 
 @Repository

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationController.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationController.kt
@@ -24,6 +24,7 @@ import org.springframework.web.bind.annotation.RestController
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.DeallocationReason
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ExclusionRevision
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AllocationUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.SuspendPrisonerRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.UnsuspendPrisonerRequest
@@ -175,8 +176,8 @@ class AllocationController(
   )
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_ADMIN')")
   fun update(
-    @PathVariable("allocationId") allocationId: Long,
-    @PathVariable("prisonCode") prisonCode: String,
+    @PathVariable allocationId: Long,
+    @PathVariable prisonCode: String,
     principal: Principal,
     @Valid
     @RequestBody
@@ -244,7 +245,7 @@ class AllocationController(
   @CaseloadHeader
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_ADMIN')")
   fun addToWaitingList(
-    @PathVariable("prisonCode") prisonCode: String,
+    @PathVariable prisonCode: String,
     principal: Principal,
     @Valid
     @RequestBody
@@ -293,7 +294,7 @@ class AllocationController(
   @CaseloadHeader
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_ADMIN')")
   fun suspend(
-    @PathVariable("prisonCode") prisonCode: String,
+    @PathVariable prisonCode: String,
     principal: Principal,
     @Valid
     @RequestBody
@@ -339,11 +340,52 @@ class AllocationController(
   @CaseloadHeader
   @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_ADMIN')")
   fun unsuspend(
-    @PathVariable("prisonCode") prisonCode: String,
+    @PathVariable prisonCode: String,
     principal: Principal,
     @Valid
     @RequestBody
     @Parameter(description = "The request with the suspension details", required = true)
     request: UnsuspendPrisonerRequest,
   ) = prisonerSuspensionsService.unsuspend(prisonCode, request, principal.name)
+
+  @GetMapping(value = ["/id/{allocationId}/exclusions/history"])
+  @ResponseBody
+  @Operation(
+    summary = "Get exclusions history by allocation id",
+    description = "Returns historical exclusion snapshots for the supplied allocation id.",
+  )
+  @ApiResponses(
+    value = [
+      ApiResponse(
+        responseCode = "200",
+        description = "Exclusions history returned",
+        content = [
+          Content(
+            mediaType = "application/json",
+            array = ArraySchema(schema = Schema(implementation = ExclusionRevision::class)),
+          ),
+        ],
+      ),
+      ApiResponse(
+        responseCode = "401",
+        description = "Unauthorised, requires a valid Oauth2 token",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "403",
+        description = "Forbidden, requires an appropriate role",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+      ApiResponse(
+        responseCode = "404",
+        description = "The allocation for this ID was not found.",
+        content = [Content(mediaType = "application/json", schema = Schema(implementation = ErrorResponse::class))],
+      ),
+    ],
+  )
+  @CaseloadHeader
+  @PreAuthorize("hasAnyRole('ACTIVITY_HUB', 'ACTIVITY_ADMIN')")
+  fun getExclusionsHistoryByAllocationId(
+    @PathVariable("allocationId") allocationId: Long,
+  ): List<ExclusionRevision> = allocationsService.getExclusionsHistory(allocationId)
 }

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsService.kt
@@ -33,6 +33,7 @@ class AllocationsService(
   private val transactionHandler: TransactionHandler,
   private val outboundEventsService: OutboundEventsService,
   private val manageAttendancesService: ManageAttendancesService,
+  private val exclusionHistoryService: ExclusionHistoryService,
 ) {
   companion object {
     private val log: Logger = LoggerFactory.getLogger(this::class.java)
@@ -162,6 +163,11 @@ class AllocationsService(
 
   @Transactional(propagation = Propagation.REQUIRED, noRollbackFor = [IllegalArgumentException::class])
   fun updateStartDateIgnoringValidationErrors(allocation: Allocation, startDate: LocalDate) = updateStartDate(allocation, startDate)
+
+  @Transactional(readOnly = true)
+  fun getExclusionsHistory(allocationId: Long) = allocationRepository.findOrThrowNotFound(allocationId)
+    .also { checkCaseloadAccess(it.activitySchedule.activity.prisonCode) }
+    .let { exclusionHistoryService.findHistory(it) }
 
   private fun updateStartDate(allocation: Allocation, startDate: LocalDate, scheduleInstanceId: Long? = null) {
     startDate.let { newStartDate ->

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryService.kt
@@ -1,0 +1,103 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import org.hibernate.envers.RevisionType as EnversRevisionType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ExclusionRevision
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RevisionType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ExclusionHistoryAuditRow
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ExclusionRepository
+import java.time.DayOfWeek
+
+@Service
+@Transactional(readOnly = true)
+class ExclusionHistoryService(private val exclusionRepository: ExclusionRepository) {
+    fun findHistory(allocation: Allocation): List<ExclusionRevision> =
+        exclusionRepository.findHistoryByAllocationId(allocation.allocationId)
+            .withoutUnchangedSlotRevisions()
+            .toExclusionHistories()
+            .sortedWith(EXCLUSION_HISTORY_ORDERING)
+
+    // If a slot has not changed, Envers records it as deleted and re-added in the same revision, so remove it from results.
+    private fun List<ExclusionHistoryAuditRow>.withoutUnchangedSlotRevisions(): List<ExclusionHistoryAuditRow> {
+        val unchangedSlotRevisionKeys = findUnchangedSlotRevisionKeys()
+
+        return filterNot { it.slotRevisionKey in unchangedSlotRevisionKeys }
+    }
+
+    private fun List<ExclusionHistoryAuditRow>.findUnchangedSlotRevisionKeys(): Set<ExclusionSlotRevisionKey> =
+        groupBy { it.slotRevisionKey }
+            .filterValues { rows -> rows.wasRemovedAndReAddedInSameRevision() }
+            .keys
+
+    private fun List<ExclusionHistoryAuditRow>.toExclusionHistories(): List<ExclusionRevision> =
+        groupBy { it.historyGroupKey }
+            .map { (_, historyRows) -> historyRows.toExclusionHistory() }
+
+    private fun List<ExclusionHistoryAuditRow>.toExclusionHistory(): ExclusionRevision {
+        val historyRows = this
+        val firstAuditRow = historyRows.first()
+
+        return ExclusionRevision(
+            weekNumber = firstAuditRow.weekNumber,
+            timeSlots = historyRows.toTimeSlots(),
+            dayOfWeek = firstAuditRow.dayOfWeek,
+            revisionType = firstAuditRow.toRevisionType(),
+            revision = firstAuditRow.revision,
+            updatedBy = firstAuditRow.username,
+            updatedDateTime = firstAuditRow.revisionDateTime,
+        )
+    }
+
+    private fun List<ExclusionHistoryAuditRow>.toTimeSlots(): List<TimeSlot> =
+        map { it.timeSlot }.sortedBy { it.ordinal }
+
+    private fun List<ExclusionHistoryAuditRow>.wasRemovedAndReAddedInSameRevision(): Boolean =
+        any { it.exclusionDaysOfWeekRevisionType == DELETED_REVISION_TYPE } &&
+                any { it.exclusionDaysOfWeekRevisionType == ADDED_REVISION_TYPE }
+
+    private fun ExclusionHistoryAuditRow.toRevisionType(): RevisionType =
+        if (exclusionRevisionType == ADDED_REVISION_TYPE) RevisionType.ADDED else RevisionType.REMOVED
+
+    private val ExclusionHistoryAuditRow.slotRevisionKey
+        get() = ExclusionSlotRevisionKey(
+            revision = revision,
+            weekNumber = weekNumber,
+            timeSlot = timeSlot,
+            dayOfWeek = dayOfWeek,
+        )
+
+    private val ExclusionHistoryAuditRow.historyGroupKey
+        get() = ExclusionHistoryGroupKey(
+            revision = revision,
+            weekNumber = weekNumber,
+            dayOfWeek = dayOfWeek,
+            exclusionDaysOfWeekRevisionType = exclusionDaysOfWeekRevisionType,
+        )
+
+    private data class ExclusionSlotRevisionKey(
+        val revision: Long,
+        val weekNumber: Int,
+        val timeSlot: TimeSlot,
+        val dayOfWeek: DayOfWeek,
+    )
+
+    private data class ExclusionHistoryGroupKey(
+        val revision: Long,
+        val weekNumber: Int,
+        val dayOfWeek: DayOfWeek,
+        val exclusionDaysOfWeekRevisionType: Int,
+    )
+
+    private companion object {
+        private val ADDED_REVISION_TYPE = EnversRevisionType.ADD.ordinal
+        private val DELETED_REVISION_TYPE = EnversRevisionType.DEL.ordinal
+
+        private val EXCLUSION_HISTORY_ORDERING =
+            compareByDescending<ExclusionRevision> { it.revision }
+                .thenBy { it.weekNumber }
+                .thenBy { it.dayOfWeek }
+    }
+}

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryService.kt
@@ -1,6 +1,5 @@
 package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
 
-import org.hibernate.envers.RevisionType as EnversRevisionType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
@@ -10,94 +9,89 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RevisionT
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ExclusionHistoryAuditRow
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ExclusionRepository
 import java.time.DayOfWeek
+import org.hibernate.envers.RevisionType as EnversRevisionType
 
 @Service
 @Transactional(readOnly = true)
 class ExclusionHistoryService(private val exclusionRepository: ExclusionRepository) {
-    fun findHistory(allocation: Allocation): List<ExclusionRevision> =
-        exclusionRepository.findHistoryByAllocationId(allocation.allocationId)
-            .withoutUnchangedSlotRevisions()
-            .toExclusionHistories()
-            .sortedWith(EXCLUSION_HISTORY_ORDERING)
+  fun findHistory(allocation: Allocation): List<ExclusionRevision> = exclusionRepository.findHistoryByAllocationId(allocation.allocationId)
+    .withoutUnchangedSlotRevisions()
+    .toExclusionHistories()
+    .sortedWith(EXCLUSION_HISTORY_ORDERING)
 
-    // If a slot has not changed, Envers records it as deleted and re-added in the same revision, so remove it from results.
-    private fun List<ExclusionHistoryAuditRow>.withoutUnchangedSlotRevisions(): List<ExclusionHistoryAuditRow> {
-        val unchangedSlotRevisionKeys = findUnchangedSlotRevisionKeys()
+  // If a slot has not changed, Envers records it as deleted and re-added in the same revision, so remove it from results.
+  private fun List<ExclusionHistoryAuditRow>.withoutUnchangedSlotRevisions(): List<ExclusionHistoryAuditRow> {
+    val unchangedSlotRevisionKeys = findUnchangedSlotRevisionKeys()
 
-        return filterNot { it.slotRevisionKey in unchangedSlotRevisionKeys }
-    }
+    return filterNot { it.slotRevisionKey in unchangedSlotRevisionKeys }
+  }
 
-    private fun List<ExclusionHistoryAuditRow>.findUnchangedSlotRevisionKeys(): Set<ExclusionSlotRevisionKey> =
-        groupBy { it.slotRevisionKey }
-            .filterValues { rows -> rows.wasRemovedAndReAddedInSameRevision() }
-            .keys
+  private fun List<ExclusionHistoryAuditRow>.findUnchangedSlotRevisionKeys(): Set<ExclusionSlotRevisionKey> = groupBy { it.slotRevisionKey }
+    .filterValues { rows -> rows.wasRemovedAndReAddedInSameRevision() }
+    .keys
 
-    private fun List<ExclusionHistoryAuditRow>.toExclusionHistories(): List<ExclusionRevision> =
-        groupBy { it.historyGroupKey }
-            .map { (_, historyRows) -> historyRows.toExclusionHistory() }
+  private fun List<ExclusionHistoryAuditRow>.toExclusionHistories(): List<ExclusionRevision> = groupBy { it.historyGroupKey }
+    .map { (_, historyRows) -> historyRows.toExclusionHistory() }
 
-    private fun List<ExclusionHistoryAuditRow>.toExclusionHistory(): ExclusionRevision {
-        val historyRows = this
-        val firstAuditRow = historyRows.first()
+  private fun List<ExclusionHistoryAuditRow>.toExclusionHistory(): ExclusionRevision {
+    val historyRows = this
+    val firstAuditRow = historyRows.first()
 
-        return ExclusionRevision(
-            weekNumber = firstAuditRow.weekNumber,
-            timeSlots = historyRows.toTimeSlots(),
-            dayOfWeek = firstAuditRow.dayOfWeek,
-            revisionType = firstAuditRow.toRevisionType(),
-            revision = firstAuditRow.revision,
-            updatedBy = firstAuditRow.username,
-            updatedDateTime = firstAuditRow.revisionDateTime,
-        )
-    }
+    return ExclusionRevision(
+      weekNumber = firstAuditRow.weekNumber,
+      timeSlots = historyRows.toTimeSlots(),
+      dayOfWeek = firstAuditRow.dayOfWeek,
+      revisionType = firstAuditRow.toRevisionType(),
+      revision = firstAuditRow.revision,
+      updatedBy = firstAuditRow.username,
+      updatedDateTime = firstAuditRow.revisionDateTime,
+    )
+  }
 
-    private fun List<ExclusionHistoryAuditRow>.toTimeSlots(): List<TimeSlot> =
-        map { it.timeSlot }.sortedBy { it.ordinal }
+  private fun List<ExclusionHistoryAuditRow>.toTimeSlots(): List<TimeSlot> = map { it.timeSlot }.sortedBy { it.ordinal }
 
-    private fun List<ExclusionHistoryAuditRow>.wasRemovedAndReAddedInSameRevision(): Boolean =
-        any { it.exclusionDaysOfWeekRevisionType == DELETED_REVISION_TYPE } &&
-                any { it.exclusionDaysOfWeekRevisionType == ADDED_REVISION_TYPE }
+  private fun List<ExclusionHistoryAuditRow>.wasRemovedAndReAddedInSameRevision(): Boolean = any { it.exclusionDaysOfWeekRevisionType == DELETED_REVISION_TYPE } &&
+    any { it.exclusionDaysOfWeekRevisionType == ADDED_REVISION_TYPE }
 
-    private fun ExclusionHistoryAuditRow.toRevisionType(): RevisionType =
-        if (exclusionRevisionType == ADDED_REVISION_TYPE) RevisionType.ADDED else RevisionType.REMOVED
+  private fun ExclusionHistoryAuditRow.toRevisionType(): RevisionType = if (exclusionRevisionType == ADDED_REVISION_TYPE) RevisionType.ADDED else RevisionType.REMOVED
 
-    private val ExclusionHistoryAuditRow.slotRevisionKey
-        get() = ExclusionSlotRevisionKey(
-            revision = revision,
-            weekNumber = weekNumber,
-            timeSlot = timeSlot,
-            dayOfWeek = dayOfWeek,
-        )
-
-    private val ExclusionHistoryAuditRow.historyGroupKey
-        get() = ExclusionHistoryGroupKey(
-            revision = revision,
-            weekNumber = weekNumber,
-            dayOfWeek = dayOfWeek,
-            exclusionDaysOfWeekRevisionType = exclusionDaysOfWeekRevisionType,
-        )
-
-    private data class ExclusionSlotRevisionKey(
-        val revision: Long,
-        val weekNumber: Int,
-        val timeSlot: TimeSlot,
-        val dayOfWeek: DayOfWeek,
+  private val ExclusionHistoryAuditRow.slotRevisionKey
+    get() = ExclusionSlotRevisionKey(
+      revision = revision,
+      weekNumber = weekNumber,
+      timeSlot = timeSlot,
+      dayOfWeek = dayOfWeek,
     )
 
-    private data class ExclusionHistoryGroupKey(
-        val revision: Long,
-        val weekNumber: Int,
-        val dayOfWeek: DayOfWeek,
-        val exclusionDaysOfWeekRevisionType: Int,
+  private val ExclusionHistoryAuditRow.historyGroupKey
+    get() = ExclusionHistoryGroupKey(
+      revision = revision,
+      weekNumber = weekNumber,
+      dayOfWeek = dayOfWeek,
+      exclusionDaysOfWeekRevisionType = exclusionDaysOfWeekRevisionType,
     )
 
-    private companion object {
-        private val ADDED_REVISION_TYPE = EnversRevisionType.ADD.ordinal
-        private val DELETED_REVISION_TYPE = EnversRevisionType.DEL.ordinal
+  private data class ExclusionSlotRevisionKey(
+    val revision: Long,
+    val weekNumber: Int,
+    val timeSlot: TimeSlot,
+    val dayOfWeek: DayOfWeek,
+  )
 
-        private val EXCLUSION_HISTORY_ORDERING =
-            compareByDescending<ExclusionRevision> { it.revision }
-                .thenBy { it.weekNumber }
-                .thenBy { it.dayOfWeek }
-    }
+  private data class ExclusionHistoryGroupKey(
+    val revision: Long,
+    val weekNumber: Int,
+    val dayOfWeek: DayOfWeek,
+    val exclusionDaysOfWeekRevisionType: Int,
+  )
+
+  private companion object {
+    private val ADDED_REVISION_TYPE = EnversRevisionType.ADD.ordinal
+    private val DELETED_REVISION_TYPE = EnversRevisionType.DEL.ordinal
+
+    private val EXCLUSION_HISTORY_ORDERING =
+      compareByDescending<ExclusionRevision> { it.revision }
+        .thenBy { it.weekNumber }
+        .thenBy { it.dayOfWeek }
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -90,14 +90,12 @@ spring:
     properties:
       hibernate:
         dialect: org.hibernate.dialect.PostgreSQLDialect
+      org.hibernate.envers.audit_table_suffix: _aud
+      org.hibernate.envers.store_data_at_delete: true
     show-sql: false
     generate-ddl: false
     hibernate:
       ddl-auto: none
-      envers:
-        autoRegisterListeners: true
-        audit_table_suffix: _aud
-        store_data_at_delete: true
 
   datasource:
     url: 'jdbc:postgresql://${DB_SERVER}/${DB_NAME}?sslmode=${DB_SSL_MODE}'

--- a/src/main/resources/migrations/common/V2026.06.23__create_exclusions_audit_tables.sql
+++ b/src/main/resources/migrations/common/V2026.06.23__create_exclusions_audit_tables.sql
@@ -1,0 +1,26 @@
+create table exclusion_aud
+(
+    exclusion_id  bigint    not null,
+    allocation_id bigserial not null references allocation (allocation_id),
+    week_number   integer not null,
+    start_date    date,
+    end_date      date,
+    time_slot     char(2)   not null,
+    rev           bigint    not null references revision (id),
+    revtype       smallint  not null,
+    primary key (exclusion_id, rev)
+);
+
+create index idx_exclusion_aud_allocation_id on exclusion_aud (allocation_id);
+
+create table exclusion_days_of_week_aud
+(
+    id           bigint   not null,
+    exclusion_id bigint   not null,
+    day_of_week  varchar(10),
+    rev          bigint   not null references revision (id),
+    revtype      smallint not null,
+    primary key (id, rev)
+);
+
+create index idx_exclusion_days_of_week_exclusion_id on exclusion_days_of_week_aud (exclusion_id);

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivitiesIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivitiesIntegrationTestBase.kt
@@ -124,7 +124,6 @@ abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
     .expectBody<Attendance>()
     .returnResult().responseBody
 
-
   fun WebTestClient.updateActivity(
     prisonCode: String,
     id: Long,

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivitiesIntegrationTestBase.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivitiesIntegrationTestBase.kt
@@ -2,16 +2,20 @@ package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration
 
 import org.springframework.http.MediaType
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Activity
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityPayHistory
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ActivityScheduleInstance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.AdvanceAttendance
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Attendance
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AdvanceAttendanceCreateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.response.ActivitySummary
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.CASELOAD_ID
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_ACTIVITY_ADMIN
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_ACTIVITY_HUB
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.resource.ROLE_PRISON
 
 abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
@@ -25,7 +29,7 @@ abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBodyList(ActivityScheduleInstance::class.java)
+    .expectBodyList<ActivityScheduleInstance>()
     .returnResult().responseBody
 
   fun WebTestClient.getActivities(prisonCode: String, nameSearch: String? = null, excludeArchived: Boolean = true) = get()
@@ -40,7 +44,7 @@ abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBodyList(ActivitySummary::class.java)
+    .expectBodyList<ActivitySummary>()
     .returnResult().responseBody
 
   fun WebTestClient.getActivityById(id: Long, caseLoadId: String = "PVI", includeScheduledInstances: Boolean? = true) = get()
@@ -56,7 +60,7 @@ abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(Activity::class.java)
+    .expectBody<Activity>()
     .returnResult().responseBody!!
 
   fun WebTestClient.getActivityPayHistory(id: Long) = get()
@@ -66,7 +70,7 @@ abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBodyList(ActivityPayHistory::class.java)
+    .expectBodyList<ActivityPayHistory>()
     .returnResult().responseBody!!
 
   fun WebTestClient.createAdvanceAttendance(request: AdvanceAttendanceCreateRequest, caseLoad: String? = "PVI") = post()
@@ -78,7 +82,7 @@ abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
     .exchange()
     .expectStatus().isCreated
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(AdvanceAttendance::class.java)
+    .expectBody<AdvanceAttendance>()
     .returnResult().responseBody
 
   fun WebTestClient.retrieveAdvanceAttendance(id: Long) = get()
@@ -89,7 +93,7 @@ abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(AdvanceAttendance::class.java)
+    .expectBody<AdvanceAttendance>()
     .returnResult().responseBody
 
   fun WebTestClient.checkAdvanceAttendanceDoesNotExist(id: Long) = get()
@@ -108,7 +112,7 @@ abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(Allocation::class.java)
+    .expectBody<Allocation>()
     .returnResult().responseBody
 
   fun WebTestClient.getAttendanceById(id: Long) = get()
@@ -117,6 +121,23 @@ abstract class ActivitiesIntegrationTestBase : IntegrationTestBase() {
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(Attendance::class.java)
+    .expectBody<Attendance>()
     .returnResult().responseBody
+
+
+  fun WebTestClient.updateActivity(
+    prisonCode: String,
+    id: Long,
+    activityUpdateRequest: ActivityUpdateRequest,
+  ) = patch()
+    .uri("/activities/$prisonCode/activityId/$id")
+    .bodyValue(activityUpdateRequest)
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisationAsUser(roles = listOf(ROLE_ACTIVITY_HUB)))
+    .header(CASELOAD_ID, prisonCode)
+    .exchange()
+    .expectStatus().isAccepted
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBody<Activity>()
+    .returnResult().responseBody!!
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/ActivityIntegrationTest.kt
@@ -15,6 +15,8 @@ import org.springframework.http.MediaType
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.config.ErrorResponse
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.ActivityState
@@ -1251,7 +1253,7 @@ class ActivityIntegrationTest : LocalStackTestBase() {
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBodyList(ActivityScheduleLite::class.java)
+    .expectBodyList<ActivityScheduleLite>()
     .returnResult().responseBody
 
   private fun WebTestClient.createActivity(
@@ -1265,24 +1267,8 @@ class ActivityIntegrationTest : LocalStackTestBase() {
     .exchange()
     .expectStatus().isCreated
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(Activity::class.java)
+    .expectBody<Activity>()
     .returnResult().responseBody
-
-  private fun WebTestClient.updateActivity(
-    prisonCode: String,
-    id: Long,
-    activityUpdateRequest: ActivityUpdateRequest,
-  ) = patch()
-    .uri("/activities/$prisonCode/activityId/$id")
-    .bodyValue(activityUpdateRequest)
-    .accept(MediaType.APPLICATION_JSON)
-    .headers(setAuthorisationAsUser(roles = listOf(ROLE_ACTIVITY_HUB)))
-    .header(CASELOAD_ID, prisonCode)
-    .exchange()
-    .expectStatus().isAccepted
-    .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(Activity::class.java)
-    .returnResult().responseBody!!
 
   private fun WebTestClient.updateActivityExpectingError(
     prisonCode: String,
@@ -1297,7 +1283,7 @@ class ActivityIntegrationTest : LocalStackTestBase() {
     .exchange()
     .expectStatus().is4xxClientError
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(ErrorResponse::class.java)
+    .expectBody<ErrorResponse>()
     .returnResult().responseBody!!
 
   private fun Activity.schedule(description: String) = schedules.schedule(description)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -46,7 +46,6 @@ import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-
 class AllocationIntegrationTest : LocalStackTestBase() {
 
   @Autowired
@@ -899,15 +898,15 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       prisonCode = RISLEY_PRISON_CODE,
       id = 2,
       activityUpdateRequest = ActivityUpdateRequest(
-        slots =listOf(
+        slots = listOf(
           Slot(
             weekNumber = 1,
             timeSlot = TimeSlot.AM,
             tuesday = true,
             daysOfWeek = setOf(DayOfWeek.TUESDAY),
-          )
-        )
-      )
+          ),
+        ),
+      ),
     )
 
     val exclusionsHistory2 = webTestClient.getExclusionsHistory(2)!!

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -6,6 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
 import org.springframework.test.context.jdbc.Sql
 import org.springframework.test.web.reactive.server.WebTestClient
+import org.springframework.test.web.reactive.server.expectBody
+import org.springframework.test.web.reactive.server.expectBodyList
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.daysFromNow
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.AttendanceStatus
@@ -14,6 +16,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.WaitingL
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.refdata.AttendanceReasonEnum
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.MOORLAND_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.PENTONVILLE_PRISON_CODE
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.RISLEY_PRISON_CODE
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.TimeSource
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.hasSize
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isBool
@@ -22,7 +25,10 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.helpers.isNotEq
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandOne
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.integration.testdata.testPentonvillePayBandTwo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ExclusionRevision
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RevisionType
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.Slot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.ActivityUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.AllocationUpdateRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.SuspendPrisonerRequest
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.UnsuspendPrisonerRequest
@@ -39,6 +45,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.
 import java.time.DayOfWeek
 import java.time.LocalDate
 import java.time.LocalDateTime
+
 
 class AllocationIntegrationTest : LocalStackTestBase() {
 
@@ -712,6 +719,233 @@ class AllocationIntegrationTest : LocalStackTestBase() {
     )
   }
 
+  @Sql("classpath:test_data/allocation-with-exclusions-history.sql")
+  @Test
+  fun `should return exclusions history for exclusions changed through allocation`() {
+    // Create new Week 1, Monday and Tuesday, AM exclusions
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory1 = webTestClient.getExclusionsHistory(1)!!
+
+    assertThat(exclusionsHistory1).hasSize(2)
+
+    with(exclusionsHistory1[0]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isNotNull()
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isNotNull()
+    }
+
+    with(exclusionsHistory1[1]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+
+    // Remove Week 1 Monday, AM exclusion (implicit as not present in request)
+    // Keep Week 1 Tuesday, AM exclusion
+    // Create new Week 2, Thursday and Friday, PM exclusions
+    // Create new Week 2, Thursday, ED exclusion
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 2,
+            timeSlot = TimeSlot.PM,
+            thursday = true,
+            friday = true,
+            daysOfWeek = setOf(DayOfWeek.THURSDAY, DayOfWeek.FRIDAY),
+          ),
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.TUESDAY),
+          ),
+          Slot(
+            weekNumber = 2,
+            timeSlot = TimeSlot.ED,
+            thursday = true,
+            daysOfWeek = setOf(DayOfWeek.THURSDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory2 = webTestClient.getExclusionsHistory(1)!!
+
+    assertThat(exclusionsHistory2).hasSize(5)
+
+    with(exclusionsHistory2[0]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isGreaterThan(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.REMOVED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isAfterOrEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+
+    with(exclusionsHistory2[1]) {
+      assertThat(weekNumber).isEqualTo(2)
+      assertThat(timeSlots).containsExactly(TimeSlot.PM, TimeSlot.ED)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory2[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory2[0].updatedDateTime)
+    }
+
+    with(exclusionsHistory2[2]) {
+      assertThat(weekNumber).isEqualTo(2)
+      assertThat(timeSlots).containsExactly(TimeSlot.PM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.FRIDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory2[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory2[0].updatedDateTime)
+    }
+
+    with(exclusionsHistory2[3]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+
+    with(exclusionsHistory2[4]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+  }
+
+  @Sql("classpath:test_data/allocation-with-exclusions-history.sql")
+  @Test
+  fun `should return exclusions history for exclusions changed through activity schedule change`() {
+    // Create new Monday and Tuesday, AM exclusions
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      2,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory1 = webTestClient.getExclusionsHistory(2)!!
+
+    assertThat(exclusionsHistory1).hasSize(2)
+
+    with(exclusionsHistory1[0]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isNotNull()
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isNotNull()
+    }
+
+    with(exclusionsHistory1[1]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+
+    // Update activity schedule to remove Tuesday AM but keep Monday AM
+    webTestClient.updateActivity(
+      prisonCode = RISLEY_PRISON_CODE,
+      id = 2,
+      activityUpdateRequest = ActivityUpdateRequest(
+        slots =listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.TUESDAY),
+          )
+        )
+      )
+    )
+
+    val exclusionsHistory2 = webTestClient.getExclusionsHistory(2)!!
+
+    assertThat(exclusionsHistory2).hasSize(3)
+
+    // Monday AM exclusion is removed because Monday AM is no longer in the activity schedule
+    with(exclusionsHistory2[0]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isGreaterThan(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.REMOVED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isAfterOrEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+
+    with(exclusionsHistory2[1]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+
+    with(exclusionsHistory2[2]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+  }
+
   private fun WebTestClient.updateAllocation(
     prisonCode: String,
     allocationId: Long,
@@ -725,7 +959,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
     .exchange()
     .expectStatus().isAccepted
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(Allocation::class.java)
+    .expectBody<Allocation>()
     .returnResult().responseBody!!
 
   private fun WebTestClient.suspendAllocation(
@@ -773,6 +1007,16 @@ class AllocationIntegrationTest : LocalStackTestBase() {
     .exchange()
     .expectStatus().isOk
     .expectHeader().contentType(MediaType.APPLICATION_JSON)
-    .expectBody(Allocation::class.java)
+    .expectBody<Allocation>()
+    .returnResult().responseBody
+
+  private fun WebTestClient.getExclusionsHistory(allocationId: Long) = get()
+    .uri("/allocations/id/$allocationId/exclusions/history")
+    .accept(MediaType.APPLICATION_JSON)
+    .headers(setAuthorisationAsClient(roles = listOf(ROLE_ACTIVITY_HUB)))
+    .exchange()
+    .expectStatus().isOk
+    .expectHeader().contentType(MediaType.APPLICATION_JSON)
+    .expectBodyList<ExclusionRevision>()
     .returnResult().responseBody
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationControllerTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/resource/AllocationControllerTest.kt
@@ -28,6 +28,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.request.W
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.AllocationsService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.PrisonerSuspensionsService
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.WaitingListService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.exclusionRevision
 import uk.gov.justice.hmpps.test.kotlin.auth.WithMockAuthUser
 import java.time.LocalDate
 
@@ -285,6 +286,52 @@ class AllocationControllerTest : ControllerTestBase() {
           header(CASELOAD_ID, "MDI")
         }.andExpect { status { isOk() } }
       }
+    }
+  }
+
+  @Nested
+  @DisplayName("Get exclusions history")
+  inner class ExclusionsHistoryTests {
+    @Test
+    @WithMockAuthUser(roles = ["ACTIVITY_HUB"])
+    fun `should return exclusions history (ROLE_ACTIVITY_HUB) - 200`() {
+      val exclusionHistory = listOf(exclusionRevision())
+
+      whenever(allocationsService.getExclusionsHistory(123)).thenReturn(exclusionHistory)
+
+      val response = mockMvc.get("/allocations/id/123/exclusions/history")
+        .andExpect { status { isOk() } }
+        .andReturn().response
+
+      assertThat(response.contentAsString).isEqualTo(mapper.writeValueAsString(exclusionHistory))
+    }
+
+    @Test
+    @WithMockAuthUser(roles = ["ACTIVITY_ADMIN"])
+    fun `should return exclusions history (ROLE_ACTIVITY_ADMIN) - 200`() {
+      val exclusionHistory = listOf(exclusionRevision())
+
+      whenever(allocationsService.getExclusionsHistory(123)).thenReturn(exclusionHistory)
+
+      val response = mockMvc.get("/allocations/id/123/exclusions/history")
+        .andExpect { status { isOk() } }
+        .andReturn().response
+
+      assertThat(response.contentAsString).isEqualTo(mapper.writeValueAsString(exclusionHistory))
+    }
+
+    @Test
+    @WithMockAuthUser(roles = ["PRISON"])
+    fun `should be forbidden - 403`() {
+      mockMvc.get("/allocations/id/123/exclusions/history").andExpect { status { isForbidden() } }
+    }
+
+    @Test
+    @WithMockAuthUser(roles = ["ACTIVITY_ADMIN"])
+    fun `allocation id not found`() {
+      whenever(allocationsService.getExclusionsHistory(123)).thenThrow(EntityNotFoundException("not found"))
+
+      mockMvc.get("/allocations/id/123/exclusions/history").andExpect { status { isNotFound() } }
     }
   }
 

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/AllocationsServiceTest.kt
@@ -4,6 +4,8 @@ import jakarta.persistence.EntityNotFoundException
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentMatchers
 import org.mockito.MockitoAnnotations.openMocks
@@ -41,6 +43,7 @@ import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.Allo
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.refdata.PrisonPayBandRepository
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEvent
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service.events.OutboundEventsService
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.CaseloadAccessException
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.addCaseloadIdToRequestHeader
 import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.util.toModelPrisonerAllocations
 import java.time.DayOfWeek
@@ -54,7 +57,8 @@ class AllocationsServiceTest {
   private val scheduleRepository: ActivityScheduleRepository = mock()
   private val outboundEventsService: OutboundEventsService = mock()
   private val manageAttendancesService: ManageAttendancesService = mock()
-  private val service: AllocationsService = AllocationsService(allocationRepository, prisonPayBandRepository, scheduleRepository, TransactionHandler(), outboundEventsService, manageAttendancesService)
+  private val exclusionHistoryService: ExclusionHistoryService = mock()
+  private val service: AllocationsService = AllocationsService(allocationRepository, prisonPayBandRepository, scheduleRepository, TransactionHandler(), outboundEventsService, manageAttendancesService, exclusionHistoryService)
   private val activeAllocation = activityEntity().schedules().first().allocations().first()
   private val allocationCaptor = argumentCaptor<Allocation>()
 
@@ -755,5 +759,40 @@ class AllocationsServiceTest {
 
     verify(outboundEventsService).send(OutboundEvent.PRISONER_ALLOCATION_AMENDED, allocationId)
     verify(manageAttendancesService).saveAttendances(newAttendances, allocation.activitySchedule.description)
+  }
+
+  @Nested
+  @DisplayName("Exclusions History")
+  inner class ExclusionsHistory {
+    @Test
+    fun `should throw exception if allocation id is not found`() {
+      whenever(allocationRepository.findById(any())).thenReturn(Optional.empty())
+
+      assertThatThrownBy { service.getExclusionsHistory(-99) }.isInstanceOf(EntityNotFoundException::class.java)
+        .hasMessage("Allocation -99 not found")
+    }
+
+    @Test
+    fun `should return exclusions history`() {
+      addCaseloadIdToRequestHeader("MDI")
+
+      val allocation = allocation()
+      val exclusionsHistory = listOf(exclusionRevision())
+
+      whenever(allocationRepository.findById(allocation.allocationId)).thenReturn(Optional.of(allocation))
+      whenever(exclusionHistoryService.findHistory(allocation)).thenReturn(exclusionsHistory)
+
+      assertThat(service.getExclusionsHistory(allocation.allocationId)).isEqualTo(exclusionsHistory)
+    }
+
+    @Test
+    fun `should throw caseload access exception if caseload id header does not match`() {
+      addCaseloadIdToRequestHeader("WRONG")
+      val allocation = allocation()
+
+      whenever(allocationRepository.findById(allocation.allocationId)).thenReturn(Optional.of(allocation))
+
+      assertThatThrownBy { service.getExclusionsHistory(allocation.allocationId) }.isInstanceOf(CaseloadAccessException::class.java)
+    }
   }
 }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryServiceTest.kt
@@ -1,0 +1,216 @@
+package uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.service
+
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot.AM
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot.ED
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.common.TimeSlot.PM
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.entity.Allocation
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.ExclusionRevision
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RevisionType
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.model.RevisionType.REMOVED
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ExclusionHistoryAuditRow
+import uk.gov.justice.digital.hmpps.hmppsactivitiesmanagementapi.repository.ExclusionRepository
+import java.time.DayOfWeek
+import java.time.DayOfWeek.MONDAY
+import java.time.DayOfWeek.THURSDAY
+import java.time.DayOfWeek.TUESDAY
+import java.time.DayOfWeek.WEDNESDAY
+import java.time.LocalDateTime
+
+class ExclusionHistoryServiceTest {
+
+  private companion object {
+    private const val ADDED = 0
+    private const val MODIFIED = 1
+    private const val DELETED = 2
+
+    const val ALLOCATION_ID = 1L
+  }
+
+  val exclusionRepository: ExclusionRepository = mockk()
+
+  val exclusionHistoryService = ExclusionHistoryService(exclusionRepository)
+
+  val allocation: Allocation = mockk()
+
+  @BeforeEach
+  fun setUp() {
+    every { allocation.allocationId } returns ALLOCATION_ID
+  }
+
+  @Test
+  fun `should return history`() {
+    // revision 1
+    val removedMondayAM = auditRow(exclusionRevisionType = MODIFIED, exclusionDaysOfWeekRevisionType = DELETED)
+    val addedMondayAM = auditRow()
+    val removedTuesdayAM = auditRow(dayOfWeek = TUESDAY, exclusionRevisionType = DELETED, exclusionDaysOfWeekRevisionType = DELETED)
+    val addedTuesdayPM = auditRow(dayOfWeek = TUESDAY, timeSlot = PM)
+
+    // revision 2
+    val addedWednesdayED = auditRow(revision = 2, weekNumber = 2, username = "SMITHJ", dayOfWeek = WEDNESDAY, timeSlot = ED)
+    val addedTuesdayAM = auditRow(revision = 2, weekNumber = 2, username = "SMITHJ", dayOfWeek = TUESDAY)
+
+    // revision 3
+    val revision3DateTime = LocalDateTime.parse("2026-06-30T12:00:01")
+    val addedThursdayAM = auditRow(revision = 3, revisionDateTime = revision3DateTime, dayOfWeek = THURSDAY)
+    val addedThursdayPM = auditRow(revision = 3, revisionDateTime = revision3DateTime, dayOfWeek = THURSDAY, timeSlot = PM)
+
+    every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
+      listOf(
+        removedMondayAM,
+        addedMondayAM,
+        removedTuesdayAM,
+        addedTuesdayPM,
+        addedWednesdayED,
+        addedTuesdayAM,
+        addedThursdayAM,
+        addedThursdayPM,
+      )
+
+    val history = exclusionHistoryService.findHistory(allocation)
+
+    assertThat(history).containsExactly(
+      exclusionRevision(revision = 3, dayOfWeek = THURSDAY, timeSlots = listOf(AM, PM), updatedDateTime = revision3DateTime),
+      exclusionRevision(revision = 2, weekNumber = 2, dayOfWeek = TUESDAY, updatedBy = "SMITHJ"),
+      exclusionRevision(revision = 2, weekNumber = 2, dayOfWeek = WEDNESDAY, timeSlots = listOf(ED), updatedBy = "SMITHJ"),
+      exclusionRevision(dayOfWeek = TUESDAY, revisionType = REMOVED),
+      exclusionRevision(dayOfWeek = TUESDAY, timeSlots = listOf(PM)),
+    )
+  }
+
+  /**
+   * An ignored change is only where an exclusion is removed and then added back in the same revision,
+   * in which case both revisions are ignored.
+   */
+  @Nested
+  @DisplayName("Check when remove and add changes should be ignored")
+  inner class IgnoredRevisionChanges {
+    @Test
+    fun `should exclude any changes where the exclusion was removed and added back in the same revision`() {
+      val removedMondayAM = auditRow(exclusionRevisionType = MODIFIED, exclusionDaysOfWeekRevisionType = DELETED)
+      val addedMondayAM = auditRow()
+      val addedExclusionMondayAM = auditRow(revision = 2)
+      val addedExclusionMondayPM = auditRow(revision = 2, timeSlot = PM)
+      val addedExclusionTuesdayAM = auditRow(revision = 2, dayOfWeek = TUESDAY)
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
+        listOf(removedMondayAM, addedExclusionMondayAM, addedMondayAM, addedExclusionTuesdayAM, addedExclusionMondayPM)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revision = 2, timeSlots = listOf(AM, PM)),
+        exclusionRevision(revision = 2, dayOfWeek = TUESDAY),
+      )
+    }
+
+    @Test
+    fun `should include any changes where the exclusion was removed and added in a different revision`() {
+      val removedMondayAM = auditRow(exclusionRevisionType = MODIFIED, exclusionDaysOfWeekRevisionType = DELETED)
+      val removedMondayPM = auditRow(timeSlot = PM, exclusionRevisionType = DELETED, exclusionDaysOfWeekRevisionType = DELETED)
+      val addedMondayAM = auditRow(revision = 2)
+      val addedMondayPM = auditRow(revision = 2, timeSlot = PM)
+      val addedTuesdayAM = auditRow(revision = 2, dayOfWeek = TUESDAY)
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns listOf(removedMondayAM, removedMondayPM, addedMondayAM, addedTuesdayAM, addedMondayPM)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revision = 2, timeSlots = listOf(AM, PM)),
+        exclusionRevision(revision = 2, dayOfWeek = TUESDAY),
+        exclusionRevision(revisionType = REMOVED, timeSlots = listOf(AM, PM)),
+      )
+    }
+
+    @Test
+    fun `should include any changes where the week number is different`() {
+      val removed = auditRow(exclusionRevisionType = MODIFIED, exclusionDaysOfWeekRevisionType = DELETED)
+      val added = auditRow(weekNumber = 2)
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns listOf(removed, added)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revisionType = REMOVED),
+        exclusionRevision(weekNumber = 2),
+      )
+    }
+
+    @Test
+    fun `should include any changes where day of week is different`() {
+      val removed = auditRow(exclusionRevisionType = MODIFIED, exclusionDaysOfWeekRevisionType = DELETED)
+      val added = auditRow(dayOfWeek = TUESDAY)
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns listOf(removed, added)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revisionType = REMOVED),
+        exclusionRevision(dayOfWeek = TUESDAY),
+      )
+    }
+
+    @Test
+    fun `should include any changes where time slot is different`() {
+      val removed = auditRow(exclusionRevisionType = MODIFIED, exclusionDaysOfWeekRevisionType = DELETED)
+      val added = auditRow(timeSlot = ED)
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns listOf(removed, added)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revisionType = REMOVED),
+        exclusionRevision(timeSlots = listOf(ED)),
+      )
+    }
+  }
+
+  private fun auditRow(
+    weekNumber: Int = 1,
+    timeSlot: TimeSlot = AM,
+    dayOfWeek: DayOfWeek = MONDAY,
+    revision: Long = 1,
+    exclusionRevisionType: Int = ADDED,
+    exclusionDaysOfWeekRevisionType: Int = ADDED,
+    username: String = "USER1",
+    revisionDateTime: LocalDateTime? = LocalDateTime.parse("2026-06-25T10:15:30"),
+  ): ExclusionHistoryAuditRow = object : ExclusionHistoryAuditRow {
+    override val weekNumber = weekNumber
+    override val timeSlot = timeSlot
+    override val dayOfWeek = dayOfWeek
+    override val revision = revision
+    override val exclusionRevisionType = exclusionRevisionType
+    override val exclusionDaysOfWeekRevisionType = exclusionDaysOfWeekRevisionType
+    override val username = username
+    override val revisionDateTime = revisionDateTime
+  }
+}
+
+internal fun exclusionRevision(
+  weekNumber: Int = 1,
+  timeSlots: List<TimeSlot> = listOf(AM),
+  dayOfWeek: DayOfWeek = MONDAY,
+  revisionType: RevisionType = RevisionType.ADDED,
+  revision: Long = 1,
+  updatedBy: String = "USER1",
+  updatedDateTime: LocalDateTime? = LocalDateTime.parse("2026-06-25T10:15:30"),
+) = ExclusionRevision(
+  weekNumber = weekNumber,
+  timeSlots = timeSlots,
+  dayOfWeek = dayOfWeek,
+  revisionType = revisionType,
+  revision = revision,
+  updatedBy = updatedBy,
+  updatedDateTime = updatedDateTime,
+)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryServiceTest.kt
@@ -184,7 +184,7 @@ class ExclusionHistoryServiceTest {
     exclusionRevisionType: Int = ADDED,
     exclusionDaysOfWeekRevisionType: Int = ADDED,
     username: String = "USER1",
-    revisionDateTime: LocalDateTime? = LocalDateTime.parse("2026-06-25T10:15:30"),
+    revisionDateTime: LocalDateTime = LocalDateTime.parse("2026-06-25T10:15:30"),
   ): ExclusionHistoryAuditRow = object : ExclusionHistoryAuditRow {
     override val weekNumber = weekNumber
     override val timeSlot = timeSlot
@@ -204,7 +204,7 @@ internal fun exclusionRevision(
   revisionType: RevisionType = RevisionType.ADDED,
   revision: Long = 1,
   updatedBy: String = "USER1",
-  updatedDateTime: LocalDateTime? = LocalDateTime.parse("2026-06-25T10:15:30"),
+  updatedDateTime: LocalDateTime = LocalDateTime.parse("2026-06-25T10:15:30"),
 ) = ExclusionRevision(
   weekNumber = weekNumber,
   timeSlots = timeSlots,

--- a/src/test/resources/test_data/allocation-with-exclusions-history.sql
+++ b/src/test/resources/test_data/allocation-with-exclusions-history.sql
@@ -1,0 +1,39 @@
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, summary, start_date, risk_level, created_time, created_by, paid, in_cell)
+values (1, 'RSI', 1, 1, 'Maths', '2022-10-10', 'high', '2022-9-21 00:00:00', 'BLOGGSJ', false, true);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, capacity, start_date, schedule_weeks)
+values (1, 1, 'Maths', 10, '2022-10-10', 2);
+
+insert into activity_schedule_slot(activity_schedule_id, week_number, time_slot, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag)
+values (1, 1, 'AM', '08:00:00', '09:00:00', true, true, true, false, false);
+
+insert into activity_schedule_slot(activity_schedule_id, week_number, time_slot, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag)
+values (1, 1, 'PM', '13:00:00', '14:00:00', true, true, true, false, false);
+
+insert into activity_schedule_slot(activity_schedule_id, week_number, time_slot, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag)
+values (1, 1, 'ED', '17:00:00', '18:00:00', true, true, true, false, false);
+
+insert into activity_schedule_slot(activity_schedule_id, week_number, time_slot, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag)
+values (1, 2, 'AM', '08:00:00', '09:00:00', false, false, false, true, true);
+
+insert into activity_schedule_slot(activity_schedule_id, week_number, time_slot, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag)
+values (1, 2, 'PM', '13:00:00', '14:00:00', false, false, false, true, true);
+
+insert into activity_schedule_slot(activity_schedule_id, week_number, time_slot, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag)
+values (1, 2, 'ED', '17:00:00', '18:00:00', false, false, false, true, true);
+
+insert into allocation(activity_schedule_id, prisoner_number, booking_id, start_date, allocated_time, allocated_by, prisoner_status)
+values (1, 'A11111A', 10001, '2022-10-10', '2022-10-10 09:00:00', 'MR BLOGGS', 'ACTIVE');
+
+insert into activity(activity_id, prison_code, activity_category_id, activity_tier_id, summary, start_date, risk_level, created_time, created_by, paid, in_cell)
+values (2, 'RSI', 1, 1, 'English', '2022-10-10', 'high', '2022-9-21 00:00:00', 'BLOGGSJ', false, true);
+
+insert into activity_schedule(activity_schedule_id, activity_id, description, capacity, start_date, schedule_weeks)
+values (2, 2, 'English', 10, '2022-10-10', 1);
+
+insert into activity_schedule_slot(activity_schedule_id, week_number, time_slot, start_time, end_time, monday_flag, tuesday_flag, wednesday_flag, thursday_flag, friday_flag)
+values (2, 1, 'AM', '08:00:00', '09:00:00', true, true, false, false, false);
+
+insert into allocation(activity_schedule_id, prisoner_number, booking_id, start_date, allocated_time, allocated_by, prisoner_status)
+values (2, 'A11111A', 10001, '2022-10-10', '2022-10-10 09:00:00', 'MR BLOGGS', 'ACTIVE');
+


### PR DESCRIPTION
Will return exclusions changes for an allocation for example:

```json
[
  {
    "weekNumber": 1,
    "timeSlots": [
      "ED"
    ],
    "dayOfWeek": "MONDAY",
    "revisionType": "REMOVED",
    "revision": 2403,
    "updatedBy": "BLOGGSJ",
    "updatedDateTime": "2026-07-02T11:51:50"
  },
  {
    "weekNumber": 1,
    "timeSlots": [
      "PM",
      "ED"
    ],
    "dayOfWeek": "TUESDAY",
    "revisionType": "ADDED",
    "revision": 2403,
    "updatedBy": "BLOGGSJ",
    "updatedDateTime": "2026-07-02T11:51:50"
  },
  {
    "weekNumber": 1,
    "timeSlots": [
      "ED"
    ],
    "dayOfWeek": "MONDAY",
    "revisionType": "ADDED",
    "revision": 2402,
    "updatedBy": "BLOGGSJ",
    "updatedDateTime": "2026-07-02T11:51:02"
  }
]