### PR TITLE
cleanup migration created planned suspensions

### DIFF
--- a/src/main/resources/migrations/prod/V2026.08.05__cleanup_planned_suspensions_rollout.sql
+++ b/src/main/resources/migrations/prod/V2026.08.05__cleanup_planned_suspensions_rollout.sql
@@ -20,6 +20,5 @@ BEGIN
 				updated_rows
 			);
 	END IF;
-END
-$$;
+END;
 

--- a/src/main/resources/migrations/prod/V2026.08.05__cleanup_planned_suspensions_rollout.sql
+++ b/src/main/resources/migrations/prod/V2026.08.05__cleanup_planned_suspensions_rollout.sql
@@ -1,0 +1,25 @@
+DO $$
+DECLARE
+	updated_rows INTEGER;
+BEGIN
+	UPDATE planned_suspension ps
+	SET planned_end_date = DATE '2026-08-05'
+	FROM allocation allo
+	WHERE allo.allocation_id = ps.allocation_id
+		AND allo.prisoner_status <> 'ENDED'
+		AND ps.planned_by = 'MIGRATION'
+		AND ps.planned_end_date IS NULL
+		AND ps.planned_start_date >= DATE '2026-07-01';
+
+	GET DIAGNOSTICS updated_rows = ROW_COUNT;
+
+	IF updated_rows < 1 OR updated_rows > 150 THEN
+		RAISE EXCEPTION USING
+			MESSAGE = format(
+				'Cleanup planned suspensions updated %s rows; expected between 1 and 150 (target around 118).',
+				updated_rows
+			);
+	END IF;
+END
+$$;
+


### PR DESCRIPTION
It seems a lot of the suspensions are activated on prisoner RECEIVE events, i.e. coming back into the prison.

This happens because the migration created planned_suspension for all the migrated allocations that were in a SUSPENDED state. but there isn't an automatic route by which planned suspensions ever get an end date. so allocations get AUTO_SUSPENDED or possibly ignored in the case of external activities when prisoners leave, and then the planned_suspension resumes their SUSPENDED status on return to prison.

When [@Sarah-Louise](https://moj.enterprise.slack.com/team/UAJQB5PJT) manually unsuspended lots of them yesterday, that also end dates the planned suspensions. There's still a bunch of them left though which could keep re-activating suspensions in certain circumstances, so I think a quick cleanup is in order. I propose

(pseudo code)
for all planned_Suspension
set planned_end_date = TODAY
where
planned_by = MIGRATION
planned_end_date = NULL
allocation.prisoner_status != 'ENDED'
and planned_start_date >= '01-Jul-2026'

That would end 118 planned suspensions.

NOMIS doesn't have a concept of planned_suspension so there's no sync to NOMIS implications and the change can be done by SQL script.