### PR TITLE
SAA-4566: Fix for incorrect sequence of revision history

### DIFF
--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryService.kt
@@ -53,7 +53,7 @@ class ExclusionHistoryService(private val exclusionRepository: ExclusionReposito
   private fun List<ExclusionHistoryAuditRow>.wasRemovedAndReAddedInSameRevision(): Boolean = any { it.exclusionDaysOfWeekRevisionType == DELETED_REVISION_TYPE } &&
     any { it.exclusionDaysOfWeekRevisionType == ADDED_REVISION_TYPE }
 
-  private fun ExclusionHistoryAuditRow.toRevisionType(): RevisionType = if (exclusionRevisionType == ADDED_REVISION_TYPE) RevisionType.ADDED else RevisionType.REMOVED
+  private fun ExclusionHistoryAuditRow.toRevisionType(): RevisionType = if (exclusionDaysOfWeekRevisionType == ADDED_REVISION_TYPE) RevisionType.ADDED else RevisionType.REMOVED
 
   private val ExclusionHistoryAuditRow.slotRevisionKey
     get() = ExclusionSlotRevisionKey(

--- a/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryService.kt
+++ b/src/main/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryService.kt
@@ -90,7 +90,7 @@ class ExclusionHistoryService(private val exclusionRepository: ExclusionReposito
     private val DELETED_REVISION_TYPE = EnversRevisionType.DEL.ordinal
 
     private val EXCLUSION_HISTORY_ORDERING =
-      compareByDescending<ExclusionRevision> { it.revision }
+      compareByDescending<ExclusionRevision> { it.updatedDateTime }
         .thenBy { it.weekNumber }
         .thenBy { it.dayOfWeek }
   }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -878,7 +878,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
       assertThat(updatedBy).isEqualTo("test-client")
-      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+      assertThat(updatedDateTime).isNotNull()
     }
 
     // Session 2: Add Week 1 Tuesday AM exclusion (keeping Week 1 Monday)
@@ -919,7 +919,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
       assertThat(updatedBy).isEqualTo("test-client")
-      assertThat(updatedDateTime).isEqualTo(exclusionsHistory2[1].updatedDateTime)
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
     }
 
     // Session 3: Add Week 2 Thursday PM exclusion (keeping Week 1 Monday and Tuesday)
@@ -963,6 +963,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
       assertThat(revision).isEqualTo(exclusionsHistory2[0].revision)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory2[0].updatedDateTime)
     }
 
     with(exclusionsHistory3[2]) {
@@ -971,6 +972,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
       assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
     }
 
     // Session 4: Add Week 2 Friday AM exclusion (keeping everything else)
@@ -1012,6 +1014,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.FRIDAY)
       assertThat(revision).isGreaterThan(exclusionsHistory3[0].revision)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedDateTime).isNotNull()
     }
 
     with(exclusionsHistory4[1]) {
@@ -1020,6 +1023,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
       assertThat(revision).isEqualTo(exclusionsHistory3[0].revision)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory3[0].updatedDateTime)
     }
 
     with(exclusionsHistory4[2]) {
@@ -1028,6 +1032,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
       assertThat(revision).isEqualTo(exclusionsHistory2[0].revision)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory2[0].updatedDateTime)
     }
 
     with(exclusionsHistory4[3]) {
@@ -1036,6 +1041,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
       assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
     }
   }
 
@@ -1073,7 +1079,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
       assertThat(updatedBy).isEqualTo("test-client")
-      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+      assertThat(updatedDateTime).isNotNull()
     }
 
     with(exclusionsHistory1[1]) {
@@ -1081,7 +1087,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
       assertThat(updatedBy).isEqualTo("test-client")
-      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[1].updatedDateTime)
+      assertThat(updatedDateTime).isNotNull()
     }
 
     // Session 2: Remove Week 2 Thursday PM, add Week 1 Tuesday AM (keeping Week 1 Monday AM)
@@ -1128,6 +1134,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
       assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
     }
 
     with(exclusionsHistory2[3]) {
@@ -1135,6 +1142,7 @@ class AllocationIntegrationTest : LocalStackTestBase() {
       assertThat(dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
       assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
       assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[1].updatedDateTime)
     }
 
     // Session 3: Add Week 2 Friday ED (keeping Week 1 Monday AM and Tuesday AM)

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/integration/AllocationIntegrationTest.kt
@@ -851,6 +851,333 @@ class AllocationIntegrationTest : LocalStackTestBase() {
 
   @Sql("classpath:test_data/allocation-with-exclusions-history.sql")
   @Test
+  fun `should return ADDED revision type when exclusions are added in separate sessions across a two week schedule`() {
+    // Session 1: Add Week 1 Monday AM exclusion
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            daysOfWeek = setOf(DayOfWeek.MONDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory1 = webTestClient.getExclusionsHistory(1)!!
+
+    assertThat(exclusionsHistory1).hasSize(1)
+
+    with(exclusionsHistory1[0]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+
+    // Session 2: Add Week 1 Tuesday AM exclusion (keeping Week 1 Monday)
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory2 = webTestClient.getExclusionsHistory(1)!!
+
+    assertThat(exclusionsHistory2).hasSize(2)
+
+    with(exclusionsHistory2[0]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
+      assertThat(revision).isGreaterThan(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory2[0].updatedDateTime)
+    }
+
+    with(exclusionsHistory2[1]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory2[1].updatedDateTime)
+    }
+
+    // Session 3: Add Week 2 Thursday PM exclusion (keeping Week 1 Monday and Tuesday)
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+          ),
+          Slot(
+            weekNumber = 2,
+            timeSlot = TimeSlot.PM,
+            thursday = true,
+            daysOfWeek = setOf(DayOfWeek.THURSDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory3 = webTestClient.getExclusionsHistory(1)!!
+
+    assertThat(exclusionsHistory3).hasSize(3)
+
+    with(exclusionsHistory3[0]) {
+      assertThat(weekNumber).isEqualTo(2)
+      assertThat(timeSlots).containsExactly(TimeSlot.PM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
+      assertThat(revision).isGreaterThan(exclusionsHistory2[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+
+    with(exclusionsHistory3[1]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory2[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+
+    with(exclusionsHistory3[2]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+
+    // Session 4: Add Week 2 Friday AM exclusion (keeping everything else)
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+          ),
+          Slot(
+            weekNumber = 2,
+            timeSlot = TimeSlot.PM,
+            thursday = true,
+            daysOfWeek = setOf(DayOfWeek.THURSDAY),
+          ),
+          Slot(
+            weekNumber = 2,
+            timeSlot = TimeSlot.AM,
+            friday = true,
+            daysOfWeek = setOf(DayOfWeek.FRIDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory4 = webTestClient.getExclusionsHistory(1)!!
+
+    assertThat(exclusionsHistory4).hasSize(4)
+
+    with(exclusionsHistory4[0]) {
+      assertThat(weekNumber).isEqualTo(2)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.FRIDAY)
+      assertThat(revision).isGreaterThan(exclusionsHistory3[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+
+    with(exclusionsHistory4[1]) {
+      assertThat(weekNumber).isEqualTo(2)
+      assertThat(timeSlots).containsExactly(TimeSlot.PM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory3[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+
+    with(exclusionsHistory4[2]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory2[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+
+    with(exclusionsHistory4[3]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+  }
+
+  @Sql("classpath:test_data/allocation-with-exclusions-history.sql")
+  @Test
+  fun `should return correct revision types for adds and removes across separate sessions with two week schedule`() {
+    // Session 1: Add Week 1 Monday AM and Week 2 Thursday PM exclusions
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            daysOfWeek = setOf(DayOfWeek.MONDAY),
+          ),
+          Slot(
+            weekNumber = 2,
+            timeSlot = TimeSlot.PM,
+            thursday = true,
+            daysOfWeek = setOf(DayOfWeek.THURSDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory1 = webTestClient.getExclusionsHistory(1)!!
+
+    assertThat(exclusionsHistory1).hasSize(2)
+
+    with(exclusionsHistory1[0]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[0].updatedDateTime)
+    }
+
+    with(exclusionsHistory1[1]) {
+      assertThat(weekNumber).isEqualTo(2)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isEqualTo(exclusionsHistory1[1].updatedDateTime)
+    }
+
+    // Session 2: Remove Week 2 Thursday PM, add Week 1 Tuesday AM (keeping Week 1 Monday AM)
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory2 = webTestClient.getExclusionsHistory(1)!!
+
+    assertThat(exclusionsHistory2).hasSize(4)
+
+    // Latest revision: Tuesday AM added and Thursday PM removed
+    with(exclusionsHistory2[0]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(timeSlots).containsExactly(TimeSlot.AM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.TUESDAY)
+      assertThat(revision).isGreaterThan(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+
+    with(exclusionsHistory2[1]) {
+      assertThat(weekNumber).isEqualTo(2)
+      assertThat(timeSlots).containsExactly(TimeSlot.PM)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
+      assertThat(revision).isGreaterThan(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.REMOVED)
+    }
+
+    // Original revision: Monday AM and Thursday PM added
+    with(exclusionsHistory2[2]) {
+      assertThat(weekNumber).isEqualTo(1)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.MONDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+
+    with(exclusionsHistory2[3]) {
+      assertThat(weekNumber).isEqualTo(2)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.THURSDAY)
+      assertThat(revision).isEqualTo(exclusionsHistory1[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+    }
+
+    // Session 3: Add Week 2 Friday ED (keeping Week 1 Monday AM and Tuesday AM)
+    webTestClient.updateAllocation(
+      RISLEY_PRISON_CODE,
+      1,
+      AllocationUpdateRequest(
+        exclusions = listOf(
+          Slot(
+            weekNumber = 1,
+            timeSlot = TimeSlot.AM,
+            monday = true,
+            tuesday = true,
+            daysOfWeek = setOf(DayOfWeek.MONDAY, DayOfWeek.TUESDAY),
+          ),
+          Slot(
+            weekNumber = 2,
+            timeSlot = TimeSlot.ED,
+            friday = true,
+            daysOfWeek = setOf(DayOfWeek.FRIDAY),
+          ),
+        ),
+      ),
+    )
+
+    val exclusionsHistory3 = webTestClient.getExclusionsHistory(1)!!
+
+    assertThat(exclusionsHistory3).hasSize(5)
+
+    // Latest revision: Friday ED added
+    with(exclusionsHistory3[0]) {
+      assertThat(weekNumber).isEqualTo(2)
+      assertThat(timeSlots).containsExactly(TimeSlot.ED)
+      assertThat(dayOfWeek).isEqualTo(DayOfWeek.FRIDAY)
+      assertThat(revision).isGreaterThan(exclusionsHistory2[0].revision)
+      assertThat(revisionType).isEqualTo(RevisionType.ADDED)
+      assertThat(updatedBy).isEqualTo("test-client")
+      assertThat(updatedDateTime).isAfterOrEqualTo(exclusionsHistory2[0].updatedDateTime)
+    }
+  }
+
+  @Sql("classpath:test_data/allocation-with-exclusions-history.sql")
+  @Test
   fun `should return exclusions history for exclusions changed through activity schedule change`() {
     // Create new Monday and Tuesday, AM exclusions
     webTestClient.updateAllocation(

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryServiceTest.kt
@@ -54,8 +54,9 @@ class ExclusionHistoryServiceTest {
     val addedTuesdayPM = auditRow(dayOfWeek = TUESDAY, timeSlot = PM)
 
     // revision 2
-    val addedWednesdayED = auditRow(revision = 2, weekNumber = 2, username = "SMITHJ", dayOfWeek = WEDNESDAY, timeSlot = ED)
-    val addedTuesdayAM = auditRow(revision = 2, weekNumber = 2, username = "SMITHJ", dayOfWeek = TUESDAY)
+    val revision2DateTime = LocalDateTime.parse("2026-06-26T10:15:30")
+    val addedWednesdayED = auditRow(revision = 2, weekNumber = 2, username = "SMITHJ", dayOfWeek = WEDNESDAY, timeSlot = ED, revisionDateTime = revision2DateTime)
+    val addedTuesdayAM = auditRow(revision = 2, weekNumber = 2, username = "SMITHJ", dayOfWeek = TUESDAY, revisionDateTime = revision2DateTime)
 
     // revision 3
     val revision3DateTime = LocalDateTime.parse("2026-06-30T12:00:01")
@@ -78,8 +79,8 @@ class ExclusionHistoryServiceTest {
 
     assertThat(history).containsExactly(
       exclusionRevision(revision = 3, dayOfWeek = THURSDAY, timeSlots = listOf(AM, PM), updatedDateTime = revision3DateTime),
-      exclusionRevision(revision = 2, weekNumber = 2, dayOfWeek = TUESDAY, updatedBy = "SMITHJ"),
-      exclusionRevision(revision = 2, weekNumber = 2, dayOfWeek = WEDNESDAY, timeSlots = listOf(ED), updatedBy = "SMITHJ"),
+      exclusionRevision(revision = 2, weekNumber = 2, dayOfWeek = TUESDAY, updatedBy = "SMITHJ", updatedDateTime = revision2DateTime),
+      exclusionRevision(revision = 2, weekNumber = 2, dayOfWeek = WEDNESDAY, timeSlots = listOf(ED), updatedBy = "SMITHJ", updatedDateTime = revision2DateTime),
       exclusionRevision(dayOfWeek = TUESDAY, revisionType = REMOVED),
       exclusionRevision(dayOfWeek = TUESDAY, timeSlots = listOf(PM)),
     )
@@ -350,6 +351,42 @@ class ExclusionHistoryServiceTest {
         exclusionRevision(weekNumber = 2, dayOfWeek = THURSDAY),
       )
     }
+
+    @Test
+    fun `should sort by revision date time when newer revision has a lower number due to multi-instance sequence allocation`() {
+      // Simulates a multi-pod deployment where Pod B pre-allocated higher revision numbers
+      // Pod B handled the first request (rev 51), then Pod A handled the next request (rev 6)
+      val olderDateTime = LocalDateTime.parse("2026-06-25T10:00:00")
+      val newerDateTime = LocalDateTime.parse("2026-06-26T14:00:00")
+
+      val olderRevisionHigherNumber = auditRow(
+        revision = 51,
+        dayOfWeek = MONDAY,
+        exclusionRevisionType = ADDED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER1",
+        revisionDateTime = olderDateTime,
+      )
+
+      val newerRevisionLowerNumber = auditRow(
+        revision = 6,
+        dayOfWeek = TUESDAY,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER2",
+        revisionDateTime = newerDateTime,
+      )
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
+        listOf(olderRevisionHigherNumber, newerRevisionLowerNumber)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revision = 6, dayOfWeek = TUESDAY, updatedBy = "USER2", updatedDateTime = newerDateTime),
+        exclusionRevision(revision = 51, dayOfWeek = MONDAY, updatedBy = "USER1", updatedDateTime = olderDateTime),
+      )
+    }
   }
 
   /**
@@ -363,9 +400,10 @@ class ExclusionHistoryServiceTest {
     fun `should exclude any changes where the exclusion was removed and added back in the same revision`() {
       val removedMondayAM = auditRow(exclusionRevisionType = MODIFIED, exclusionDaysOfWeekRevisionType = DELETED)
       val addedMondayAM = auditRow()
-      val addedExclusionMondayAM = auditRow(revision = 2)
-      val addedExclusionMondayPM = auditRow(revision = 2, timeSlot = PM)
-      val addedExclusionTuesdayAM = auditRow(revision = 2, dayOfWeek = TUESDAY)
+      val revision2DateTime = LocalDateTime.parse("2026-06-26T10:15:30")
+      val addedExclusionMondayAM = auditRow(revision = 2, revisionDateTime = revision2DateTime)
+      val addedExclusionMondayPM = auditRow(revision = 2, timeSlot = PM, revisionDateTime = revision2DateTime)
+      val addedExclusionTuesdayAM = auditRow(revision = 2, dayOfWeek = TUESDAY, revisionDateTime = revision2DateTime)
 
       every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
         listOf(removedMondayAM, addedExclusionMondayAM, addedMondayAM, addedExclusionTuesdayAM, addedExclusionMondayPM)
@@ -373,8 +411,8 @@ class ExclusionHistoryServiceTest {
       val history = exclusionHistoryService.findHistory(allocation)
 
       assertThat(history).containsExactly(
-        exclusionRevision(revision = 2, timeSlots = listOf(AM, PM)),
-        exclusionRevision(revision = 2, dayOfWeek = TUESDAY),
+        exclusionRevision(revision = 2, timeSlots = listOf(AM, PM), updatedDateTime = revision2DateTime),
+        exclusionRevision(revision = 2, dayOfWeek = TUESDAY, updatedDateTime = revision2DateTime),
       )
     }
 
@@ -382,17 +420,18 @@ class ExclusionHistoryServiceTest {
     fun `should include any changes where the exclusion was removed and added in a different revision`() {
       val removedMondayAM = auditRow(exclusionRevisionType = MODIFIED, exclusionDaysOfWeekRevisionType = DELETED)
       val removedMondayPM = auditRow(timeSlot = PM, exclusionRevisionType = DELETED, exclusionDaysOfWeekRevisionType = DELETED)
-      val addedMondayAM = auditRow(revision = 2)
-      val addedMondayPM = auditRow(revision = 2, timeSlot = PM)
-      val addedTuesdayAM = auditRow(revision = 2, dayOfWeek = TUESDAY)
+      val revision2DateTime = LocalDateTime.parse("2026-06-26T10:15:30")
+      val addedMondayAM = auditRow(revision = 2, revisionDateTime = revision2DateTime)
+      val addedMondayPM = auditRow(revision = 2, timeSlot = PM, revisionDateTime = revision2DateTime)
+      val addedTuesdayAM = auditRow(revision = 2, dayOfWeek = TUESDAY, revisionDateTime = revision2DateTime)
 
       every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns listOf(removedMondayAM, removedMondayPM, addedMondayAM, addedTuesdayAM, addedMondayPM)
 
       val history = exclusionHistoryService.findHistory(allocation)
 
       assertThat(history).containsExactly(
-        exclusionRevision(revision = 2, timeSlots = listOf(AM, PM)),
-        exclusionRevision(revision = 2, dayOfWeek = TUESDAY),
+        exclusionRevision(revision = 2, timeSlots = listOf(AM, PM), updatedDateTime = revision2DateTime),
+        exclusionRevision(revision = 2, dayOfWeek = TUESDAY, updatedDateTime = revision2DateTime),
         exclusionRevision(revisionType = REMOVED, timeSlots = listOf(AM, PM)),
       )
     }

--- a/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryServiceTest.kt
+++ b/src/test/kotlin/uk/gov/justice/digital/hmpps/hmppsactivitiesmanagementapi/service/ExclusionHistoryServiceTest.kt
@@ -85,6 +85,273 @@ class ExclusionHistoryServiceTest {
     )
   }
 
+  @Nested
+  @DisplayName("Adding exclusions across separate sessions")
+  inner class AddingExclusionsAcrossSessions {
+    @Test
+    fun `should return ADDED revision type when adding exclusions in separate sessions`() {
+      // Session 1: Add Monday AM exclusion - exclusion entity is new (ADDED)
+      val session1MondayAM = auditRow(
+        dayOfWeek = MONDAY,
+        exclusionRevisionType = ADDED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+      )
+
+      // Session 2: Add Tuesday AM exclusion - exclusion entity already exists so is MODIFIED, but day is ADDED
+      val session2TuesdayAM = auditRow(
+        revision = 2,
+        dayOfWeek = TUESDAY,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER2",
+        revisionDateTime = LocalDateTime.parse("2026-06-26T11:00:00"),
+      )
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
+        listOf(session1MondayAM, session2TuesdayAM)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revision = 2, dayOfWeek = TUESDAY, updatedBy = "USER2", updatedDateTime = LocalDateTime.parse("2026-06-26T11:00:00")),
+        exclusionRevision(dayOfWeek = MONDAY),
+      )
+
+      // Both should be ADDED
+      assertThat(history).allMatch { it.revisionType == RevisionType.ADDED }
+    }
+
+    @Test
+    fun `should return ADDED revision type when adding multiple exclusions across three sessions`() {
+      // Session 1: Add Monday AM
+      val session1MondayAM = auditRow(
+        dayOfWeek = MONDAY,
+        exclusionRevisionType = ADDED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+      )
+
+      // Session 2: Add Tuesday AM - exclusion entity is MODIFIED
+      val session2TuesdayAM = auditRow(
+        revision = 2,
+        dayOfWeek = TUESDAY,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER2",
+        revisionDateTime = LocalDateTime.parse("2026-06-26T11:00:00"),
+      )
+
+      // Session 3: Add Wednesday PM - exclusion entity is MODIFIED
+      val session3WednesdayPM = auditRow(
+        revision = 3,
+        dayOfWeek = WEDNESDAY,
+        timeSlot = PM,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER3",
+        revisionDateTime = LocalDateTime.parse("2026-06-27T14:00:00"),
+      )
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
+        listOf(session1MondayAM, session2TuesdayAM, session3WednesdayPM)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revision = 3, dayOfWeek = WEDNESDAY, timeSlots = listOf(PM), updatedBy = "USER3", updatedDateTime = LocalDateTime.parse("2026-06-27T14:00:00")),
+        exclusionRevision(revision = 2, dayOfWeek = TUESDAY, updatedBy = "USER2", updatedDateTime = LocalDateTime.parse("2026-06-26T11:00:00")),
+        exclusionRevision(dayOfWeek = MONDAY),
+      )
+
+      // All should be ADDED
+      assertThat(history).allMatch { it.revisionType == RevisionType.ADDED }
+    }
+
+    @Test
+    fun `should return ADDED revision type when adding exclusions across weeks in separate sessions`() {
+      // Session 1: Add Week 1 Monday AM
+      val session1Week1MondayAM = auditRow(
+        weekNumber = 1,
+        dayOfWeek = MONDAY,
+        exclusionRevisionType = ADDED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+      )
+
+      // Session 2: Add Week 2 Thursday AM - exclusion entity is MODIFIED
+      val session2Week2ThursdayAM = auditRow(
+        revision = 2,
+        weekNumber = 2,
+        dayOfWeek = THURSDAY,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER2",
+        revisionDateTime = LocalDateTime.parse("2026-06-26T11:00:00"),
+      )
+
+      // Session 3: Add Week 1 Tuesday PM - exclusion entity is MODIFIED
+      val session3Week1TuesdayPM = auditRow(
+        revision = 3,
+        weekNumber = 1,
+        dayOfWeek = TUESDAY,
+        timeSlot = PM,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER3",
+        revisionDateTime = LocalDateTime.parse("2026-06-27T14:00:00"),
+      )
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
+        listOf(session1Week1MondayAM, session2Week2ThursdayAM, session3Week1TuesdayPM)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revision = 3, weekNumber = 1, dayOfWeek = TUESDAY, timeSlots = listOf(PM), updatedBy = "USER3", updatedDateTime = LocalDateTime.parse("2026-06-27T14:00:00")),
+        exclusionRevision(revision = 2, weekNumber = 2, dayOfWeek = THURSDAY, updatedBy = "USER2", updatedDateTime = LocalDateTime.parse("2026-06-26T11:00:00")),
+        exclusionRevision(weekNumber = 1, dayOfWeek = MONDAY),
+      )
+
+      // All should be ADDED
+      assertThat(history).allMatch { it.revisionType == RevisionType.ADDED }
+    }
+
+    @Test
+    fun `should return REMOVED revision type when removing exclusion from existing exclusions in a later session`() {
+      // Session 1: Add Monday AM and Tuesday AM
+      val session1MondayAM = auditRow(
+        dayOfWeek = MONDAY,
+        exclusionRevisionType = ADDED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+      )
+      val session1TuesdayAM = auditRow(
+        dayOfWeek = TUESDAY,
+        exclusionRevisionType = ADDED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+      )
+
+      // Session 2: Remove Tuesday AM - exclusion entity is MODIFIED, day is DELETED
+      val session2RemovedTuesdayAM = auditRow(
+        revision = 2,
+        dayOfWeek = TUESDAY,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = DELETED,
+        username = "USER2",
+        revisionDateTime = LocalDateTime.parse("2026-06-26T11:00:00"),
+      )
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
+        listOf(session1MondayAM, session1TuesdayAM, session2RemovedTuesdayAM)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revision = 2, dayOfWeek = TUESDAY, revisionType = REMOVED, updatedBy = "USER2", updatedDateTime = LocalDateTime.parse("2026-06-26T11:00:00")),
+        exclusionRevision(dayOfWeek = MONDAY),
+        exclusionRevision(dayOfWeek = TUESDAY),
+      )
+    }
+
+    @Test
+    fun `should return correct revision types for a mix of adds and removes across sessions`() {
+      // Session 1: Add Monday AM
+      val session1MondayAM = auditRow(
+        dayOfWeek = MONDAY,
+        exclusionRevisionType = ADDED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+      )
+
+      // Session 2: Add Tuesday AM - exclusion entity is MODIFIED, day is ADDED
+      val session2TuesdayAM = auditRow(
+        revision = 2,
+        dayOfWeek = TUESDAY,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER2",
+        revisionDateTime = LocalDateTime.parse("2026-06-26T11:00:00"),
+      )
+
+      // Session 3: Remove Monday AM and add Wednesday PM - exclusion entity is MODIFIED
+      val session3RemovedMondayAM = auditRow(
+        revision = 3,
+        dayOfWeek = MONDAY,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = DELETED,
+        username = "USER3",
+        revisionDateTime = LocalDateTime.parse("2026-06-27T14:00:00"),
+      )
+      val session3AddedWednesdayPM = auditRow(
+        revision = 3,
+        dayOfWeek = WEDNESDAY,
+        timeSlot = PM,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER3",
+        revisionDateTime = LocalDateTime.parse("2026-06-27T14:00:00"),
+      )
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
+        listOf(session1MondayAM, session2TuesdayAM, session3RemovedMondayAM, session3AddedWednesdayPM)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revision = 3, dayOfWeek = MONDAY, revisionType = REMOVED, updatedBy = "USER3", updatedDateTime = LocalDateTime.parse("2026-06-27T14:00:00")),
+        exclusionRevision(revision = 3, dayOfWeek = WEDNESDAY, timeSlots = listOf(PM), updatedBy = "USER3", updatedDateTime = LocalDateTime.parse("2026-06-27T14:00:00")),
+        exclusionRevision(revision = 2, dayOfWeek = TUESDAY, updatedBy = "USER2", updatedDateTime = LocalDateTime.parse("2026-06-26T11:00:00")),
+        exclusionRevision(dayOfWeek = MONDAY),
+      )
+    }
+
+    @Test
+    fun `should return correct revision types for adds and removes across weeks in separate sessions`() {
+      // Session 1: Add Week 1 Monday AM and Week 2 Thursday AM
+      val session1Week1MondayAM = auditRow(
+        weekNumber = 1,
+        dayOfWeek = MONDAY,
+        exclusionRevisionType = ADDED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+      )
+      val session1Week2ThursdayAM = auditRow(
+        weekNumber = 2,
+        dayOfWeek = THURSDAY,
+        exclusionRevisionType = ADDED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+      )
+
+      // Session 2: Remove Week 2 Thursday AM, add Week 1 Tuesday PM - exclusion entity is MODIFIED
+      val session2RemovedWeek2ThursdayAM = auditRow(
+        revision = 2,
+        weekNumber = 2,
+        dayOfWeek = THURSDAY,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = DELETED,
+        username = "USER2",
+        revisionDateTime = LocalDateTime.parse("2026-06-26T11:00:00"),
+      )
+      val session2AddedWeek1TuesdayPM = auditRow(
+        revision = 2,
+        weekNumber = 1,
+        dayOfWeek = TUESDAY,
+        timeSlot = PM,
+        exclusionRevisionType = MODIFIED,
+        exclusionDaysOfWeekRevisionType = ADDED,
+        username = "USER2",
+        revisionDateTime = LocalDateTime.parse("2026-06-26T11:00:00"),
+      )
+
+      every { exclusionRepository.findHistoryByAllocationId(ALLOCATION_ID) } returns
+        listOf(session1Week1MondayAM, session1Week2ThursdayAM, session2RemovedWeek2ThursdayAM, session2AddedWeek1TuesdayPM)
+
+      val history = exclusionHistoryService.findHistory(allocation)
+
+      assertThat(history).containsExactly(
+        exclusionRevision(revision = 2, weekNumber = 1, dayOfWeek = TUESDAY, timeSlots = listOf(PM), updatedBy = "USER2", updatedDateTime = LocalDateTime.parse("2026-06-26T11:00:00")),
+        exclusionRevision(revision = 2, weekNumber = 2, dayOfWeek = THURSDAY, revisionType = REMOVED, updatedBy = "USER2", updatedDateTime = LocalDateTime.parse("2026-06-26T11:00:00")),
+        exclusionRevision(weekNumber = 1, dayOfWeek = MONDAY),
+        exclusionRevision(weekNumber = 2, dayOfWeek = THURSDAY),
+      )
+    }
+  }
+
   /**
    * An ignored change is only where an exclusion is removed and then added back in the same revision,
    * in which case both revisions are ignored.


### PR DESCRIPTION
**Issue:** There was an issue found when testing in DEV where sometimes the latest revision has a lower number as compared to an older revision. Its works fine locally and the issue only appears with multiple pods in deployed environments , where each pod pre-allocates its own block of 50 IDs from the sequence and hands them out independently. So when the successive requests got to different pods we are seeing inconsistency in revision numbers.

To fix this the history is now being returned sorted by updatedDateTime i.e. the revisionDateTime and not revision.